### PR TITLE
Return NotImplemented for math ops instead of TypeError

### DIFF
--- a/crates/pybevy_math/src/affine2.rs
+++ b/crates/pybevy_math/src/affine2.rs
@@ -358,13 +358,13 @@ impl PyMat2 {
         Ok(self.as_ref()?.is_nan())
     }
 
-    fn __mul__(&self, other: &Bound<'_, PyAny>) -> PyResult<PyMat2> {
+    fn __mul__(&self, other: &Bound<'_, PyAny>, py: Python<'_>) -> PyResult<Py<PyAny>> {
         if let Ok(scalar) = other.extract::<f32>() {
-            Ok(PyMat2::from_mat2(self.get() * scalar))
+            Ok(Py::new(py, PyMat2::from_mat2(self.get() * scalar))?.into_any())
         } else if let Ok(other_mat) = other.extract::<PyMat2>() {
-            Ok(PyMat2::from_mat2(self.get() * other_mat.get()))
+            Ok(Py::new(py, PyMat2::from_mat2(self.get() * other_mat.get()))?.into_any())
         } else {
-            Err(PyTypeError::new_err("Unsupported operand type for *"))
+            Ok(py.NotImplemented().into_any())
         }
     }
 

--- a/crates/pybevy_math/src/dir3.rs
+++ b/crates/pybevy_math/src/dir3.rs
@@ -175,7 +175,7 @@ impl PyDir3 {
                 "Dir3 * Quat is not supported. Use Quat * Dir3 to rotate a direction.",
             ))
         } else {
-            Err(PyTypeError::new_err("Dir3 can only be multiplied by float"))
+            Ok(py.NotImplemented().into_any())
         }
     }
 
@@ -186,9 +186,7 @@ impl PyDir3 {
             // Quat * Dir3 -> Dir3 (rotation)
             Ok(Py::new(py, PyDir3::dir3(quat.get() * self.0))?.into_any())
         } else {
-            Err(PyTypeError::new_err(
-                "Dir3 can only be multiplied by float or Quat",
-            ))
+            Ok(py.NotImplemented().into_any())
         }
     }
 }

--- a/crates/pybevy_math/src/mat3.rs
+++ b/crates/pybevy_math/src/mat3.rs
@@ -279,18 +279,16 @@ impl PyMat3 {
         } else if let Ok(vec) = other.extract::<PyVec3>() {
             Ok(Py::new(py, PyVec3::from_vec3(self_mat * Vec3::from(&vec)))?.into_any())
         } else {
-            Err(PyTypeError::new_err(
-                "Unsupported operand type for * (expected Mat3, Vec3, or scalar)",
-            ))
+            Ok(py.NotImplemented().into_any())
         }
     }
 
-    fn __rmul__(&self, other: &Bound<'_, PyAny>) -> PyResult<PyMat3> {
+    fn __rmul__(&self, other: &Bound<'_, PyAny>, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let self_mat = *self.as_ref()?;
         if let Ok(scalar) = other.extract::<f32>() {
-            Ok(PyMat3::mat3(scalar * self_mat))
+            Ok(Py::new(py, PyMat3::mat3(scalar * self_mat))?.into_any())
         } else {
-            Err(PyTypeError::new_err("Unsupported operand type for *"))
+            Ok(py.NotImplemented().into_any())
         }
     }
 

--- a/crates/pybevy_math/src/mat3a.rs
+++ b/crates/pybevy_math/src/mat3a.rs
@@ -196,9 +196,7 @@ impl PyMat3A {
         } else if let Ok(vec) = other.extract::<PyVec3A>() {
             Ok(Py::new(py, PyVec3A::from_vec3a(self_mat * Vec3A::from(&vec)))?.into_any())
         } else {
-            Err(PyTypeError::new_err(
-                "Unsupported operand type for * (expected Mat3A, Vec3A, or scalar)",
-            ))
+            Ok(py.NotImplemented().into_any())
         }
     }
 

--- a/crates/pybevy_math/src/mat4.rs
+++ b/crates/pybevy_math/src/mat4.rs
@@ -372,18 +372,16 @@ impl PyMat4 {
         } else if let Ok(vec) = other.extract::<PyVec4>() {
             Ok(Py::new(py, PyVec4::from_vec4(self_mat * Vec4::from(&vec)))?.into_any())
         } else {
-            Err(PyTypeError::new_err(
-                "Unsupported operand type for * (expected Mat4, Vec4, or scalar)",
-            ))
+            Ok(py.NotImplemented().into_any())
         }
     }
 
