### PR TITLE
Unsafety documentation to pybevy macros

### DIFF
--- a/crates/pybevy_macros/src/asset.rs
+++ b/crates/pybevy_macros/src/asset.rs
@@ -359,6 +359,7 @@ pub fn asset_bridge(input: TokenStream) -> TokenStream {
                 match assets.get(&typed_handle) {
                     Some(asset) => {
                         let ptr = asset as *const #bevy_type;
+                        // SAFETY: `ptr` is derived from a valid Bevy `Assets` borrow. The `validity` flag ensures the storage is invalidated before the borrow expires.
                         let storage = unsafe {
                             pybevy_core::AssetStorage::borrowed_readonly(
                                 ptr,
@@ -392,6 +393,7 @@ pub fn asset_bridge(input: TokenStream) -> TokenStream {
                 match assets.get_mut(&typed_handle) {
                     Some(asset) => {
                         let ptr = asset as *mut #bevy_type;
+                        // SAFETY: `ptr` is derived from a valid Bevy `Assets` mutable borrow. The `validity` flag ensures the storage is invalidated before the borrow expires.
                         let storage = unsafe {
                             pybevy_core::AssetStorage::borrowed_mut(
                                 ptr,
@@ -505,6 +507,7 @@ pub fn asset_bridge(input: TokenStream) -> TokenStream {
                         }
                     };
                     let ptr = asset as *const #bevy_type;
+                    // SAFETY: `ptr` is derived from a valid Bevy `Assets` borrow. The `validity` flag ensures the storage is invalidated before the borrow expires.
                     let storage = unsafe {
                         pybevy_core::AssetStorage::borrowed_readonly(
                             ptr,
@@ -665,6 +668,7 @@ pub fn handle_bridge(input: TokenStream) -> TokenStream {
                     pyo3::exceptions::PyRuntimeError::new_err(concat!(#component_name, " not found"))
                 })?;
 
+                // SAFETY: component_id was registered for #bevy_type, so the untyped pointer points to a valid instance.
                 let component = unsafe { untyped.deref::<#bevy_type>() };
                 let py_component = #py_type::from(component);
                 let obj = pyo3::Py::new(py, (py_component, pybevy_core::PyComponent))?;
@@ -683,6 +687,7 @@ pub fn handle_bridge(input: TokenStream) -> TokenStream {
                         pyo3::exceptions::PyRuntimeError::new_err(concat!(#component_name, " not found"))
                     })?;
 
+                    // SAFETY: component_id was registered for #bevy_type, so the untyped pointer points to a valid instance.
                     let component = unsafe { untyped.deref::<#bevy_type>() };
                     let py_component = #py_type::from(component);
                     let obj = pyo3::Py::new(py, (py_component, pybevy_core::PyComponent))?;

--- a/crates/pybevy_macros/src/component.rs
+++ b/crates/pybevy_macros/src/component.rs
@@ -541,11 +541,12 @@ pub fn component_bridge(input: TokenStream) -> TokenStream {
                     world.register_component::<#bevy_type>()
                 }
 
-                fn column_data_ptr_fn(
+                unsafe fn column_data_ptr_fn(
                     column: &bevy::ecs::storage::Column,
                     entity_count: usize,
                 ) -> *const u8 {
-                    let data_slice = unsafe { column.get_data_slice::<#bevy_type>(entity_count) };
+                    // SAFETY: caller guarantees entity_count == column.len(); #bevy_type matches the column's component type.
+                    let data_slice = column.get_data_slice::<#bevy_type>(entity_count);
                     data_slice.as_ptr() as *const u8
                 }
 
@@ -667,10 +668,12 @@ pub fn component_bridge(input: TokenStream) -> TokenStream {
                     pyo3::exceptions::PyRuntimeError::new_err(concat!(#component_name, " not found"))
                 })?;
 
+                // SAFETY: component_id was registered for #bevy_type, so the untyped pointer points to a valid instance.
                 let ptr = unsafe {
                     untyped.as_mut().deref_mut::<#bevy_type>() as *mut #bevy_type
                 };
 
+                // SAFETY: ptr is from a valid Bevy entity borrow; validity flag invalidates storage when borrow expires.
                 let storage = unsafe {
                     pybevy_core::ComponentStorage::borrowed(ptr, validity)
                 };
@@ -693,10 +696,12 @@ pub fn component_bridge(input: TokenStream) -> TokenStream {
                         pyo3::exceptions::PyRuntimeError::new_err("Component not found")
                     })?;
 
+                    // SAFETY: component_id was registered for #bevy_type, so the untyped pointer points to a valid instance.
                     let ptr = unsafe {
                         untyped.as_mut().deref_mut::<#bevy_type>() as *mut #bevy_type
                     };
 
+                    // SAFETY: ptr is from a valid Bevy entity borrow; validity flag invalidates storage when borrow expires.
                     let storage = unsafe {
                         pybevy_core::ComponentStorage::borrowed(ptr, validity)
                     };
@@ -719,6 +724,7 @@ pub fn component_bridge(input: TokenStream) -> TokenStream {
             ) -> pyo3::PyResult<Option<pyo3::Py<pyo3::PyAny>>> {
                 if let Some(component) = entity.get::<#bevy_type>() {
                     let ptr = component as *const #bevy_type as *mut #bevy_type;
+                    // SAFETY: ptr is from a valid entity.get() borrow; validity flag invalidates storage when borrow expires.
                     let storage = unsafe {
                         pybevy_core::ComponentStorage::borrowed(ptr, validity)
                     };
@@ -737,6 +743,7 @@ pub fn component_bridge(input: TokenStream) -> TokenStream {
             ) -> pyo3::PyResult<Option<pyo3::Py<pyo3::PyAny>>> {
                 if let Some(mut component) = entity.get_mut::<#bevy_type>() {
                     let ptr = component.as_mut() as *mut #bevy_type;
+                    // SAFETY: ptr is from a valid entity.get_mut() borrow; validity flag invalidates storage when borrow expires.
                     let storage = unsafe {
                         pybevy_core::ComponentStorage::borrowed(ptr, validity)
                     };

--- a/crates/pybevy_macros/src/derive.rs
+++ b/crates/pybevy_macros/src/derive.rs
@@ -225,10 +225,12 @@ pub fn derive_py_component(input: TokenStream) -> TokenStream {
                     #pyo3_path::exceptions::PyRuntimeError::new_err(concat!(#bevy_type_str, " not found"))
                 })?;
 
+                // SAFETY: component_id was registered for #bevy_type, so the untyped pointer points to a valid instance.
                 let ptr = unsafe {
                     untyped.as_mut().deref_mut::<#bevy_type>() as *mut #bevy_type
                 };
 
+                // SAFETY: ptr is from a valid Bevy entity borrow; validity flag invalidates storage when borrow expires.
                 let storage = unsafe {
                     #core_path::ComponentStorage::borrowed(ptr, validity)
                 };
@@ -276,10 +278,12 @@ pub fn derive_py_component(input: TokenStream) -> TokenStream {
                         #pyo3_path::exceptions::PyRuntimeError::new_err("Component not found")
                     })?;
 
+                    // SAFETY: component_id was registered for #bevy_type, so the untyped pointer points to a valid instance.
                     let ptr = unsafe {
                         untyped.as_mut().deref_mut::<#bevy_type>() as *mut #bevy_type
                     };
 
+                    // SAFETY: ptr is from a valid Bevy entity borrow; validity flag invalidates storage when borrow expires.
                     let storage = unsafe {
                         #core_path::ComponentStorage::borrowed(ptr, validity)
                     };
@@ -302,6 +306,7 @@ pub fn derive_py_component(input: TokenStream) -> TokenStream {
             ) -> #pyo3_path::PyResult<Option<#pyo3_path::Py<#pyo3_path::PyAny>>> {
                 if let Some(component) = entity.get::<#bevy_type>() {
                     let ptr = component as *const #bevy_type as *mut #bevy_type;
+                    // SAFETY: ptr is from a valid entity.get() borrow; validity flag invalidates storage when borrow expires.
                     let storage = unsafe {
                         #core_path::ComponentStorage::borrowed(ptr, validity)
                     };
@@ -320,6 +325,7 @@ pub fn derive_py_component(input: TokenStream) -> TokenStream {
             ) -> #pyo3_path::PyResult<Option<#pyo3_path::Py<#pyo3_path::PyAny>>> {
                 if let Some(mut component) = entity.get_mut::<#bevy_type>() {
                     let ptr = component.as_mut() as *mut #bevy_type;
+                    // SAFETY: ptr is from a valid entity.get_mut() borrow; validity flag invalidates storage when borrow expires.
                     let storage = unsafe {
                         #core_path::ComponentStorage::borrowed(ptr, validity)
                     };

--- a/crates/pybevy_macros/src/newtype.rs
+++ b/crates/pybevy_macros/src/newtype.rs
@@ -187,6 +187,7 @@ pub fn newtype_bridge(input: TokenStream) -> TokenStream {
                     pyo3::exceptions::PyRuntimeError::new_err(concat!(#component_name, " not found"))
                 })?;
 
+                // SAFETY: component_id was registered for #bevy_type, so the untyped pointer points to a valid instance.
                 let component = unsafe {
                     untyped.deref::<#bevy_type>()
                 };
@@ -233,6 +234,7 @@ pub fn newtype_bridge(input: TokenStream) -> TokenStream {
                         pyo3::exceptions::PyRuntimeError::new_err("Component not found")
                     })?;
 
+                    // SAFETY: component_id was registered for #bevy_type, so the untyped pointer points to a valid instance.
                     let component = unsafe {
                         untyped.deref::<#bevy_type>()
                     };

--- a/crates/pybevy_macros/src/resource.rs
+++ b/crates/pybevy_macros/src/resource.rs
@@ -338,6 +338,7 @@ pub fn resource_bridge(input: TokenStream) -> TokenStream {
                 let ptr = resource as *const #bevy_type as *mut #bevy_type;
                 // Override to read mode even though caller requested write
                 let read_validity = validity.flag.with_access_mode(pybevy_core::AccessMode::Read);
+                // SAFETY: ptr is from a valid Bevy resource borrow; validity flag invalidates storage when borrow expires.
                 let storage = unsafe {
                     pybevy_core::ResourceStorage::borrowed(ptr, read_validity)
                 };
@@ -359,6 +360,7 @@ pub fn resource_bridge(input: TokenStream) -> TokenStream {
                 })?;
 
                 let ptr = resource.into_inner() as *mut #bevy_type;
+                // SAFETY: ptr is from a valid Bevy resource mutable borrow; validity flag invalidates storage when borrow expires.
                 let storage = unsafe {
                     pybevy_core::ResourceStorage::borrowed(ptr, validity)
                 };
@@ -418,6 +420,7 @@ pub fn resource_bridge(input: TokenStream) -> TokenStream {
                 })?;
 
                 let ptr = resource as *const #bevy_type as *mut #bevy_type;
+                // SAFETY: ptr is from a valid Bevy resource borrow; validity flag invalidates storage when borrow expires.
                 let storage = unsafe {
                     pybevy_core::ResourceStorage::borrowed(ptr, validity)
                 };

--- a/crates/pybevy_shader_types/src/lib.rs
+++ b/crates/pybevy_shader_types/src/lib.rs
@@ -3,11 +3,6 @@
 //! This crate contains the Bevy-side `ShaderMaterial` type definition
 //! (`ExtendedMaterial<StandardMaterial, ShaderMaterialExtension>`) and
 //! supporting types. No Python dependencies.
-//!
-//! Used by:
-//! - `pybevy_pbr` — Python wrappers + plugin registration
-//! - `pybevy_replicon` — server-side extraction for browser sync
-//! - `pybevy_browser` — client-side material reconstruction
 
 use std::{
     collections::HashMap,

--- a/crates/pybevy_storage/src/view_bridge.rs
+++ b/crates/pybevy_storage/src/view_bridge.rs
@@ -102,9 +102,11 @@ pub struct ViewBridge {
     ///
     /// # Safety
     ///
+    /// `entity_count` must equal the column's actual length.
     /// The returned pointer is valid only for the lifetime of the column.
     /// Caller must ensure proper synchronization for mutable access.
-    pub column_data_ptr: fn(column: &bevy::ecs::storage::Column, entity_count: usize) -> *const u8,
+    pub column_data_ptr:
+        unsafe fn(column: &bevy::ecs::storage::Column, entity_count: usize) -> *const u8,
 }
 
 impl std::fmt::Debug for ViewBridge {

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -611,6 +611,10 @@ def system(state: ResMut[GameState]) -> None:
 # then it's not protected by Bevy's scheduler
 ```
 
+**CAUTION: Spawning threads inside systems**:
+
+Passing component references to threads spawned within a system bypasses PyBevy's safety guarantees. Without the GIL, two threads calling `as_mut()` on the same component simultaneously would create a data race on the underlying Rust memory. In practice the effect is limited to corrupted field values (torn writes on non-atomic types). A thread-id check in the validity flag could detect this, but would add a branch to every component access on the hot path.
+
 ### Safe Patterns
 
 **Standard component mutations**:

--- a/src/ecs/view/view.rs
+++ b/src/ecs/view/view.rs
@@ -2044,7 +2044,7 @@ impl PyBatch {
                     ))
                 })?;
 
-                (view_bridge.column_data_ptr)(column, entity_count)
+                unsafe { (view_bridge.column_data_ptr)(column, entity_count) }
             }
         };
 
@@ -2188,7 +2188,7 @@ impl PyBatch {
                     ))
                 })?;
 
-                (view_bridge.column_data_ptr)(column, entity_count)
+                unsafe { (view_bridge.column_data_ptr)(column, entity_count) }
             }
         };
 


### PR DESCRIPTION
Documenting unsafe usage in macros. Also remnant comment removal.