### PR TITLE
Install wgpu error handler to prevent process crash on shader error (#9)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4252,6 +4252,7 @@ dependencies = [
  "sysinfo",
  "thiserror 2.0.17",
  "uuid",
+ "wgpu",
  "wgpu-types",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,7 @@ uuid = { workspace = true }
 sysinfo = "0.37"
 paste = "1.0"
 
+wgpu = { version = "27", default-features = false }
 wgpu-types = "27"
 naga = { version = "27", default-features = false }
 

--- a/assets/shaders/test/invalid_binding.wgsl
+++ b/assets/shaders/test/invalid_binding.wgsl
@@ -1,0 +1,13 @@
+// Test: shader with invalid binding reference (group 0 binding 99)
+// Triggers a wgpu validation error
+#import bevy_pbr::forward_io::VertexOutput
+
+struct FakeData {
+    value: vec4<f32>,
+}
+@group(0) @binding(99) var<uniform> fake: FakeData;
+
+@fragment
+fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
+    return fake.value;
+}

--- a/src/app/plugins.rs
+++ b/src/app/plugins.rs
@@ -76,6 +76,7 @@ impl PyDefaultPlugins {
                     .set(default_window_plugin())
                     .disable::<bevy::log::LogPlugin>(),
             );
+            bevy_app.add_plugins(crate::render::wgpu_error_handler::WgpuErrorHandlerPlugin);
             // Register the SceneInstanceReady observer so MessageReader[SceneInstanceReady]
             // works without requiring an explicit ScenePlugin() addition.
             bevy_app.add_observer(pybevy_scene::scene_instance_ready_bridge);
@@ -278,6 +279,7 @@ impl PyPluginGroupBuilder {
             self.insert_pre_plugin_resources(app.py(), bevy_app)?;
             let builder = self.apply_to_bevy(app.py())?;
             bevy_app.add_plugins(builder);
+            bevy_app.add_plugins(crate::render::wgpu_error_handler::WgpuErrorHandlerPlugin);
             // Register the SceneInstanceReady observer so MessageReader[SceneInstanceReady]
             // works without requiring an explicit ScenePlugin() addition.
             bevy_app.add_observer(pybevy_scene::scene_instance_ready_bridge);

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -2,6 +2,7 @@ use pyo3::prelude::*;
 
 pub mod readback;
 pub mod readback_py;
+pub mod wgpu_error_handler;
 
 pub(crate) fn add_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     readback_py::register_readback_bridges();

--- a/src/render/wgpu_error_handler.rs
+++ b/src/render/wgpu_error_handler.rs
@@ -1,0 +1,47 @@
+use std::{
+    collections::HashSet,
+    sync::{Arc, Mutex},
+};
+
+use bevy::{app::Plugin, render::renderer::RenderDevice};
+
+/// Plugin that installs a non-panicking wgpu error handler for validation errors.
+///
+/// By default, wgpu's uncaptured error handler panics, which kills the render
+/// thread on shader validation errors (e.g., binding mismatches). This plugin
+/// replaces it with a handler that logs validation errors instead, deduplicating
+/// repeated messages. OutOfMemory and Internal errors still panic.
+///
+/// This is needed for hot reload to work and not crash the pybevy renderer
+pub struct WgpuErrorHandlerPlugin;
+
+impl Plugin for WgpuErrorHandlerPlugin {
+    fn build(&self, _app: &mut bevy::app::App) {}
+
+    fn finish(&self, app: &mut bevy::app::App) {
+        let Some(render_app) = app.get_sub_app(bevy::render::RenderApp) else {
+            return;
+        };
+
+        let Some(device) = render_app.world().get_resource::<RenderDevice>() else {
+            return;
+        };
+
+        let seen: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
+
+        device.wgpu_device().on_uncaptured_error(Arc::new(move |error| {
+            match &error {
+                wgpu::Error::Validation { description, .. } => {
+                    let is_new = seen
+                        .lock()
+                        .map(|mut set| set.insert(description.clone()))
+                        .unwrap_or(true);
+                    if is_new {
+                        bevy::log::error!("wgpu validation error (non-fatal): {error}");
+                    }
+                }
+                _ => panic!("wgpu error: {error}"),
+            }
+        }));
+    }
+}


### PR DESCRIPTION
The handler logs wgpu pipeline `Validation` errors, panics (as standard method) on others such as out of memory.

Outputs to console only if the log is nonexistant.

Fixes #9 