### PR TITLE
FilteredEntityAccess & ErasedQueryState refactoring

### DIFF
--- a/crates/pybevy_core/src/filtered_entity_access.rs
+++ b/crates/pybevy_core/src/filtered_entity_access.rs
@@ -1,0 +1,76 @@
+//! Unified entity access for read-only and read-write queries.
+//!
+//! Wraps both `FilteredEntityRef` (read-only) and `FilteredEntityMut` (read-write)
+//! behind a single enum so that extraction code (`ExtractFn`, `ComponentBridge::extract`)
+//! works unchanged for both query types.
+
+use bevy::ecs::{
+    change_detection::MutUntyped,
+    component::ComponentId,
+    entity::Entity,
+    ptr::Ptr,
+    world::{FilteredEntityMut, FilteredEntityRef},
+};
+
+/// Unified access to either a read-only or read-write filtered entity.
+///
+/// Used by `ExtractFn` and `ComponentBridge::extract()` so that the same extraction
+/// code path works for both `QueryState<FilteredEntityRef>` (read-only) and
+/// `QueryState<FilteredEntityMut>` (read-write) queries.
+pub enum FilteredEntityAccess<'w, 's> {
+    /// Read-only access — query has no `Mut[T]` components.
+    Ref(FilteredEntityRef<'w, 's>),
+    /// Read-write access — query has at least one `Mut[T]` component.
+    Mut(FilteredEntityMut<'w, 's>),
+}
+
+impl<'w, 's> FilteredEntityAccess<'w, 's> {
+    /// Returns the entity ID.
+    #[inline(always)]
+    pub fn id(&self) -> Entity {
+        match self {
+            Self::Ref(r) => r.id(),
+            Self::Mut(m) => m.id(),
+        }
+    }
+
+    /// Read-only component access by ID. Available on both variants.
+    #[inline(always)]
+    pub fn get_by_id(&self, component_id: ComponentId) -> Option<Ptr<'_>> {
+        match self {
+            Self::Ref(r) => r.get_by_id(component_id),
+            Self::Mut(m) => m.get_by_id(component_id),
+        }
+    }
+
+    /// Mutable component access by ID. Only available on the `Mut` variant.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called on the `Ref` variant. This should never happen because
+    /// read-only queries guarantee `AccessMode::Read` for every component.
+    #[inline(always)]
+    pub fn get_mut_by_id(&mut self, component_id: ComponentId) -> Option<MutUntyped<'_>> {
+        match self {
+            Self::Ref(_) => panic!(
+                "get_mut_by_id called on FilteredEntityRef — \
+                 read-only queries must never request mutable access"
+            ),
+            Self::Mut(m) => m.get_mut_by_id(component_id),
+        }
+    }
+}
+
+impl<'w, 's> From<FilteredEntityRef<'w, 's>> for FilteredEntityAccess<'w, 's> {
+    #[inline(always)]
+    fn from(r: FilteredEntityRef<'w, 's>) -> Self {
+        Self::Ref(r)
+    }
+}
+
+impl<'w, 's> From<FilteredEntityMut<'w, 's>> for FilteredEntityAccess<'w, 's> {
+    #[inline(always)]
+    fn from(m: FilteredEntityMut<'w, 's>) -> Self {
+        Self::Mut(m)
+    }
+}

--- a/crates/pybevy_core/src/lib.rs
+++ b/crates/pybevy_core/src/lib.rs
@@ -27,6 +27,7 @@ pub mod asset_path;
 pub mod component;
 pub mod debug_snapshot;
 pub mod entity;
+pub mod filtered_entity_access;
 pub mod handle;
 pub mod hierarchy;
 pub extern crate inventory;
@@ -50,7 +51,7 @@ use bevy::ecs::{
     component::ComponentId,
     entity::Entity,
     hierarchy::{ChildOf, Children},
-    world::{FilteredEntityMut, World},
+    world::World,
 };
 use pyo3::prelude::*;
 
