### PR TITLE
Resource, assets - ECS read & write filtering fix

### DIFF
--- a/crates/pybevy_core/src/registry/asset_bridge.rs
+++ b/crates/pybevy_core/src/registry/asset_bridge.rs
@@ -31,7 +31,7 @@ use std::any::TypeId;
 
 use bevy::{
     asset::{AssetPath, AssetServer, UntypedHandle},
-    ecs::world::World,
+    ecs::{component::ComponentId, world::World},
 };
 use pyo3::{ffi::PyTypeObject, prelude::*, types::PyType};
 
@@ -66,6 +66,10 @@ pub trait AssetBridge: Send + Sync + 'static {
 
     /// Human-readable name for error messages
     fn name(&self) -> &'static str;
+
+    /// Get the ComponentId of the `Assets<T>` resource in the world.
+    /// Used by FilteredAccessSet to track cross-system asset access.
+    fn resource_id(&self, world: &World) -> Option<ComponentId>;
 
     /// Get asset from Assets resource and convert to Python object (read-only)
     ///

--- a/crates/pybevy_ecs/src/shared/access_sets.rs
+++ b/crates/pybevy_ecs/src/shared/access_sets.rs
@@ -13,6 +13,27 @@ pub fn build_access_set(
     components_to_write: &[ComponentId],
     with_filters: &[ComponentId],
 ) -> FilteredAccessSet {
+    build_full_access_set(
+        components_to_read,
+        components_to_write,
+        with_filters,
+        &[],
+        &[],
+    )
+}
+
+/// Build a `FilteredAccessSet` from component AND resource access information.
+///
+/// Extends `build_access_set` with resource read/write tracking, telling Bevy's
+/// scheduler about `Res<T>`, `ResMut<T>`, and `Assets<T>` accesses so it can
+/// prevent cross-system data races.
+pub fn build_full_access_set(
+    components_to_read: &[ComponentId],
+    components_to_write: &[ComponentId],
+    with_filters: &[ComponentId],
+    resources_to_read: &[ComponentId],
+    resources_to_write: &[ComponentId],
+) -> FilteredAccessSet {
     let mut set = FilteredAccessSet::default();
     let mut access = FilteredAccess::default();
 
@@ -24,6 +45,12 @@ pub fn build_access_set(
     }
     for &id in with_filters {
         access.and_with(id);
+    }
+    for &id in resources_to_write {
+        access.add_resource_write(id);
+    }
+    for &id in resources_to_read {
+        access.add_resource_read(id);
     }
 
     set.add(access);

--- a/crates/pybevy_ecs/src/shared/access_sets.rs
+++ b/crates/pybevy_ecs/src/shared/access_sets.rs
@@ -3,30 +3,12 @@ use bevy::ecs::{
     query::{FilteredAccess, FilteredAccessSet},
 };
 
-/// Build a `FilteredAccessSet` from collected component access information.
+/// Build a `FilteredAccessSet` from component and resource access information.
 ///
 /// Constructs the Bevy scheduler metadata from resolved ComponentIds.
 /// Tells Bevy's scheduler what components this system reads, writes, and
-/// filters on, enabling parallel scheduling.
-pub fn build_access_set(
-    components_to_read: &[ComponentId],
-    components_to_write: &[ComponentId],
-    with_filters: &[ComponentId],
-) -> FilteredAccessSet {
-    build_full_access_set(
-        components_to_read,
-        components_to_write,
-        with_filters,
-        &[],
-        &[],
-    )
-}
-
-/// Build a `FilteredAccessSet` from component AND resource access information.
-///
-/// Extends `build_access_set` with resource read/write tracking, telling Bevy's
-/// scheduler about `Res<T>`, `ResMut<T>`, and `Assets<T>` accesses so it can
-/// prevent cross-system data races.
+/// filters on, as well as `Res<T>`, `ResMut<T>`, and `Assets<T>` resource
+/// accesses, enabling parallel scheduling and preventing cross-system data races.
 pub fn build_full_access_set(
     components_to_read: &[ComponentId],
     components_to_write: &[ComponentId],

--- a/crates/pybevy_macros/src/asset.rs
+++ b/crates/pybevy_macros/src/asset.rs
@@ -319,6 +319,10 @@ pub(crate) fn generate_asset_bridge_tokens(
                 #asset_name
             }
 
+            fn resource_id(&self, world: &bevy::ecs::world::World) -> Option<bevy::ecs::component::ComponentId> {
+                world.components().resource_id::<bevy::asset::Assets<#bevy_type>>()
+            }
+
             #is_loadable_impl
 
             fn get(

--- a/src/ecs/dynamic_system.rs
+++ b/src/ecs/dynamic_system.rs
@@ -15,10 +15,10 @@ use bevy::{
     },
     prelude::*,
 };
-use pybevy_ecs::shared::access_sets::build_full_access_set;
 use pybevy_core::registry::global_registry;
-use pybevy_ecs::shared::access_validation::{
-    self as shared_validation, ComponentAccess, ParamAccess, QueryFilters,
+use pybevy_ecs::shared::{
+    access_sets::build_full_access_set,
+    access_validation::{self as shared_validation, ComponentAccess, ParamAccess, QueryFilters},
 };
 use pybevy_reload::{HotReloadGeneration, SystemProfiler, SystemStage};
 use pyo3::{
@@ -1137,9 +1137,7 @@ impl System for DynamicSystem {
                     mutable,
                 } => {
                     let key = wrapper_class.unwrap_or(*type_ptr).0;
-                    if let Some(bridge) =
-                        global_registry::get_asset_bridge_by_py_type(key)
-                    {
+                    if let Some(bridge) = global_registry::get_asset_bridge_by_py_type(key) {
                         if let Some(id) = bridge.resource_id(world) {
                             if *mutable {
                                 self.resources_to_write.push(id);

--- a/src/ecs/dynamic_system.rs
+++ b/src/ecs/dynamic_system.rs
@@ -15,6 +15,8 @@ use bevy::{
     },
     prelude::*,
 };
+use pybevy_ecs::shared::access_sets::build_full_access_set;
+use pybevy_core::registry::global_registry;
 use pybevy_ecs::shared::access_validation::{
     self as shared_validation, ComponentAccess, ParamAccess, QueryFilters,
 };
@@ -115,6 +117,8 @@ pub struct DynamicSystem {
     components_to_write: Vec<ComponentId>,
     components_to_read: Vec<ComponentId>,
     with_filters: Vec<ComponentId>,
+    resources_to_read: Vec<ComponentId>,
+    resources_to_write: Vec<ComponentId>,
     /// Maps custom component type pointers to their registered ComponentIds
     custom_component_ids: HashMap<*const PyTypeObject, ComponentId>,
     /// Shared inner state holding Python references - can be gutted externally
@@ -287,6 +291,8 @@ impl DynamicSystem {
             components_to_write: Vec::new(),
             components_to_read: Vec::new(),
             with_filters: Vec::new(),
+            resources_to_read: Vec::new(),
+            resources_to_write: Vec::new(),
             custom_component_ids: HashMap::new(),
             inner,
             func_name,
@@ -1110,14 +1116,38 @@ impl System for DynamicSystem {
                         }
                     }
                 }
-                SystemParamType::Resource {
-                    type_obj: _,
-                    mutable: _,
-                } => {
-                    // Resources will be handled differently - they don't affect filtered access
+                SystemParamType::Resource { type_obj, mutable } => {
+                    let resource_type = Python::attach(|py| {
+                        let type_bound = type_obj.bind(py);
+                        PyResourceType::try_from((type_bound, py)).ok()
+                    });
+                    if let Some(rt) = resource_type {
+                        if let Some(id) = rt.get_component_id(world) {
+                            if *mutable {
+                                self.resources_to_write.push(id);
+                            } else {
+                                self.resources_to_read.push(id);
+                            }
+                        }
+                    }
                 }
-                SystemParamType::Assets { .. } => {
-                    // Assets are resources - they don't affect filtered access
+                SystemParamType::Assets {
+                    type_ptr,
+                    wrapper_class,
+                    mutable,
+                } => {
+                    let key = wrapper_class.unwrap_or(*type_ptr).0;
+                    if let Some(bridge) =
+                        global_registry::get_asset_bridge_by_py_type(key)
+                    {
+                        if let Some(id) = bridge.resource_id(world) {
+                            if *mutable {
+                                self.resources_to_write.push(id);
+                            } else {
+                                self.resources_to_read.push(id);
+                            }
+                        }
+                    }
                 }
                 SystemParamType::View { param } => {
                     // Extract component types and mutability from PyViewParam
@@ -1210,10 +1240,12 @@ impl System for DynamicSystem {
             self.add_with(id);
         }
 
-        pybevy_ecs::shared::access_sets::build_access_set(
+        build_full_access_set(
             &self.components_to_read,
             &self.components_to_write,
             &self.with_filters,
+            &self.resources_to_read,
+            &self.resources_to_write,
         )
     }
 
@@ -1327,6 +1359,9 @@ impl DynamicSystem {
 ///
 /// # Arguments
 /// * `py` - Python GIL token
+/// Get or create a synthetic ComponentId for an asset type, keyed by Python type pointer.
+/// Used to register `Res[Assets[T]]`/`ResMut[Assets[T]]` access in FilteredAccessSet
+/// so Bevy's scheduler prevents cross-system data races on the same asset type.
 /// * `system_func` - The parsed system function with parameters
 /// * `world` - Mutable world reference
 /// * `on_param` - The On trigger parameter (required for observer dispatch)


### PR DESCRIPTION
Python-freethreaded implementation was unsound, since Bevy ECS registrations did not cover resources (including assets) filtering, and bevy could schedule the systems to run simultaneously. Implement resource filtering.