### PR TITLE
Remove non-res asset server access

### DIFF
--- a/examples/bevy/2d/rotation.py
+++ b/examples/bevy/2d/rotation.py
@@ -44,7 +44,7 @@ class RotateToPlayer(Component):
     rotation_speed: float = 0.0  # Radians per second
 
 
-def setup(commands: Commands, assets: AssetServer) -> None:
+def setup(commands: Commands, assets: Res[AssetServer]) -> None:
     """Set up the game entities and camera."""
     ship_handle = assets.load_image("bevy/textures/simplespace/ship_C.png")
     enemy_a_handle = assets.load_image("bevy/textures/simplespace/enemy_A.png")

--- a/examples/bevy/2d/sprite_animation.py
+++ b/examples/bevy/2d/sprite_animation.py
@@ -82,7 +82,7 @@ class RightSprite(Component):
 
 def setup(
     commands: Commands,
-    asset_server: AssetServer,
+    asset_server: Res[AssetServer],
     texture_atlas_layouts: ResMut[Assets[TextureAtlasLayout]],
 ) -> None:
     """Set up the scene with camera and animated sprites."""

--- a/src/ecs/dynamic_system.rs
+++ b/src/ecs/dynamic_system.rs
@@ -30,7 +30,7 @@ use pyo3::{
 use smallvec::SmallVec;
 
 use crate::{
-    assets::{asset_server::PyAssetServer, assets::PyAssets},
+    assets::assets::PyAssets,
     ecs::{
         commands::PyCommands,
         component_type::{PyComponentType, register_component_id, register_custom_component},
@@ -670,14 +670,6 @@ impl System for DynamicSystem {
                         let obj = Py::new(py, py_world).expect("Failed to create PyWorld");
                         self.args_buffer.push(obj.into_any());
                     }
-                    SystemParamType::AssetServer => {
-                        // Create PyAssetServer wrapper with world access
-                        let py_asset_server =
-                            unsafe { PyAssetServer::new(world_mut, validity.clone()) };
-                        let obj = Py::new(py, (py_asset_server, PyResource))
-                            .expect("Failed to create PyAssetServer");
-                        self.args_buffer.push(obj.into_any());
-                    }
                     SystemParamType::Commands => {
                         // Use the pre-created Commands from commands_storage
                         let commands = commands_storage
@@ -1201,9 +1193,6 @@ impl System for DynamicSystem {
                 SystemParamType::Local(_) => {
                     // Local state doesn't affect world access
                 }
-                SystemParamType::AssetServer => {
-                    // AssetServer is a resource - doesn't affect filtered access
-                }
                 SystemParamType::World => {
                     // World access requires exclusive access - no filtering needed
                 }
@@ -1442,12 +1431,6 @@ pub(crate) fn execute_system_func(
                         .expect("Failed to create PyRes");
                     args_buffer.push(res_wrapper.into_any());
                 }
-            }
-            SystemParamType::AssetServer => {
-                let py_asset_server = unsafe { PyAssetServer::new(world, validity.clone()) };
-                let obj = Py::new(py, (py_asset_server, PyResource))
-                    .expect("Failed to create PyAssetServer");
-                args_buffer.push(obj.into_any());
             }
             SystemParamType::World => {
                 let py_world = unsafe { PyWorld::new(world, validity.clone()) };

--- a/src/ecs/system.rs
+++ b/src/ecs/system.rs
@@ -20,7 +20,7 @@ use super::{
     world::PyWorld,
 };
 use crate::{
-    assets::{asset_server::PyAssetServer, asset_type::PyAssetTypeParam},
+    assets::asset_type::PyAssetTypeParam,
     ecs::{
         component_type::PyComponentType,
         messages::MessageType,
@@ -282,8 +282,6 @@ impl SystemFunction {
                     wrapper_class: asset_param.wrapper_class().map(AssetTypePtr),
                     mutable: is_mutable,
                 }
-            } else if annotation.is(PyAssetServer::type_object(py)) {
-                SystemParamType::AssetServer
             } else if annotation.is(PyWorld::type_object(py)) {
                 SystemParamType::World
             } else if annotation.is(PyCommands::type_object(py)) {
@@ -392,7 +390,6 @@ pub enum SystemParamType {
         wrapper_class: Option<AssetTypePtr>,
         mutable: bool,
     },
-    AssetServer,
     World,
     Commands,
     MessageWriter {
@@ -430,7 +427,6 @@ impl Clone for SystemParamType {
                 wrapper_class: *wrapper_class,
                 mutable: *mutable,
             },
-            SystemParamType::AssetServer => SystemParamType::AssetServer,
             SystemParamType::World => SystemParamType::World,
             SystemParamType::Commands => SystemParamType::Commands,
             SystemParamType::MessageWriter { message_type } => SystemParamType::MessageWriter {


### PR DESCRIPTION
Fixes #84 

this no longer works:
```python
asset_server: AssetServer
```

must use
```python
asset_server: Res[AssetServer]
```

as in Rust Bevy.