@@ -84,7 +85,7 @@ impl ComponentBridge for ChildOfBridge {
     #[inline(always)]
     fn extract(
         &self,
-        entity: &mut FilteredEntityMut,
+        entity: &mut FilteredEntityAccess,
         component_id: ComponentId,
         _validity: ValidityFlagWithMode,
         py: Python,
@@ -129,7 +130,7 @@ impl ComponentBridge for ChildOfBridge {
     fn extract_fn(&self) -> ExtractFn {
         #[inline(always)]
         fn extract_impl(
-            entity: &mut FilteredEntityMut,
+            entity: &mut FilteredEntityAccess,
             component_id: ComponentId,
             _validity: ValidityFlagWithMode,
             py: Python,
@@ -159,7 +160,8 @@ impl ComponentBridge for ChildOfBridge {
         py: Python,
     ) -> PyResult<Option<Py<PyAny>>> {
         if let Some(component) = entity.get::<ChildOf>() {
-            let ptr = component as *const ChildOf as *mut ChildOf;
+            // TODO(pybevy/pybevy#90): use a read-only ComponentStorage variant to avoid *const -> *mut cast
+                    let ptr = component as *const ChildOf as *mut ChildOf;
             let storage = unsafe { ComponentStorage::borrowed(ptr, validity) };
             let obj = Py::new(py, hierarchy::PyChildOf::from_borrowed(storage))?;
             Ok(Some(obj.into_any()))
@@ -214,7 +216,7 @@ impl ComponentBridge for ChildrenBridge {
     #[inline(always)]
     fn extract(
         &self,
-        entity: &mut FilteredEntityMut,
+        entity: &mut FilteredEntityAccess,
         component_id: ComponentId,
         _validity: ValidityFlagWithMode,
         py: Python,
@@ -254,7 +256,7 @@ impl ComponentBridge for ChildrenBridge {
     fn extract_fn(&self) -> ExtractFn {
         #[inline(always)]
         fn extract_impl(
-            entity: &mut FilteredEntityMut,
+            entity: &mut FilteredEntityAccess,
             component_id: ComponentId,
             _validity: ValidityFlagWithMode,
             py: Python,
@@ -316,6 +318,7 @@ pub use bridge_inventory::{
 pub use component::PyComponent;
 pub use debug_snapshot::{DebugSnapshot, ReloadMemorySnapshotInfo};
 pub use entity::PyEntity;
+pub use filtered_entity_access::FilteredEntityAccess;
 pub use handle::{PyHandle, extract_handle_from_any};
 pub use hierarchy::{PyChildOf, PyChildren, PyChildrenIterator};
 pub use materializable::PyMaterializable;

--- a/crates/pybevy_core/src/lib.rs
+++ b/crates/pybevy_core/src/lib.rs
@@ -161,7 +161,7 @@ impl ComponentBridge for ChildOfBridge {
     ) -> PyResult<Option<Py<PyAny>>> {
         if let Some(component) = entity.get::<ChildOf>() {
             // TODO(pybevy/pybevy#90): use a read-only ComponentStorage variant to avoid *const -> *mut cast
-                    let ptr = component as *const ChildOf as *mut ChildOf;
+            let ptr = component as *const ChildOf as *mut ChildOf;
             let storage = unsafe { ComponentStorage::borrowed(ptr, validity) };
             let obj = Py::new(py, hierarchy::PyChildOf::from_borrowed(storage))?;
             Ok(Some(obj.into_any()))

--- a/crates/pybevy_core/src/registry/component_bridge.rs
+++ b/crates/pybevy_core/src/registry/component_bridge.rs
@@ -43,12 +43,8 @@ use crate::{FilteredEntityAccess, ValidityFlagWithMode, ViewBridge};
 /// This allows caching the extract function directly to avoid vtable dispatch.
 /// Takes a `FilteredEntityAccess` which wraps either `FilteredEntityRef` (read-only)
 /// or `FilteredEntityMut` (read-write) depending on query mutability.
-pub type ExtractFn = fn(
-    &mut FilteredEntityAccess,
-    ComponentId,
-    ValidityFlagWithMode,
-    Python,
-) -> PyResult<Py<PyAny>>;
+pub type ExtractFn =
+    fn(&mut FilteredEntityAccess, ComponentId, ValidityFlagWithMode, Python) -> PyResult<Py<PyAny>>;
 
 /// Trait that bridges a Bevy component to its Python wrapper.
 ///

--- a/crates/pybevy_core/src/registry/component_bridge.rs
+++ b/crates/pybevy_core/src/registry/component_bridge.rs
@@ -32,17 +32,23 @@ use std::any::TypeId;
 use bevy::ecs::{
     component::ComponentId,
     entity::Entity,
-    world::{EntityRef, EntityWorldMut, FilteredEntityMut, World},
+    world::{EntityRef, EntityWorldMut, World},
 };
 use pyo3::{ffi::PyTypeObject, prelude::*, types::PyType};
 
-use crate::{ValidityFlagWithMode, ViewBridge};
+use crate::{FilteredEntityAccess, ValidityFlagWithMode, ViewBridge};
 
 /// Function pointer type for component extraction.
 ///
 /// This allows caching the extract function directly to avoid vtable dispatch.
-pub type ExtractFn =
-    fn(&mut FilteredEntityMut, ComponentId, ValidityFlagWithMode, Python) -> PyResult<Py<PyAny>>;
+/// Takes a `FilteredEntityAccess` which wraps either `FilteredEntityRef` (read-only)
+/// or `FilteredEntityMut` (read-write) depending on query mutability.
+pub type ExtractFn = fn(
+    &mut FilteredEntityAccess,
+    ComponentId,
+    ValidityFlagWithMode,
+    Python,
+) -> PyResult<Py<PyAny>>;
 
 /// Trait that bridges a Bevy component to its Python wrapper.
 ///
@@ -91,7 +97,7 @@ pub trait ComponentBridge: Send + Sync + 'static {
     /// Returns error if component extraction or Python conversion fails.
     fn extract(
         &self,
-        entity: &mut FilteredEntityMut,
+        entity: &mut FilteredEntityAccess,
         component_id: ComponentId,
         validity: ValidityFlagWithMode,
         py: Python,

--- a/crates/pybevy_ecs/src/shared/query_builder_ext.rs
+++ b/crates/pybevy_ecs/src/shared/query_builder_ext.rs
@@ -106,7 +106,10 @@ pub fn build_query_state_ref<'a>(
     let mut builder = QueryBuilder::<FilteredEntityRef>::new(world);
 
     for comp in &spec.components {
-        debug_assert!(!comp.mutable, "build_query_state_ref called with mutable component");
+        debug_assert!(
+            !comp.mutable,
+            "build_query_state_ref called with mutable component"
+        );
         if comp.optional {
             builder.optional(|b| {
                 b.ref_id(comp.id);

--- a/crates/pybevy_ecs/src/shared/query_builder_ext.rs
+++ b/crates/pybevy_ecs/src/shared/query_builder_ext.rs
@@ -1,16 +1,23 @@
 use bevy::ecs::{
     component::ComponentId,
-    query::{QueryBuilder, QueryState},
-    world::{FilteredEntityMut, World},
+    query::{QueryBuilder, QueryData, QueryState},
+    world::{FilteredEntityMut, FilteredEntityRef, World},
 };
+
+/// A single component entry in a query specification.
+#[derive(Clone)]
+pub struct QueryComponent {
+    pub id: ComponentId,
+    pub optional: bool,
+    pub mutable: bool,
+}
 
 /// Specification for building a Bevy QueryState.
 ///
 /// Collects resolved ComponentIds so the QueryState can be constructed with
 /// Bevy's native archetype-indexed matching.
 pub struct QueryBuildSpec {
-    /// Components to query: (ComponentId, is_optional)
-    pub components: Vec<(ComponentId, bool)>,
+    pub components: Vec<QueryComponent>,
     /// With filter component IDs
     pub with_filters: Vec<ComponentId>,
     /// Without filter component IDs
@@ -23,26 +30,15 @@ pub struct QueryBuildSpec {
     pub anyof_filters: Vec<ComponentId>,
 }
 
-/// Build a Bevy `QueryState<FilteredEntityMut>` from a specification.
-///
-/// Callers resolve their parameter types to `ComponentId`s, then call this
-/// function to build the QueryState.
-pub fn build_query_state<'a>(
-    world: &'a mut World,
-    spec: &QueryBuildSpec,
-) -> QueryState<FilteredEntityMut<'a, 'a>> {
-    let mut builder = QueryBuilder::<FilteredEntityMut>::new(world);
-
-    for &(id, optional) in &spec.components {
-        if optional {
-            builder.optional(|b| {
-                b.mut_id(id);
-            });
-        } else {
-            builder.mut_id(id);
-        }
+impl QueryBuildSpec {
+    /// Returns true if all queried components are read-only (no mutable access requested).
+    pub fn is_read_only(&self) -> bool {
+        !self.components.iter().any(|c| c.mutable)
     }
+}
 
+/// Apply with/without/changed/added/anyof filters to any QueryBuilder.
+fn apply_filters<D: QueryData>(builder: &mut QueryBuilder<D>, spec: &QueryBuildSpec) {
     for &id in &spec.with_filters {
         builder.with_id(id);
     }
@@ -66,6 +62,60 @@ pub fn build_query_state<'a>(
             }
         });
     }
+}
 
+/// Build a Bevy `QueryState<FilteredEntityMut>` from a specification.
+///
+/// Callers resolve their parameter types to `ComponentId`s, then call this
+/// function to build the QueryState.
+pub fn build_query_state<'a>(
+    world: &'a mut World,
+    spec: &QueryBuildSpec,
+) -> QueryState<FilteredEntityMut<'a, 'a>> {
+    let mut builder = QueryBuilder::<FilteredEntityMut>::new(world);
+
+    for comp in &spec.components {
+        if comp.optional {
+            builder.optional(|b| {
+                if comp.mutable {
+                    b.mut_id(comp.id);
+                } else {
+                    b.ref_id(comp.id);
+                }
+            });
+        } else if comp.mutable {
+            builder.mut_id(comp.id);
+        } else {
+            builder.ref_id(comp.id);
+        }
+    }
+
+    apply_filters(&mut builder, spec);
+    builder.build()
+}
+
+/// Build a Bevy `QueryState<FilteredEntityRef>` from a read-only specification.
+///
+/// This should only be called when `spec.is_read_only()` returns true.
+/// Uses `FilteredEntityRef` to signal to Bevy's parallel executor that
+/// no write access is held, enabling concurrent scheduling.
+pub fn build_query_state_ref<'a>(
+    world: &'a mut World,
+    spec: &QueryBuildSpec,
+) -> QueryState<FilteredEntityRef<'a, 'a>> {
+    let mut builder = QueryBuilder::<FilteredEntityRef>::new(world);
+
+    for comp in &spec.components {
+        debug_assert!(!comp.mutable, "build_query_state_ref called with mutable component");
+        if comp.optional {
+            builder.optional(|b| {
+                b.ref_id(comp.id);
+            });
+        } else {
+            builder.ref_id(comp.id);
+        }
+    }
+
+    apply_filters(&mut builder, spec);
     builder.build()
 }

--- a/crates/pybevy_macros/src/asset.rs
+++ b/crates/pybevy_macros/src/asset.rs
@@ -604,7 +604,7 @@ pub(crate) fn generate_handle_bridge_tokens(
 
             fn extract(
                 &self,
-                entity: &mut bevy::ecs::world::FilteredEntityMut,
+                entity: &mut pybevy_core::FilteredEntityAccess,
                 component_id: bevy::ecs::component::ComponentId,
                 _validity: pybevy_core::ValidityFlagWithMode,
                 py: pyo3::Python,
@@ -623,7 +623,7 @@ pub(crate) fn generate_handle_bridge_tokens(
             fn extract_fn(&self) -> pybevy_core::ExtractFn {
                 #[inline(always)]
                 fn extract_impl(
-                    entity: &mut bevy::ecs::world::FilteredEntityMut,
+                    entity: &mut pybevy_core::FilteredEntityAccess,
                     component_id: bevy::ecs::component::ComponentId,
                     _validity: pybevy_core::ValidityFlagWithMode,
                     py: pyo3::Python,

--- a/crates/pybevy_macros/src/component.rs
+++ b/crates/pybevy_macros/src/component.rs
@@ -664,18 +664,25 @@ fn generate_bridge_tokens(
             #[inline(always)]
             fn extract(
                 &self,
-                entity: &mut bevy::ecs::world::FilteredEntityMut,
+                entity: &mut pybevy_core::FilteredEntityAccess,
                 component_id: bevy::ecs::component::ComponentId,
                 validity: pybevy_core::ValidityFlagWithMode,
                 py: pyo3::Python,
             ) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>> {
-                let mut untyped = entity.get_mut_by_id(component_id).ok_or_else(|| {
-                    pyo3::exceptions::PyRuntimeError::new_err(concat!(#component_name, " not found"))
-                })?;
-
-                // SAFETY: component_id was registered for #bevy_type, so the untyped pointer points to a valid instance.
-                let ptr = unsafe {
-                    untyped.as_mut().deref_mut::<#bevy_type>() as *mut #bevy_type
+                let ptr = if validity.access_mode() == pybevy_core::AccessMode::Write {
+                    let mut untyped = entity.get_mut_by_id(component_id).ok_or_else(|| {
+                        pyo3::exceptions::PyRuntimeError::new_err(concat!(#component_name, " not found"))
+                    })?;
+                    // SAFETY: component_id was registered for #bevy_type; MutUntyped guarantees valid mutable access.
+                    unsafe { untyped.as_mut().deref_mut::<#bevy_type>() as *mut #bevy_type }
+                } else {
+                    let untyped = entity.get_by_id(component_id).ok_or_else(|| {
+                        pyo3::exceptions::PyRuntimeError::new_err(concat!(#component_name, " not found"))
+                    })?;
+                    // TODO(pybevy/pybevy#90): use a read-only ComponentStorage variant to avoid *const -> *mut cast
+                    // SAFETY: component_id was registered for #bevy_type; pointer is not written through
+                    // because AccessMode::Read prevents mutation at the Python boundary.
+                    unsafe { untyped.deref::<#bevy_type>() as *const #bevy_type as *mut #bevy_type }
                 };
 
                 // SAFETY: ptr is from a valid Bevy entity borrow; validity flag invalidates storage when borrow expires.
@@ -692,18 +699,25 @@ fn generate_bridge_tokens(
             fn extract_fn(&self) -> pybevy_core::ExtractFn {
                 #[inline(always)]
                 fn extract_impl(
-                    entity: &mut bevy::ecs::world::FilteredEntityMut,
+                    entity: &mut pybevy_core::FilteredEntityAccess,
                     component_id: bevy::ecs::component::ComponentId,
                     validity: pybevy_core::ValidityFlagWithMode,
                     py: pyo3::Python,
                 ) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>> {
-                    let mut untyped = entity.get_mut_by_id(component_id).ok_or_else(|| {
-                        pyo3::exceptions::PyRuntimeError::new_err("Component not found")
-                    })?;
-
-                    // SAFETY: component_id was registered for #bevy_type, so the untyped pointer points to a valid instance.
-                    let ptr = unsafe {
-                        untyped.as_mut().deref_mut::<#bevy_type>() as *mut #bevy_type
+                    let ptr = if validity.access_mode() == pybevy_core::AccessMode::Write {
+                        let mut untyped = entity.get_mut_by_id(component_id).ok_or_else(|| {
+                            pyo3::exceptions::PyRuntimeError::new_err("Component not found")
+                        })?;
+                        // SAFETY: component_id was registered for this type; MutUntyped guarantees valid mutable access.
+                        unsafe { untyped.as_mut().deref_mut::<#bevy_type>() as *mut #bevy_type }
+                    } else {
+                        let untyped = entity.get_by_id(component_id).ok_or_else(|| {
+                            pyo3::exceptions::PyRuntimeError::new_err("Component not found")
+                        })?;
+                        // TODO(pybevy/pybevy#90): use a read-only ComponentStorage variant to avoid *const -> *mut cast
+                        // SAFETY: component_id was registered for this type; pointer is not written through
+                        // because AccessMode::Read prevents mutation at the Python boundary.
+                        unsafe { untyped.deref::<#bevy_type>() as *const #bevy_type as *mut #bevy_type }
                     };
 
                     // SAFETY: ptr is from a valid Bevy entity borrow; validity flag invalidates storage when borrow expires.
@@ -728,6 +742,7 @@ fn generate_bridge_tokens(
                 py: pyo3::Python,
             ) -> pyo3::PyResult<Option<pyo3::Py<pyo3::PyAny>>> {
                 if let Some(component) = entity.get::<#bevy_type>() {
+                    // TODO(pybevy/pybevy#90): use a read-only ComponentStorage variant to avoid *const -> *mut cast
                     let ptr = component as *const #bevy_type as *mut #bevy_type;
                     // SAFETY: ptr is from a valid entity.get() borrow; validity flag invalidates storage when borrow expires.
                     let storage = unsafe {

--- a/crates/pybevy_macros/src/derive.rs
+++ b/crates/pybevy_macros/src/derive.rs
@@ -212,18 +212,24 @@ pub fn derive_py_component(input: TokenStream) -> TokenStream {
 
             fn extract(
                 &self,
-                entity: &mut bevy::ecs::world::FilteredEntityMut,
+                entity: &mut #core_path::FilteredEntityAccess,
                 component_id: bevy::ecs::component::ComponentId,
                 validity: #core_path::ValidityFlagWithMode,
                 py: #pyo3_path::Python,
             ) -> #pyo3_path::PyResult<#pyo3_path::Py<#pyo3_path::PyAny>> {
-                let mut untyped = entity.get_mut_by_id(component_id).ok_or_else(|| {
-                    #pyo3_path::exceptions::PyRuntimeError::new_err(concat!(#bevy_type_str, " not found"))
-                })?;
-
-                // SAFETY: component_id was registered for #bevy_type, so the untyped pointer points to a valid instance.
-                let ptr = unsafe {
-                    untyped.as_mut().deref_mut::<#bevy_type>() as *mut #bevy_type
+                let ptr = if validity.access_mode() == #core_path::AccessMode::Write {
+                    let mut untyped = entity.get_mut_by_id(component_id).ok_or_else(|| {
+                        #pyo3_path::exceptions::PyRuntimeError::new_err(concat!(#bevy_type_str, " not found"))
+                    })?;
+                    unsafe { untyped.as_mut().deref_mut::<#bevy_type>() as *mut #bevy_type }
+                } else {
+                    let untyped = entity.get_by_id(component_id).ok_or_else(|| {
+                        #pyo3_path::exceptions::PyRuntimeError::new_err(concat!(#bevy_type_str, " not found"))
+                    })?;
+                    // TODO(pybevy/pybevy#90): use a read-only ComponentStorage variant to avoid *const -> *mut cast
+                    // SAFETY: component_id was registered for #bevy_type; pointer is not written through
+                    // because AccessMode::Read prevents mutation at the Python boundary.
+                    unsafe { untyped.deref::<#bevy_type>() as *const #bevy_type as *mut #bevy_type }
                 };
 
                 // SAFETY: ptr is from a valid Bevy entity borrow; validity flag invalidates storage when borrow expires.
@@ -265,18 +271,25 @@ pub fn derive_py_component(input: TokenStream) -> TokenStream {
             fn extract_fn(&self) -> #core_path::ExtractFn {
                 #[inline(always)]
                 fn extract_impl(
-                    entity: &mut bevy::ecs::world::FilteredEntityMut,
+                    entity: &mut #core_path::FilteredEntityAccess,
                     component_id: bevy::ecs::component::ComponentId,
                     validity: #core_path::ValidityFlagWithMode,
                     py: #pyo3_path::Python,
                 ) -> #pyo3_path::PyResult<#pyo3_path::Py<#pyo3_path::PyAny>> {
-                    let mut untyped = entity.get_mut_by_id(component_id).ok_or_else(|| {
-                        #pyo3_path::exceptions::PyRuntimeError::new_err("Component not found")
-                    })?;
-
-                    // SAFETY: component_id was registered for #bevy_type, so the untyped pointer points to a valid instance.
-                    let ptr = unsafe {
-                        untyped.as_mut().deref_mut::<#bevy_type>() as *mut #bevy_type
+                    let ptr = if validity.access_mode() == #core_path::AccessMode::Write {
+                        let mut untyped = entity.get_mut_by_id(component_id).ok_or_else(|| {
+                            #pyo3_path::exceptions::PyRuntimeError::new_err("Component not found")
+                        })?;
+                        // SAFETY: component_id was registered for this type; MutUntyped guarantees valid mutable access.
+                        unsafe { untyped.as_mut().deref_mut::<#bevy_type>() as *mut #bevy_type }
+                    } else {
+                        let untyped = entity.get_by_id(component_id).ok_or_else(|| {
+                            #pyo3_path::exceptions::PyRuntimeError::new_err("Component not found")
+                        })?;
+                        // TODO(pybevy/pybevy#90): use a read-only ComponentStorage variant to avoid *const -> *mut cast
+                        // SAFETY: component_id was registered for this type; pointer is not written through
+                        // because AccessMode::Read prevents mutation at the Python boundary.
+                        unsafe { untyped.deref::<#bevy_type>() as *const #bevy_type as *mut #bevy_type }
                     };
 
                     // SAFETY: ptr is from a valid Bevy entity borrow; validity flag invalidates storage when borrow expires.
@@ -301,6 +314,7 @@ pub fn derive_py_component(input: TokenStream) -> TokenStream {
                 py: #pyo3_path::Python,
             ) -> #pyo3_path::PyResult<Option<#pyo3_path::Py<#pyo3_path::PyAny>>> {
                 if let Some(component) = entity.get::<#bevy_type>() {
+                    // TODO(pybevy/pybevy#90): use a read-only ComponentStorage variant to avoid *const -> *mut cast
                     let ptr = component as *const #bevy_type as *mut #bevy_type;
                     // SAFETY: ptr is from a valid entity.get() borrow; validity flag invalidates storage when borrow expires.
                     let storage = unsafe {

--- a/crates/pybevy_macros/src/newtype.rs
+++ b/crates/pybevy_macros/src/newtype.rs
@@ -187,7 +187,7 @@ pub(crate) fn generate_newtype_bridge_tokens(
             #[inline(always)]
             fn extract(
                 &self,
-                entity: &mut bevy::ecs::world::FilteredEntityMut,
+                entity: &mut pybevy_core::FilteredEntityAccess,
                 component_id: bevy::ecs::component::ComponentId,
                 _validity: pybevy_core::ValidityFlagWithMode,
                 py: pyo3::Python,
@@ -234,7 +234,7 @@ pub(crate) fn generate_newtype_bridge_tokens(
             fn extract_fn(&self) -> pybevy_core::ExtractFn {
                 #[inline(always)]
                 fn extract_impl(
-                    entity: &mut bevy::ecs::world::FilteredEntityMut,
+                    entity: &mut pybevy_core::FilteredEntityAccess,
                     component_id: bevy::ecs::component::ComponentId,
                     _validity: pybevy_core::ValidityFlagWithMode,
                     py: pyo3::Python,

--- a/crates/pybevy_macros/src/resource.rs
+++ b/crates/pybevy_macros/src/resource.rs
@@ -358,6 +358,7 @@ pub(crate) fn generate_resource_bridge_tokens(
                     pyo3::exceptions::PyRuntimeError::new_err(concat!(#resource_name, " resource not found"))
                 })?;
 
+                // TODO(pybevy/pybevy#90): use a read-only ResourceStorage variant to avoid *const -> *mut cast
                 let ptr = resource as *const #bevy_type as *mut #bevy_type;
                 // Override to read mode even though caller requested write
                 let read_validity = validity.flag.with_access_mode(pybevy_core::AccessMode::Read);
@@ -442,6 +443,7 @@ pub(crate) fn generate_resource_bridge_tokens(
                     pyo3::exceptions::PyRuntimeError::new_err(concat!(#resource_name, " resource not found"))
                 })?;
 
+                // TODO(pybevy/pybevy#90): use a read-only ResourceStorage variant to avoid *const -> *mut cast
                 let ptr = resource as *const #bevy_type as *mut #bevy_type;
                 // SAFETY: ptr is from a valid Bevy resource borrow; validity flag invalidates storage when borrow expires.
                 let storage = unsafe {

--- a/crates/pybevy_macros/src/unit.rs
+++ b/crates/pybevy_macros/src/unit.rs
@@ -45,7 +45,7 @@ pub(crate) fn generate_unit_bridge_tokens(
             #[inline(always)]
             fn extract(
                 &self,
-                entity: &mut bevy::ecs::world::FilteredEntityMut,
+                entity: &mut pybevy_core::FilteredEntityAccess,
                 component_id: bevy::ecs::component::ComponentId,
                 _validity: pybevy_core::ValidityFlagWithMode,
                 py: pyo3::Python,
@@ -95,7 +95,7 @@ pub(crate) fn generate_unit_bridge_tokens(
             fn extract_fn(&self) -> pybevy_core::ExtractFn {
                 #[inline(always)]
                 fn extract_impl(
-                    entity: &mut bevy::ecs::world::FilteredEntityMut,
+                    entity: &mut pybevy_core::FilteredEntityAccess,
                     component_id: bevy::ecs::component::ComponentId,
                     _validity: pybevy_core::ValidityFlagWithMode,
                     py: pyo3::Python,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,4 +170,4 @@ markers = [
 source = ["pybevy"]
 
 [tool.coverage.report]
-fail_under = 0
+fail_under = 90

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,4 +170,4 @@ markers = [
 source = ["pybevy"]
 
 [tool.coverage.report]
-fail_under = 90
+fail_under = 0

--- a/src/ecs/component_type.rs
+++ b/src/ecs/component_type.rs
@@ -193,7 +193,7 @@ impl PyComponentType {
     /// For custom components: Delegates to QueryRuntime helper (handles wrapper/PyObject storage).
     pub fn extract_from_entity<'py>(
         &self,
-        entity_mut: &mut bevy::ecs::world::FilteredEntityMut,
+        entity: &mut pybevy_core::FilteredEntityAccess,
         component_id: bevy::ecs::component::ComponentId,
         validity: crate::ecs::helpers::validity_guard::ValidityFlagWithMode,
         py: pyo3::Python<'py>,
@@ -204,11 +204,11 @@ impl PyComponentType {
             PyComponentType::Dynamic(type_ptr) => {
                 // Use pre-cached extraction function pointer indexed by param position
                 if let Some(extract_fn) = query_iter.get_extract_fn(param_idx) {
-                    extract_fn(entity_mut, component_id, validity, py)
+                    extract_fn(entity, component_id, validity, py)
                 } else {
                     // Fallback to global registry
                     if let Some(bridge) = global_registry::get_bridge_by_py_type(*type_ptr) {
-                        bridge.extract(entity_mut, component_id, validity, py)
+                        bridge.extract(entity, component_id, validity, py)
                     } else {
                         Err(pyo3::exceptions::PyRuntimeError::new_err(
                             "Dynamic component bridge not found",
@@ -217,7 +217,7 @@ impl PyComponentType {
                 }
             }
             PyComponentType::Custom(ptr) => {
-                query_iter.extract_custom_component(*ptr, entity_mut, component_id, param_idx, py)
+                query_iter.extract_custom_component(*ptr, entity, component_id, param_idx, py)
             }
         }
     }

--- a/src/ecs/query/query_runtime.rs
+++ b/src/ecs/query/query_runtime.rs
@@ -4,12 +4,14 @@ use bevy::{
     ecs::{
         component::ComponentId,
         query::{QueryIter, QueryState},
-        world::FilteredEntityMut,
+        world::{FilteredEntityMut, FilteredEntityRef},
     },
     prelude::*,
 };
-use pybevy_core::{ExtractFn, registry::global_registry};
-use pybevy_ecs::shared::query_builder_ext::{QueryBuildSpec, build_query_state};
+use pybevy_core::{ExtractFn, FilteredEntityAccess, registry::global_registry};
+use pybevy_ecs::shared::query_builder_ext::{
+    QueryBuildSpec, QueryComponent, build_query_state, build_query_state_ref,
+};
 use pyo3::{
     exceptions::{PyRuntimeError, PyStopIteration},
     ffi::PyTypeObject,
@@ -27,6 +29,186 @@ use crate::ecs::{
     lazy_wrapper_proxy::PyLazyWrapperProxy,
     query::query_param::{PyQueryParam, QueryData},
 };
+
+/// Type-erased Bevy QueryState. Owns a heap-allocated QueryState behind a raw pointer.
+///
+/// SAFETY: The caller must guarantee the erased lifetimes (tied to system execution scope).
+/// Drop reconstructs the correct Box type to deallocate.
+///
+/// Methods that produce borrows (`create_iter`, `get_entity`) are intentionally designed
+/// to not borrow `self`, so that PyQueryIter can call them without conflicting with
+/// borrows of other fields (e.g. `extract_components_from_entity`).
+enum ErasedQueryState {
+    /// `QueryState<FilteredEntityRef>` - all components read-only.
+    ReadOnly(*mut ()),
+    /// `QueryState<FilteredEntityMut>` - at least one `Mut[T]` component.
+    Mutable(*mut ()),
+}
+
+impl ErasedQueryState {
+    fn from_ref(qs: QueryState<FilteredEntityRef>) -> Self {
+        Self::ReadOnly(Box::into_raw(Box::new(qs)) as *mut ())
+    }
+
+    fn from_mut(qs: QueryState<FilteredEntityMut>) -> Self {
+        Self::Mutable(Box::into_raw(Box::new(qs)) as *mut ())
+    }
+
+    /// Returns (is_read_only, raw_pointer) for use in methods that need to avoid
+    /// borrowing self (to prevent conflicts with other field borrows on PyQueryIter).
+    fn parts(&self) -> (bool, *mut ()) {
+        match self {
+            Self::ReadOnly(p) => (true, *p),
+            Self::Mutable(p) => (false, *p),
+        }
+    }
+
+    /// Count matching entities (O(n) - iterates all).
+    fn count(&self, world: &World) -> usize {
+        let (read_only, p) = self.parts();
+        unsafe {
+            if read_only {
+                (&*(p as *const QueryState<FilteredEntityRef>))
+                    .iter_manual(world)
+                    .count()
+            } else {
+                (&*(p as *const QueryState<FilteredEntityMut>))
+                    .iter_manual(world)
+                    .count()
+            }
+        }
+    }
+
+    /// Check if no entities match.
+    fn is_empty_check(
+        &self,
+        world: &World,
+        last_tick: bevy::ecs::change_detection::Tick,
+        current_tick: bevy::ecs::change_detection::Tick,
+    ) -> bool {
+        let (read_only, p) = self.parts();
+        unsafe {
+            if read_only {
+                (&*(p as *const QueryState<FilteredEntityRef>))
+                    .is_empty(world, last_tick, current_tick)
+            } else {
+                (&*(p as *const QueryState<FilteredEntityMut>))
+                    .is_empty(world, last_tick, current_tick)
+            }
+        }
+    }
+}
+
+/// Create a new lazy iterator. Freestanding to avoid borrowing ErasedQueryState.
+///
+/// SAFETY: `qs_ptr` must point to a valid QueryState of the type indicated by `read_only`.
+/// `world_ptr` must point to a valid World for the duration of iteration.
+unsafe fn erased_create_iter(
+    read_only: bool,
+    qs_ptr: *mut (),
+    mut world_ptr: NonNull<World>,
+) -> ErasedQueryIter {
+    if read_only {
+        let qs = unsafe { &mut *(qs_ptr as *mut QueryState<FilteredEntityRef>) };
+        let iter = qs.iter(unsafe { world_ptr.as_ref() });
+        ErasedQueryIter::ReadOnly(Box::into_raw(Box::new(iter)) as *mut ())
+    } else {
+        let qs = unsafe { &mut *(qs_ptr as *mut QueryState<FilteredEntityMut>) };
+        let iter = qs.iter_mut(unsafe { world_ptr.as_mut() });
+        ErasedQueryIter::Mutable(Box::into_raw(Box::new(iter)) as *mut ())
+    }
+}
+
+/// Look up a single entity by ID. Freestanding to avoid borrowing ErasedQueryState.
+///
+/// SAFETY: `qs_ptr` must point to a valid QueryState of the type indicated by `read_only`.
+/// `world_ptr` must point to a valid World.
+unsafe fn erased_get_entity<'a>(
+    read_only: bool,
+    qs_ptr: *mut (),
+    mut world_ptr: NonNull<World>,
+    entity: Entity,
+) -> Option<FilteredEntityAccess<'a, 'a>> {
+    if read_only {
+        let qs = unsafe { &mut *(qs_ptr as *mut QueryState<FilteredEntityRef>) };
+        qs.get(unsafe { world_ptr.as_ref() }, entity)
+            .ok()
+            .map(FilteredEntityAccess::Ref)
+    } else {
+        let qs = unsafe { &mut *(qs_ptr as *mut QueryState<FilteredEntityMut>) };
+        qs.get_mut(unsafe { world_ptr.as_mut() }, entity)
+            .ok()
+            .map(FilteredEntityAccess::Mut)
+    }
+}
+
+impl Drop for ErasedQueryState {
+    fn drop(&mut self) {
+        let p = match self {
+            Self::ReadOnly(p) | Self::Mutable(p) => *p,
+        };
+        if p.is_null() {
+            return;
+        }
+        unsafe {
+            match self {
+                Self::ReadOnly(_) => {
+                    let _ = Box::from_raw(p as *mut QueryState<FilteredEntityRef>);
+                }
+                Self::Mutable(_) => {
+                    let _ = Box::from_raw(p as *mut QueryState<FilteredEntityMut>);
+                }
+            }
+        }
+    }
+}
+
+/// Type-erased Bevy QueryIter. Owns a heap-allocated iterator behind a raw pointer.
+///
+/// SAFETY: The erased lifetimes are tied to the system execution scope.
+enum ErasedQueryIter {
+    ReadOnly(*mut ()),
+    Mutable(*mut ()),
+}
+
+impl ErasedQueryIter {
+    /// Advance the iterator, returning the next entity wrapped in `FilteredEntityAccess`.
+    fn next(&mut self) -> Option<FilteredEntityAccess<'_, '_>> {
+        unsafe {
+            match self {
+                Self::ReadOnly(p) => {
+                    let iter = &mut *(*p as *mut QueryIter<FilteredEntityRef, ()>);
+                    iter.next().map(FilteredEntityAccess::Ref)
+                }
+                Self::Mutable(p) => {
+                    let iter = &mut *(*p as *mut QueryIter<FilteredEntityMut, ()>);
+                    iter.next().map(FilteredEntityAccess::Mut)
+                }
+            }
+        }
+    }
+}
+
+impl Drop for ErasedQueryIter {
+    fn drop(&mut self) {
+        let p = match self {
+            Self::ReadOnly(p) | Self::Mutable(p) => *p,
+        };
+        if p.is_null() {
+            return;
+        }
+        unsafe {
+            match self {
+                Self::ReadOnly(_) => {
+                    let _ = Box::from_raw(p as *mut QueryIter<FilteredEntityRef, ()>);
+                }
+                Self::Mutable(_) => {
+                    let _ = Box::from_raw(p as *mut QueryIter<FilteredEntityMut, ()>);
+                }
+            }
+        }
+    }
+}
 
 /// Runtime query iterator that can be passed to Python systems.
 /// Uses Bevy's QueryState for efficient cached iteration.
@@ -48,16 +230,11 @@ pub struct PyQueryIter {
     /// The query parameter information (shared via Arc to avoid clones)
     param: Arc<PyQueryParam>,
 
-    /// The Bevy QueryState with lifetime erased via transmute
-    /// SAFETY: This is created from a QueryState<FilteredEntityMut<'w, 's>> in new()
-    /// The actual type is QueryState<FilteredEntityMut<'static, 'static>> due to transmute
-    /// but the real lifetimes are tied to the system execution and guaranteed by caller
-    query_state_ptr: *mut (),
+    /// The Bevy QueryState (type-erased, owns the heap allocation).
+    query_state: ErasedQueryState,
 
-    /// Current iterator state (also lifetime-erased)
-    /// Stores the actual Bevy QueryIter - we call .next() on it incrementally
-    /// Type is QueryIter<'w, 's, FilteredEntityMut, ()> with lifetime erased
-    iterator_ptr: Option<*mut ()>,
+    /// Current lazy iterator state (created on first `__next__` call).
+    query_iter: Option<ErasedQueryIter>,
 
     /// Raw pointer to the World (only valid during system execution)
     /// SAFETY: This pointer is only valid within the scope of the system execution
@@ -105,27 +282,6 @@ pub struct PyQueryIter {
     >,
 }
 
-impl Drop for PyQueryIter {
-    fn drop(&mut self) {
-        // Clean up the QueryState
-        if !self.query_state_ptr.is_null() {
-            unsafe {
-                // SAFETY: We created this from a valid QueryState in new()
-                let _ = Box::from_raw(self.query_state_ptr as *mut QueryState<FilteredEntityMut>);
-            }
-        }
-        // Clean up the iterator if it exists
-        if let Some(iter_ptr) = self.iterator_ptr
-            && !iter_ptr.is_null()
-        {
-            unsafe {
-                // SAFETY: We created this from a valid QueryIter
-                let _ = Box::from_raw(iter_ptr as *mut QueryIter<FilteredEntityMut, ()>);
-            }
-        }
-    }
-}
-
 // SAFETY: PyQueryIter is only used during system execution on a single thread.
 // The world pointer and query state are only accessed during system execution and never across threads.
 // Arc<PyQueryParam> and Arc<HashMap> are already Send/Sync.
@@ -142,17 +298,18 @@ impl PyQueryIter {
         custom_component_ids: Arc<HashMap<*const PyTypeObject, ComponentId>>,
         validity: ValidityFlag,
     ) -> Self {
-        // First, collect and register all component IDs (tracking optional status)
+        // First, collect and register all component IDs (tracking optional and mutable status)
         let mut component_ids = Vec::new();
         for param_type in &param.data {
             if let QueryData::Component {
                 ty: comp_type,
                 optional,
+                mutable,
                 ..
             } = param_type
             {
                 let id = register_component_id(world, comp_type, &custom_component_ids);
-                component_ids.push((id, *optional));
+                component_ids.push(QueryComponent { id, optional: *optional, mutable: *mutable });
             }
         }
 
@@ -215,12 +372,15 @@ impl PyQueryIter {
             added_filters: added_filter_ids,
             anyof_filters: anyof_filter_ids,
         };
-        let query_state = build_query_state(world, &spec);
-
-        // SAFETY: Transmute to erase lifetime - the caller guarantees this is only used
-        // within the system execution scope where the World reference is valid
-        let query_state_boxed = Box::new(query_state);
-        let query_state_ptr = Box::into_raw(query_state_boxed) as *mut ();
+        // Build the correct QueryState variant.
+        // SAFETY: Lifetime is erased — the caller guarantees this is only used
+        // within the system execution scope where the World reference is valid.
+        // Use FilteredEntityRef for all-read-only queries to enable parallel scheduling.
+        let query_state = if spec.is_read_only() {
+            ErasedQueryState::from_ref(build_query_state_ref(world, &spec))
+        } else {
+            ErasedQueryState::from_mut(build_query_state(world, &spec))
+        };
 
         // Build component ID cache by mapping TypeId back to PyComponentType
         let mut component_id_cache = HashMap::new();
@@ -228,7 +388,7 @@ impl PyQueryIter {
         for param_type in param.data.iter() {
             if let QueryData::Component { ty, .. } = param_type {
                 // Get the corresponding ComponentId from the component_ids vec
-                if let Some(&(comp_id, _optional)) = component_ids.get(component_idx) {
+                if let Some(&QueryComponent { id: comp_id, .. }) = component_ids.get(component_idx) {
                     // For built-in components, verify by TypeId
                     let type_id = ty.type_id();
 
@@ -293,8 +453,8 @@ impl PyQueryIter {
 
         Self {
             param,
-            query_state_ptr,
-            iterator_ptr: None,
+            query_state,
+            query_iter: None,
             world_ptr: Some(NonNull::from(world)),
             component_id_cache,
             custom_component_ids,
@@ -326,7 +486,7 @@ impl PyQueryIter {
     pub(crate) fn extract_custom_component(
         &self,
         type_ptr: *const PyTypeObject,
-        entity_mut: &mut FilteredEntityMut,
+        entity: &mut FilteredEntityAccess,
         component_id: ComponentId,
         param_idx: usize,
         py: Python,
@@ -369,7 +529,7 @@ impl PyQueryIter {
         match storage_type {
             ComponentStorageType::Wrapper(wrapper_size) => {
                 let data_ptr: *mut u8 = {
-                    let untyped = entity_mut
+                    let untyped = entity
                         .get_by_id(component_id)
                         .expect("Custom component should exist on matched entity");
                     unsafe { wrapper_size.get_ref_ptr_as_mut(untyped) }
@@ -378,7 +538,7 @@ impl PyQueryIter {
                 let layout = cached_layout.expect("Wrapper storage must have layout");
 
                 // Create lazy wrapper proxy
-                let entity = entity_mut.id();
+                let entity_id = entity.id();
                 let access_mode = self.param_access_modes[param_idx];
                 let validity = self.validity.with_access_mode(access_mode);
                 let mutable = access_mode == AccessMode::Write;
@@ -394,7 +554,7 @@ impl PyQueryIter {
                         validity,
                         mutable, // true for Mut[T], false for read-only
                         component_id,
-                        entity,
+                        entity_id,
                         world_ptr,
                     )
                 };
@@ -406,13 +566,13 @@ impl PyQueryIter {
                 // PyObject storage - return borrowed reference to ECS-stored Python object
                 use crate::ecs::custom_component::PyCustomComponent;
 
-                let entity = entity_mut.id();
+                let entity_id = entity.id();
 
                 // Get pointer to the PyAny in ECS storage
                 // SAFETY: We know this is a Py<PyAny> because that's how we registered it
                 // NOTE: We use get_by_id() for both mutable and immutable access.
                 // Change detection is handled by __setattr__ hook + stored entity context.
-                let untyped_ptr = entity_mut
+                let untyped_ptr = entity
                     .get_by_id(component_id)
                     .expect("Custom component should exist on matched entity")
                     .as_ptr();
@@ -434,7 +594,7 @@ impl PyQueryIter {
                     py_obj_ptr,
                     validity,
                     component_id,
-                    entity,
+                    entity_id,
                     world_ptr,
                 );
 
@@ -451,7 +611,7 @@ impl PyQueryIter {
     /// __next__(), single(), and get() methods.
     fn extract_components_from_entity(
         &mut self,
-        entity_mut: &mut FilteredEntityMut,
+        entity: &mut FilteredEntityAccess,
         py: Python,
     ) -> PyResult<()> {
         self.values_buffer.clear();
@@ -459,7 +619,7 @@ impl PyQueryIter {
         for (param_idx, param_type) in self.param.data.iter().enumerate() {
             match param_type {
                 QueryData::Entity => {
-                    let py_entity = PyEntity(entity_mut.id());
+                    let py_entity = PyEntity(entity.id());
                     let obj = Py::new(py, py_entity).expect("Failed to create PyEntity");
                     self.values_buffer.push(obj.into_any());
                 }
@@ -481,7 +641,7 @@ impl PyQueryIter {
                     };
 
                     // For optional components, check if entity has the component
-                    if *optional && entity_mut.get_by_id(component_id).is_none() {
+                    if *optional && entity.get_by_id(component_id).is_none() {
                         self.values_buffer.push(py.None());
                         continue;
                     }
@@ -492,7 +652,7 @@ impl PyQueryIter {
 
                     // Use macro-generated dispatch method (handles all component types)
                     let obj = ty.extract_from_entity(
-                        entity_mut,
+                        entity,
                         component_id,
                         validity,
                         py,
@@ -525,14 +685,8 @@ impl PyQueryIter {
                 ));
             }
 
-            // Reset iterator for sequential re-iteration
-            if let Some(iter_ptr) = borrowed.iterator_ptr.take()
-                && !iter_ptr.is_null()
-            {
-                unsafe {
-                    let _ = Box::from_raw(iter_ptr as *mut QueryIter<FilteredEntityMut, ()>);
-                }
-            }
+            // Reset iterator for sequential re-iteration (Drop handles cleanup)
+            borrowed.query_iter.take();
         }
         Ok(slf)
     }
@@ -546,35 +700,24 @@ impl PyQueryIter {
         self.iterating = true;
 
         // Create iterator on first call
-        if self.iterator_ptr.is_none() {
-            // SAFETY: world_ptr is guaranteed to be valid during system execution
-            let world = unsafe {
-                self.world_ptr
-                    .expect("Query used outside system execution")
-                    .as_mut()
-            };
-
-            // SAFETY: We transmuted this pointer from a valid QueryState in new()
-            // and the lifetime is tied to the system execution
-            let query_state =
-                unsafe { &mut *(self.query_state_ptr as *mut QueryState<FilteredEntityMut>) };
-
-            // Create the iterator - NO pre-collection, truly lazy
-            let iter = query_state.iter_mut(world);
-            let boxed = Box::new(iter);
-            self.iterator_ptr = Some(Box::into_raw(boxed) as *mut ());
+        if self.query_iter.is_none() {
+            let world_ptr = self.world_ptr.expect("Query used outside system execution");
+            let (read_only, qs_ptr) = self.query_state.parts();
+            // SAFETY: world_ptr and qs_ptr are valid during system execution
+            self.query_iter =
+                Some(unsafe { erased_create_iter(read_only, qs_ptr, world_ptr) });
         }
 
-        // SAFETY: We created this as QueryIter in the block above
-        let iter =
-            unsafe { &mut *(self.iterator_ptr.unwrap() as *mut QueryIter<FilteredEntityMut, ()>) };
+        // Advance iterator — get raw pointer to avoid borrow conflict with self
+        let iter_ref = self.query_iter.as_mut().unwrap() as *mut ErasedQueryIter;
+        // SAFETY: iter_ref is valid; we don't access self.query_iter again until
+        // entity_access is dropped (after extract_components_from_entity).
+        let next_entity = unsafe { (*iter_ref).next() };
 
-        // Call .next() on the Bevy iterator - truly incremental
-        if let Some(mut entity_mut) = iter.next() {
-            let entity = entity_mut.id();
+        if let Some(mut entity_access) = next_entity {
+            let entity = entity_access.id();
 
             // Set entity context for lazy change tracking
-            // SAFETY: world_ptr is valid during query iteration
             let world_ptr = self
                 .world_ptr
                 .expect("Query used outside system execution")
@@ -582,7 +725,7 @@ impl PyQueryIter {
             pybevy_ecs::shared::change_tracking::set_entity_context(entity, world_ptr);
 
             // Extract components using the shared helper
-            self.extract_components_from_entity(&mut entity_mut, py)?;
+            self.extract_components_from_entity(&mut entity_access, py)?;
 
             // Return single value or tuple based on whether query was Query[T] or Query[tuple[...]]
             if self.param.single {
@@ -599,120 +742,115 @@ impl PyQueryIter {
         }
     }
 
-    /// Returns the number of entities matching the query
-    /// Note: Since we use a lazy iterator, this requires iterating through
-    /// all remaining entities to count them, which consumes the iterator.
-    /// It's better to avoid calling len() if possible.
+    /// Returns the number of entities matching the query.
+    ///
+    /// **Warning: O(n)** - this iterates all matching entities to count them.
+    /// Python users calling `len(query)` may expect O(1) but Bevy's
+    /// `QueryState` does not cache entity counts.
     fn __len__(&self) -> usize {
         let world = match self.world_ptr {
             Some(ptr) => unsafe { ptr.as_ref() },
             None => return 0,
         };
-        if self.query_state_ptr.is_null() {
-            return 0;
-        }
-        let query_state =
-            unsafe { &*(self.query_state_ptr as *const QueryState<FilteredEntityMut>) };
-        // SAFETY: We only need a read-only count; iter_manual requires &World
-        query_state.iter_manual(world).count()
+        self.query_state.count(world)
     }
 
     /// Get exactly one entity from the query.
     /// Returns an error if there are 0 or 2+ entities matching the query.
     fn single(&mut self, py: Python) -> PyResult<Py<PyAny>> {
-        // SAFETY: world_ptr is guaranteed to be valid during system execution
-        let world = unsafe {
-            self.world_ptr
-                .expect("Query used outside system execution")
-                .as_mut()
-        };
+        let mut world_ptr = self.world_ptr.expect("Query used outside system execution");
+        let (read_only, qs_ptr) = self.query_state.parts();
 
-        // SAFETY: We transmuted this pointer from a valid QueryState in new()
-        let query_state =
-            unsafe { &mut *(self.query_state_ptr as *mut QueryState<FilteredEntityMut>) };
-
-        // Collect all matching entities
-        let mut iter = query_state.iter_mut(world);
-
-        let first = iter.next();
-        let second = iter.next();
-
-        match (first, second) {
-            (None, _) => Err(PyRuntimeError::new_err(
-                "Query returned no entities. Expected exactly one.",
-            )),
-            (Some(_), Some(_)) => Err(PyRuntimeError::new_err(
-                "Query returned multiple entities. Expected exactly one.",
-            )),
-            (Some(mut entity_mut), None) => {
-                // Exactly one entity - extract components
-                let entity = entity_mut.id();
-
-                // Set entity context for lazy change tracking
-                // SAFETY: world_ptr is valid during query iteration
-                let world_ptr = self
-                    .world_ptr
-                    .expect("Query used outside system execution")
-                    .as_ptr();
-                pybevy_ecs::shared::change_tracking::set_entity_context(entity, world_ptr);
-
-                self.values_buffer.clear();
-
-                self.extract_components_from_entity(&mut entity_mut, py)?;
-
-                // Return single value or tuple based on whether query was Query[T] or Query[tuple[...]]
-                if self.param.single {
-                    Ok(self.values_buffer[0].clone_ref(py))
-                } else {
-                    let tuple = PyTuple::new(py, &self.values_buffer)?;
-                    Ok(tuple.into_any().unbind())
+        // Validate exactly one entity exists and get it for extraction.
+        // SAFETY: world_ptr and qs_ptr are valid during system execution.
+        // We use raw pointer casts to avoid holding borrows across extraction.
+        let mut entity_access: FilteredEntityAccess = unsafe {
+            if read_only {
+                let qs = &mut *(qs_ptr as *mut QueryState<FilteredEntityRef>);
+                let mut iter = qs.iter(world_ptr.as_ref());
+                let first = iter.next();
+                let has_second = iter.next().is_some();
+                match (first, has_second) {
+                    (None, _) => {
+                        return Err(PyRuntimeError::new_err(
+                            "Query returned no entities. Expected exactly one.",
+                        ))
+                    }
+                    (Some(_), true) => {
+                        return Err(PyRuntimeError::new_err(
+                            "Query returned multiple entities. Expected exactly one.",
+                        ))
+                    }
+                    (Some(e), false) => FilteredEntityAccess::Ref(e),
+                }
+            } else {
+                let qs = &mut *(qs_ptr as *mut QueryState<FilteredEntityMut>);
+                let mut iter = qs.iter_mut(world_ptr.as_mut());
+                let first = iter.next();
+                let has_second = iter.next().is_some();
+                match (first, has_second) {
+                    (None, _) => {
+                        return Err(PyRuntimeError::new_err(
+                            "Query returned no entities. Expected exactly one.",
+                        ))
+                    }
+                    (Some(_), true) => {
+                        return Err(PyRuntimeError::new_err(
+                            "Query returned multiple entities. Expected exactly one.",
+                        ))
+                    }
+                    (Some(e), false) => FilteredEntityAccess::Mut(e),
                 }
             }
+        };
+
+        let entity = entity_access.id();
+        let world_raw = self
+            .world_ptr
+            .expect("Query used outside system execution")
+            .as_ptr();
+        pybevy_ecs::shared::change_tracking::set_entity_context(entity, world_raw);
+
+        self.extract_components_from_entity(&mut entity_access, py)?;
+
+        if self.param.single {
+            Ok(self.values_buffer[0].clone_ref(py))
+        } else {
+            let tuple = PyTuple::new(py, &self.values_buffer)?;
+            Ok(tuple.into_any().unbind())
         }
     }
 
     /// Check if the query has no matching entities.
     /// Returns true if there are no entities matching the query filters.
     fn is_empty(&self) -> PyResult<bool> {
-        // SAFETY: world_ptr is guaranteed to be valid during system execution
+        // SAFETY: world_ptr is guaranteed to be valid during system execution.
+        // Only shared access needed - last_change_tick/read_change_tick/is_empty all take &World.
         let world = unsafe {
             self.world_ptr
                 .expect("Query used outside system execution")
-                .as_mut()
+                .as_ref()
         };
 
-        // Get the ticks before borrowing world for the query
         let last_tick = world.last_change_tick();
-        let current_tick = world.change_tick();
+        let current_tick = world.read_change_tick();
 
-        // SAFETY: We transmuted this pointer from a valid QueryState in new()
-        let query_state =
-            unsafe { &*(self.query_state_ptr as *const QueryState<FilteredEntityMut>) };
-
-        Ok(query_state.is_empty(world, last_tick, current_tick))
+        Ok(self.query_state.is_empty_check(world, last_tick, current_tick))
     }
 
     /// Get components for a specific entity by ID.
     /// Returns None if the entity doesn't match the query filters.
     /// Returns an error if the entity doesn't have the queried components.
     fn get(&mut self, entity: PyEntity, py: Python) -> PyResult<Option<Py<PyAny>>> {
-        // SAFETY: world_ptr is guaranteed to be valid during system execution
-        let world = unsafe {
-            self.world_ptr
-                .expect("Query used outside system execution")
-                .as_mut()
-        };
+        let world_ptr = self.world_ptr.expect("Query used outside system execution");
+        let (read_only, qs_ptr) = self.query_state.parts();
+        // SAFETY: world_ptr and qs_ptr are valid during system execution
+        let result = unsafe { erased_get_entity(read_only, qs_ptr, world_ptr, entity.0) };
 
-        // SAFETY: We transmuted this pointer from a valid QueryState in new()
-        let query_state =
-            unsafe { &mut *(self.query_state_ptr as *mut QueryState<FilteredEntityMut>) };
+        match result {
+            Some(mut entity_access) => {
+                self.extract_components_from_entity(&mut entity_access, py)?;
 
-        // Try to get the specific entity
-        match query_state.get_mut(world, entity.0) {
-            Ok(mut entity_mut) => {
-                self.extract_components_from_entity(&mut entity_mut, py)?;
-
-                // Return single value or tuple based on whether query was Query[T] or Query[tuple[...]]
                 if self.param.single {
                     Ok(Some(self.values_buffer[0].clone_ref(py)))
                 } else {
@@ -720,10 +858,7 @@ impl PyQueryIter {
                     Ok(Some(tuple.into_any().unbind()))
                 }
             }
-            Err(_) => {
-                // Entity doesn't match query filters
-                Ok(None)
-            }
+            None => Ok(None),
         }
     }
 
@@ -745,44 +880,26 @@ impl PyQueryIter {
     ///     pass
     /// ```
     fn iter_many(&mut self, entities: &Bound<'_, PyAny>, py: Python) -> PyResult<Vec<Py<PyAny>>> {
-        // SAFETY: world_ptr is guaranteed to be valid during system execution
-        let world = unsafe {
-            self.world_ptr
-                .expect("Query used outside system execution")
-                .as_mut()
-        };
-
-        // SAFETY: We transmuted this pointer from a valid QueryState in new()
-        let query_state =
-            unsafe { &mut *(self.query_state_ptr as *mut QueryState<FilteredEntityMut>) };
-
         let mut results = Vec::new();
+        let world_ptr = self.world_ptr.expect("Query used outside system execution");
+        let (read_only, qs_ptr) = self.query_state.parts();
 
-        // Iterate over the provided entities
         for entity_obj in entities.try_iter()? {
-            let entity_obj = entity_obj?;
-            let entity_id: PyEntity = entity_obj.extract()?;
+            let entity_id: PyEntity = entity_obj?.extract()?;
 
-            // Try to get this specific entity
-            match query_state.get_mut(world, entity_id.0) {
-                Ok(mut entity_mut) => {
-                    self.extract_components_from_entity(&mut entity_mut, py)?;
-
-                    // Return single value or tuple based on whether query was Query[T] or Query[tuple[...]]
-                    let result = if self.param.single {
-                        self.values_buffer[0].clone_ref(py)
-                    } else {
-                        let tuple =
-                            PyTuple::new(py, &self.values_buffer).expect("Failed to create tuple");
-                        tuple.into_any().unbind()
-                    };
-
-                    results.push(result);
-                }
-                Err(_) => {
-                    // Entity doesn't match query filters - skip it
-                    continue;
-                }
+            // SAFETY: world_ptr and qs_ptr are valid during system execution
+            if let Some(mut access) =
+                unsafe { erased_get_entity(read_only, qs_ptr, world_ptr, entity_id.0) }
+            {
+                self.extract_components_from_entity(&mut access, py)?;
+                let result = if self.param.single {
+                    self.values_buffer[0].clone_ref(py)
+                } else {
+                    let tuple =
+                        PyTuple::new(py, &self.values_buffer).expect("Failed to create tuple");
+                    tuple.into_any().unbind()
+                };
+                results.push(result);
             }
         }
 

--- a/src/ecs/query/query_runtime.rs
+++ b/src/ecs/query/query_runtime.rs
@@ -89,11 +89,17 @@ impl ErasedQueryState {
         let (read_only, p) = self.parts();
         unsafe {
             if read_only {
-                (&*(p as *const QueryState<FilteredEntityRef>))
-                    .is_empty(world, last_tick, current_tick)
+                (&*(p as *const QueryState<FilteredEntityRef>)).is_empty(
+                    world,
+                    last_tick,
+                    current_tick,
+                )
             } else {
-                (&*(p as *const QueryState<FilteredEntityMut>))
-                    .is_empty(world, last_tick, current_tick)
+                (&*(p as *const QueryState<FilteredEntityMut>)).is_empty(
+                    world,
+                    last_tick,
+                    current_tick,
+                )
             }
         }
     }
@@ -309,7 +315,11 @@ impl PyQueryIter {
             } = param_type
             {
                 let id = register_component_id(world, comp_type, &custom_component_ids);
-                component_ids.push(QueryComponent { id, optional: *optional, mutable: *mutable });
+                component_ids.push(QueryComponent {
+                    id,
+                    optional: *optional,
+                    mutable: *mutable,
+                });
             }
         }
 
@@ -388,7 +398,8 @@ impl PyQueryIter {
         for param_type in param.data.iter() {
             if let QueryData::Component { ty, .. } = param_type {
                 // Get the corresponding ComponentId from the component_ids vec
-                if let Some(&QueryComponent { id: comp_id, .. }) = component_ids.get(component_idx) {
+                if let Some(&QueryComponent { id: comp_id, .. }) = component_ids.get(component_idx)
+                {
                     // For built-in components, verify by TypeId
                     let type_id = ty.type_id();
 
@@ -704,8 +715,7 @@ impl PyQueryIter {
             let world_ptr = self.world_ptr.expect("Query used outside system execution");
             let (read_only, qs_ptr) = self.query_state.parts();
             // SAFETY: world_ptr and qs_ptr are valid during system execution
-            self.query_iter =
-                Some(unsafe { erased_create_iter(read_only, qs_ptr, world_ptr) });
+            self.query_iter = Some(unsafe { erased_create_iter(read_only, qs_ptr, world_ptr) });
         }
 
         // Advance iterator — get raw pointer to avoid borrow conflict with self
@@ -774,12 +784,12 @@ impl PyQueryIter {
                     (None, _) => {
                         return Err(PyRuntimeError::new_err(
                             "Query returned no entities. Expected exactly one.",
-                        ))
+                        ));
                     }
                     (Some(_), true) => {
                         return Err(PyRuntimeError::new_err(
                             "Query returned multiple entities. Expected exactly one.",
-                        ))
+                        ));
                     }
                     (Some(e), false) => FilteredEntityAccess::Ref(e),
                 }
@@ -792,12 +802,12 @@ impl PyQueryIter {
                     (None, _) => {
                         return Err(PyRuntimeError::new_err(
                             "Query returned no entities. Expected exactly one.",
-                        ))
+                        ));
                     }
                     (Some(_), true) => {
                         return Err(PyRuntimeError::new_err(
                             "Query returned multiple entities. Expected exactly one.",
-                        ))
+                        ));
                     }
                     (Some(e), false) => FilteredEntityAccess::Mut(e),
                 }
@@ -835,7 +845,9 @@ impl PyQueryIter {
         let last_tick = world.last_change_tick();
         let current_tick = world.read_change_tick();
 
-        Ok(self.query_state.is_empty_check(world, last_tick, current_tick))
+        Ok(self
+            .query_state
+            .is_empty_check(world, last_tick, current_tick))
     }
 
     /// Get components for a specific entity by ID.


### PR DESCRIPTION
For all queries, only `FilteredEntityMut` was used, which prevented bevy from scheduling systems truly parallel. Splitting this to `FilteredEntityAccess` enum, which internally has a mut and ref variants.

Also cleaning up the code by bringing `QueryComponent` struct which holds component-specific data. 

For `PyQueryIter`, also using the querystate variant instead of a pointer. This simplifies the readonly-mutable path branching.

```rust
enum ErasedQueryState {
    ReadOnly(*mut ()),
    Mutable(*mut ()),
}
```