-    fn __rmul__(&self, other: &Bound<'_, PyAny>) -> PyResult<PyMat4> {
+    fn __rmul__(&self, other: &Bound<'_, PyAny>, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let self_mat = *self.as_ref()?;
         if let Ok(scalar) = other.extract::<f32>() {
-            Ok(PyMat4::mat4(scalar * self_mat))
+            Ok(Py::new(py, PyMat4::mat4(scalar * self_mat))?.into_any())
         } else {
-            Err(PyTypeError::new_err("Unsupported operand type for *"))
+            Ok(py.NotImplemented().into_any())
         }
     }
 

--- a/crates/pybevy_math/src/quat.rs
+++ b/crates/pybevy_math/src/quat.rs
@@ -267,9 +267,7 @@ impl PyQuat {
             let v = *self_quat * other_vec3.get();
             Ok(Py::new(py, PyVec3::from_vec3(v))?.into_any())
         } else {
-            Err(PyTypeError::new_err(
-                "Quat can only be multiplied by Quat or Vec3",
-            ))
+            Ok(py.NotImplemented().into_any())
         }
     }
 

--- a/crates/pybevy_math/src/vec2.rs
+++ b/crates/pybevy_math/src/vec2.rs
@@ -196,66 +196,66 @@ impl PyVec2 {
         Ok(PyVec2::from_vec2(self.as_ref()?.normalize()))
     }
 
-    fn __add__(&self, other: &Bound<'_, PyAny>) -> PyResult<PyVec2> {
+    fn __add__(&self, other: &Bound<'_, PyAny>, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let self_v = self.as_ref()?;
         if let Ok(scalar) = other.extract::<f32>() {
-            Ok(PyVec2::from_vec2(*self_v + Vec2::splat(scalar)))
+            Ok(Py::new(py, PyVec2::from_vec2(*self_v + Vec2::splat(scalar)))?.into_any())
         } else if let Ok(other_vec) = other.extract::<PyVec2>() {
-            Ok(PyVec2::from_vec2(*self_v + other_vec.get()))
+            Ok(Py::new(py, PyVec2::from_vec2(*self_v + other_vec.get()))?.into_any())
         } else {
-            Err(PyTypeError::new_err("Unsupported operand type for +"))
+            Ok(py.NotImplemented().into_any())
         }
     }
 
-    fn __sub__(&self, other: &Bound<'_, PyAny>) -> PyResult<PyVec2> {
+    fn __sub__(&self, other: &Bound<'_, PyAny>, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let self_v = self.as_ref()?;
         if let Ok(scalar) = other.extract::<f32>() {
-            Ok(PyVec2::from_vec2(*self_v - Vec2::splat(scalar)))
+            Ok(Py::new(py, PyVec2::from_vec2(*self_v - Vec2::splat(scalar)))?.into_any())
         } else if let Ok(other_vec) = other.extract::<PyVec2>() {
-            Ok(PyVec2::from_vec2(*self_v - other_vec.get()))
+            Ok(Py::new(py, PyVec2::from_vec2(*self_v - other_vec.get()))?.into_any())
         } else {
-            Err(PyTypeError::new_err("Unsupported operand type for -"))
+            Ok(py.NotImplemented().into_any())
         }
     }
 
-    fn __mul__(&self, other: &Bound<'_, PyAny>) -> PyResult<PyVec2> {
+    fn __mul__(&self, other: &Bound<'_, PyAny>, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let self_v = self.as_ref()?;
         if let Ok(scalar) = other.extract::<f32>() {
-            Ok(PyVec2::from_vec2(*self_v * scalar))
+            Ok(Py::new(py, PyVec2::from_vec2(*self_v * scalar))?.into_any())
         } else if let Ok(other_vec) = other.extract::<PyVec2>() {
-            Ok(PyVec2::from_vec2(*self_v * other_vec.get()))
+            Ok(Py::new(py, PyVec2::from_vec2(*self_v * other_vec.get()))?.into_any())
         } else {
-            Err(PyTypeError::new_err("Unsupported operand type for *"))
+            Ok(py.NotImplemented().into_any())
         }
     }
 
-    fn __div__(&self, other: &Bound<'_, PyAny>) -> PyResult<PyVec2> {
+    fn __div__(&self, other: &Bound<'_, PyAny>, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let self_v = self.as_ref()?;
         if let Ok(scalar) = other.extract::<f32>() {
-            Ok(PyVec2::from_vec2(*self_v / scalar))
+            Ok(Py::new(py, PyVec2::from_vec2(*self_v / scalar))?.into_any())
         } else if let Ok(other_vec) = other.extract::<PyVec2>() {
-            Ok(PyVec2::from_vec2(*self_v / other_vec.get()))
+            Ok(Py::new(py, PyVec2::from_vec2(*self_v / other_vec.get()))?.into_any())
         } else {
-            Err(PyTypeError::new_err("Unsupported operand type for /"))
+            Ok(py.NotImplemented().into_any())
         }
     }
 
-    fn __truediv__(&self, other: &Bound<'_, PyAny>) -> PyResult<PyVec2> {
-        self.__div__(other)
+    fn __truediv__(&self, other: &Bound<'_, PyAny>, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        self.__div__(other, py)
     }
 
     fn __neg__(&self) -> PyResult<PyVec2> {
         Ok(PyVec2::from_vec2(-*self.as_ref()?))
     }
 
-    fn __rmul__(&self, other: &Bound<'_, PyAny>) -> PyResult<PyVec2> {
+    fn __rmul__(&self, other: &Bound<'_, PyAny>, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let self_v = self.as_ref()?;
         if let Ok(scalar) = other.extract::<f32>() {
-            Ok(PyVec2::from_vec2(scalar * *self_v))
+            Ok(Py::new(py, PyVec2::from_vec2(scalar * *self_v))?.into_any())
         } else if let Ok(other_vec) = other.extract::<PyVec2>() {
-            Ok(PyVec2::from_vec2(other_vec.get() * *self_v))
+            Ok(Py::new(py, PyVec2::from_vec2(other_vec.get() * *self_v))?.into_any())
         } else {
-            Err(PyTypeError::new_err("Unsupported operand type for *"))
+            Ok(py.NotImplemented().into_any())
         }
     }
 

--- a/crates/pybevy_math/src/vec3.rs
+++ b/crates/pybevy_math/src/vec3.rs
@@ -423,66 +423,66 @@ impl PyVec3 {
         Ok(self.as_ref()?.element_product())
     }
 
-    fn __add__(&self, other: &Bound<'_, PyAny>) -> PyResult<PyVec3> {
+    fn __add__(&self, other: &Bound<'_, PyAny>, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let self_vec = *self.as_ref()?;
         if let Ok(scalar) = other.extract::<f32>() {
-            Ok(PyVec3::from_vec3(self_vec + scalar))
+            Ok(Py::new(py, PyVec3::from_vec3(self_vec + scalar))?.into_any())
         } else if let Ok(other_vec) = other.extract::<PyVec3>() {
-            Ok(PyVec3::from_vec3(self_vec + *other_vec.as_ref()?))
+            Ok(Py::new(py, PyVec3::from_vec3(self_vec + *other_vec.as_ref()?))?.into_any())
         } else {
-            Err(PyTypeError::new_err("Unsupported operand type for +"))
+            Ok(py.NotImplemented().into_any())
         }
     }
 
-    fn __sub__(&self, other: &Bound<'_, PyAny>) -> PyResult<PyVec3> {
+    fn __sub__(&self, other: &Bound<'_, PyAny>, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let self_vec = *self.as_ref()?;
         if let Ok(scalar) = other.extract::<f32>() {
-            Ok(PyVec3::from_vec3(self_vec - scalar))
+            Ok(Py::new(py, PyVec3::from_vec3(self_vec - scalar))?.into_any())
         } else if let Ok(other_vec) = other.extract::<PyVec3>() {
-            Ok(PyVec3::from_vec3(self_vec - *other_vec.as_ref()?))
+            Ok(Py::new(py, PyVec3::from_vec3(self_vec - *other_vec.as_ref()?))?.into_any())
         } else {
-            Err(PyTypeError::new_err("Unsupported operand type for -"))
+            Ok(py.NotImplemented().into_any())
         }
     }
 
-    fn __mul__(&self, other: &Bound<'_, PyAny>) -> PyResult<PyVec3> {
+    fn __mul__(&self, other: &Bound<'_, PyAny>, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let self_vec = *self.as_ref()?;
         if let Ok(scalar) = other.extract::<f32>() {
-            Ok(PyVec3::from_vec3(self_vec * scalar))
+            Ok(Py::new(py, PyVec3::from_vec3(self_vec * scalar))?.into_any())
         } else if let Ok(other_vec) = other.extract::<PyVec3>() {
-            Ok(PyVec3::from_vec3(self_vec * *other_vec.as_ref()?))
+            Ok(Py::new(py, PyVec3::from_vec3(self_vec * *other_vec.as_ref()?))?.into_any())
         } else {
-            Err(PyTypeError::new_err("Unsupported operand type for *"))
+            Ok(py.NotImplemented().into_any())
         }
     }
 
-    fn __div__(&self, other: &Bound<'_, PyAny>) -> PyResult<PyVec3> {
+    fn __div__(&self, other: &Bound<'_, PyAny>, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let self_vec = *self.as_ref()?;
         if let Ok(scalar) = other.extract::<f32>() {
-            Ok(PyVec3::from_vec3(self_vec / scalar))
+            Ok(Py::new(py, PyVec3::from_vec3(self_vec / scalar))?.into_any())
         } else if let Ok(other_vec) = other.extract::<PyVec3>() {
-            Ok(PyVec3::from_vec3(self_vec / *other_vec.as_ref()?))
+            Ok(Py::new(py, PyVec3::from_vec3(self_vec / *other_vec.as_ref()?))?.into_any())
         } else {
-            Err(PyTypeError::new_err("Unsupported operand type for /"))
+            Ok(py.NotImplemented().into_any())
         }
     }
 
-    fn __truediv__(&self, other: &Bound<'_, PyAny>) -> PyResult<PyVec3> {
-        self.__div__(other)
+    fn __truediv__(&self, other: &Bound<'_, PyAny>, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        self.__div__(other, py)
     }
 
     fn __neg__(&self) -> PyResult<PyVec3> {
         Ok(PyVec3::from_vec3(-*self.as_ref()?))
     }
 
-    fn __rmul__(&self, other: &Bound<'_, PyAny>) -> PyResult<PyVec3> {
+    fn __rmul__(&self, other: &Bound<'_, PyAny>, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let self_vec = *self.as_ref()?;
         if let Ok(scalar) = other.extract::<f32>() {
-            Ok(PyVec3::from_vec3(scalar * self_vec))
+            Ok(Py::new(py, PyVec3::from_vec3(scalar * self_vec))?.into_any())
         } else if let Ok(other_vec) = other.extract::<PyVec3>() {
-            Ok(PyVec3::from_vec3(*other_vec.as_ref()? * self_vec))
+            Ok(Py::new(py, PyVec3::from_vec3(*other_vec.as_ref()? * self_vec))?.into_any())
         } else {
-            Err(PyTypeError::new_err("Unsupported operand type for *"))
+            Ok(py.NotImplemented().into_any())
         }
     }
 

--- a/crates/pybevy_math/src/vec4.rs
+++ b/crates/pybevy_math/src/vec4.rs
@@ -392,66 +392,66 @@ impl PyVec4 {
         Ok(PyVec4::from_vec4(self.as_ref()?.xyzw()))
     }
 
-    fn __add__(&self, other: &Bound<'_, PyAny>) -> PyResult<PyVec4> {
+    fn __add__(&self, other: &Bound<'_, PyAny>, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let self_vec = *self.as_ref()?;
         if let Ok(scalar) = other.extract::<f32>() {
-            Ok(PyVec4::from_vec4(self_vec + scalar))
+            Ok(Py::new(py, PyVec4::from_vec4(self_vec + scalar))?.into_any())
         } else if let Ok(other_vec) = other.extract::<PyVec4>() {
-            Ok(PyVec4::from_vec4(self_vec + *other_vec.as_ref()?))
+            Ok(Py::new(py, PyVec4::from_vec4(self_vec + *other_vec.as_ref()?))?.into_any())
         } else {
-            Err(PyTypeError::new_err("Unsupported operand type for +"))
+            Ok(py.NotImplemented().into_any())
         }
     }
 
-    fn __sub__(&self, other: &Bound<'_, PyAny>) -> PyResult<PyVec4> {
+    fn __sub__(&self, other: &Bound<'_, PyAny>, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let self_vec = *self.as_ref()?;
         if let Ok(scalar) = other.extract::<f32>() {
-            Ok(PyVec4::from_vec4(self_vec - scalar))
+            Ok(Py::new(py, PyVec4::from_vec4(self_vec - scalar))?.into_any())
         } else if let Ok(other_vec) = other.extract::<PyVec4>() {
-            Ok(PyVec4::from_vec4(self_vec - *other_vec.as_ref()?))
+            Ok(Py::new(py, PyVec4::from_vec4(self_vec - *other_vec.as_ref()?))?.into_any())
         } else {
-            Err(PyTypeError::new_err("Unsupported operand type for -"))
+            Ok(py.NotImplemented().into_any())
         }
     }
 
-    fn __mul__(&self, other: &Bound<'_, PyAny>) -> PyResult<PyVec4> {
+    fn __mul__(&self, other: &Bound<'_, PyAny>, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let self_vec = *self.as_ref()?;
         if let Ok(scalar) = other.extract::<f32>() {
-            Ok(PyVec4::from_vec4(self_vec * scalar))
+            Ok(Py::new(py, PyVec4::from_vec4(self_vec * scalar))?.into_any())
         } else if let Ok(other_vec) = other.extract::<PyVec4>() {
-            Ok(PyVec4::from_vec4(self_vec * *other_vec.as_ref()?))
+            Ok(Py::new(py, PyVec4::from_vec4(self_vec * *other_vec.as_ref()?))?.into_any())
         } else {
-            Err(PyTypeError::new_err("Unsupported operand type for *"))
+            Ok(py.NotImplemented().into_any())
         }
     }
 
-    fn __div__(&self, other: &Bound<'_, PyAny>) -> PyResult<PyVec4> {
+    fn __div__(&self, other: &Bound<'_, PyAny>, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let self_vec = *self.as_ref()?;
         if let Ok(scalar) = other.extract::<f32>() {
-            Ok(PyVec4::from_vec4(self_vec / scalar))
+            Ok(Py::new(py, PyVec4::from_vec4(self_vec / scalar))?.into_any())
         } else if let Ok(other_vec) = other.extract::<PyVec4>() {
-            Ok(PyVec4::from_vec4(self_vec / *other_vec.as_ref()?))
+            Ok(Py::new(py, PyVec4::from_vec4(self_vec / *other_vec.as_ref()?))?.into_any())
         } else {
-            Err(PyTypeError::new_err("Unsupported operand type for /"))
+            Ok(py.NotImplemented().into_any())
         }
     }
 
-    fn __truediv__(&self, other: &Bound<'_, PyAny>) -> PyResult<PyVec4> {
-        self.__div__(other)
+    fn __truediv__(&self, other: &Bound<'_, PyAny>, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        self.__div__(other, py)
     }
 
     fn __neg__(&self) -> PyResult<PyVec4> {
         Ok(PyVec4::from_vec4(-*self.as_ref()?))
     }
 
-    fn __rmul__(&self, other: &Bound<'_, PyAny>) -> PyResult<PyVec4> {
+    fn __rmul__(&self, other: &Bound<'_, PyAny>, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let self_vec = *self.as_ref()?;
         if let Ok(scalar) = other.extract::<f32>() {
-            Ok(PyVec4::from_vec4(scalar * self_vec))
+            Ok(Py::new(py, PyVec4::from_vec4(scalar * self_vec))?.into_any())
         } else if let Ok(other_vec) = other.extract::<PyVec4>() {
-            Ok(PyVec4::from_vec4(*other_vec.as_ref()? * self_vec))
+            Ok(Py::new(py, PyVec4::from_vec4(*other_vec.as_ref()? * self_vec))?.into_any())
         } else {
-            Err(PyTypeError::new_err("Unsupported operand type for *"))
+            Ok(py.NotImplemented().into_any())
         }
     }
 


### PR DESCRIPTION
As referenced in https://docs.python.org/3/reference/datamodel.html#emulating-numeric-types - If one of those methods does not support the operation with the supplied arguments, it should return [NotImplemented](https://docs.python.org/3/library/constants.html#NotImplemented).