### PR TITLE
Migrate to fieldtype enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4370,6 +4370,7 @@ version = "0.2.1"
 dependencies = [
  "bevy_ecs",
  "criterion",
+ "pybevy_storage",
  "pyo3",
  "rayon",
  "smallvec",

--- a/crates/pybevy_bytecodevm/Cargo.toml
+++ b/crates/pybevy_bytecodevm/Cargo.toml
@@ -16,6 +16,7 @@ pyo3.workspace = true
 bevy_ecs = "0.18"
 smallvec = "1.0"
 rayon = { version = "1.10", optional = true }
+pybevy_storage = { path = "../pybevy_storage", version = "=0.2.1" }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/crates/pybevy_bytecodevm/src/bytecode.rs
+++ b/crates/pybevy_bytecodevm/src/bytecode.rs
@@ -203,38 +203,7 @@ pub enum Op {
     RandomRange,
 }
 
-/// Field types supported by the VM
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum FieldType {
-    F32,
-    F64,
-    I32,
-    I64,
-    U32,
-    U64,
-    Bool,
-    /// Composite signal type: 3 × f32 (12 bytes). VM decomposes to individual F32 sub-fields.
-    Vec3,
-    /// Composite signal type: 2 × f32 (8 bytes). VM decomposes to individual F32 sub-fields.
-    Vec2,
-}
-
-impl FieldType {
-    /// Size in bytes of this field type
-    pub const fn size_bytes(&self) -> usize {
-        match self {
-            FieldType::F32 => 4,
-            FieldType::F64 => 8,
-            FieldType::I32 => 4,
-            FieldType::I64 => 8,
-            FieldType::U32 => 4,
-            FieldType::U64 => 8,
-            FieldType::Bool => 1,
-            FieldType::Vec3 => 12,
-            FieldType::Vec2 => 8,
-        }
-    }
-}
+pub use pybevy_storage::FieldType;
 
 /// Identifies a specific field within a component
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -415,10 +384,10 @@ pub unsafe fn read_field_value(ptr: *const u8, field_type: FieldType) -> f64 {
         FieldType::U32 => unsafe { *(ptr as *const u32) as f64 },
         FieldType::U64 => unsafe { *(ptr as *const u64) as f64 },
         FieldType::Bool => unsafe { if *(ptr as *const bool) { 1.0 } else { 0.0 } },
-        // Vec3/Vec2 are composite signal types — the VM decomposes them to individual F32 sub-fields
+        // Vec2/Vec3/Vec4 are composite signal types — the VM decomposes them to individual F32 sub-fields
         // before execution, so these should never appear in read_field_value
-        FieldType::Vec3 | FieldType::Vec2 => {
-            unreachable!("VM should decompose Vec3/Vec2 to F32 sub-fields")
+        FieldType::Vec2 | FieldType::Vec3 | FieldType::Vec4 => {
+            unreachable!("VM should decompose Vec2/Vec3/Vec4 to F32 sub-fields")
         }
     }
 }
@@ -451,8 +420,8 @@ pub unsafe fn write_field_value(ptr: *mut u8, value: f64, field_type: FieldType)
         FieldType::Bool => unsafe {
             *(ptr as *mut bool) = value >= 0.5;
         },
-        FieldType::Vec3 | FieldType::Vec2 => {
-            unreachable!("VM should decompose Vec3/Vec2 to F32 sub-fields")
+        FieldType::Vec2 | FieldType::Vec3 | FieldType::Vec4 => {
+            unreachable!("VM should decompose Vec2/Vec3/Vec4 to F32 sub-fields")
         }
     }
 }

--- a/crates/pybevy_core/src/lib.rs
+++ b/crates/pybevy_core/src/lib.rs
@@ -326,7 +326,7 @@ pub use message::{PyMessage, PyMessageId};
 pub use plugin::{PluginBridge, PluginBuild, PyPlugin};
 pub use pybevy_storage::{
     AccessMode, AssetStorage, BorrowableStorage, ComponentStorage, ComponentStorageInner,
-    FieldOffset, FieldStorage, FieldStorageInner, FromBorrowedStorage, ListStorage,
+    FieldOffset, FieldStorage, FieldStorageInner, FieldType, FromBorrowedStorage, ListStorage,
     ListStorageInner, ResourceStorage, ResourceStorageInner, StorageError, ValidityFlag,
     ValidityFlagWithMode, ValidityGuard, ValueStorage, ValueStorageInner, ViewBridge,
     ViewFieldAccess, normalize_index,
@@ -334,7 +334,7 @@ pub use pybevy_storage::{
 pub use registry::{
     AssetBridge, BatchComponent, BatchFieldMeta, BatchableField, ComponentBatchInsertFn,
     ComponentBatchMeta, ComponentBridge, ExtractFn, MessageBridge, PluginConfigs,
-    PyRustComponentBatch, ResourceBridge, batch_field_meta_for, field_offset_view_meta_for,
+    PyRustComponentBatch, ResourceBridge, batch_field_meta_for, field_type_of,
     set_field_from_numpy,
 };
 pub use reload_request::{

--- a/crates/pybevy_core/src/registry/batchable_field.rs
+++ b/crates/pybevy_core/src/registry/batchable_field.rs
@@ -9,6 +9,7 @@ use bevy::{
     color::{Color, Srgba},
     math::{Quat, Vec2, Vec3, Vec4},
 };
+use pybevy_storage::FieldType;
 
 /// A component field type that can be populated from numpy float32 data.
 ///
@@ -24,13 +25,8 @@ pub trait BatchableField: Sized + Copy {
     /// Number of columns in the numpy array (same as ELEMENT_COUNT)
     const NUMPY_COLUMNS: usize;
 
-    /// View API dtype string (e.g., "f4" for f32, "u1" for bool).
-    /// Only meaningful for types used in `view_fields`.
-    const VIEW_DTYPE: &'static str;
-
-    /// Native size in bytes of a single element for View API access.
-    /// Only meaningful for types used in `view_fields`.
-    const VIEW_ELEMENT_SIZE: usize;
+    /// View API field type. Only meaningful for types used in `view_fields`.
+    const VIEW_FIELD_TYPE: FieldType;
 
     /// Construct a value from a contiguous f32 slice at the given entity index.
     ///
@@ -43,8 +39,7 @@ impl BatchableField for f32 {
     const ELEMENT_COUNT: usize = 1;
     const NUMPY_DTYPE: &'static str = "float32";
     const NUMPY_COLUMNS: usize = 1;
-    const VIEW_DTYPE: &'static str = "f4";
-    const VIEW_ELEMENT_SIZE: usize = 4;
+    const VIEW_FIELD_TYPE: FieldType = FieldType::F32;
 
     #[inline(always)]
     fn from_numpy_f32_slice(data: &[f32], index: usize) -> Self {
@@ -56,8 +51,7 @@ impl BatchableField for bool {
     const ELEMENT_COUNT: usize = 1;
     const NUMPY_DTYPE: &'static str = "float32";
     const NUMPY_COLUMNS: usize = 1;
-    const VIEW_DTYPE: &'static str = "u1";
-    const VIEW_ELEMENT_SIZE: usize = 1;
+    const VIEW_FIELD_TYPE: FieldType = FieldType::Bool;
 
     #[inline(always)]
     fn from_numpy_f32_slice(data: &[f32], index: usize) -> Self {
@@ -69,8 +63,7 @@ impl BatchableField for u32 {
     const ELEMENT_COUNT: usize = 1;
     const NUMPY_DTYPE: &'static str = "float32";
     const NUMPY_COLUMNS: usize = 1;
-    const VIEW_DTYPE: &'static str = "u4";
-    const VIEW_ELEMENT_SIZE: usize = 4;
+    const VIEW_FIELD_TYPE: FieldType = FieldType::U32;
 
     #[inline(always)]
     fn from_numpy_f32_slice(data: &[f32], index: usize) -> Self {
@@ -82,9 +75,7 @@ impl BatchableField for Color {
     const ELEMENT_COUNT: usize = 4;
     const NUMPY_DTYPE: &'static str = "float32";
     const NUMPY_COLUMNS: usize = 4;
-    // Color is batch-only (enum with discriminant), these are not used in View API
-    const VIEW_DTYPE: &'static str = "f4";
-    const VIEW_ELEMENT_SIZE: usize = 4;
+    const VIEW_FIELD_TYPE: FieldType = FieldType::F32;
 
     #[inline(always)]
     fn from_numpy_f32_slice(data: &[f32], index: usize) -> Self {
@@ -102,8 +93,7 @@ impl BatchableField for Vec2 {
     const ELEMENT_COUNT: usize = 2;
     const NUMPY_DTYPE: &'static str = "float32";
     const NUMPY_COLUMNS: usize = 2;
-    const VIEW_DTYPE: &'static str = "f4";
-    const VIEW_ELEMENT_SIZE: usize = 4;
+    const VIEW_FIELD_TYPE: FieldType = FieldType::Vec2;
 
     #[inline(always)]
     fn from_numpy_f32_slice(data: &[f32], index: usize) -> Self {
@@ -116,8 +106,7 @@ impl BatchableField for Vec3 {
     const ELEMENT_COUNT: usize = 3;
     const NUMPY_DTYPE: &'static str = "float32";
     const NUMPY_COLUMNS: usize = 3;
-    const VIEW_DTYPE: &'static str = "f4";
-    const VIEW_ELEMENT_SIZE: usize = 4;
+    const VIEW_FIELD_TYPE: FieldType = FieldType::Vec3;
 
     #[inline(always)]
     fn from_numpy_f32_slice(data: &[f32], index: usize) -> Self {
@@ -130,8 +119,7 @@ impl BatchableField for Vec4 {
     const ELEMENT_COUNT: usize = 4;
     const NUMPY_DTYPE: &'static str = "float32";
     const NUMPY_COLUMNS: usize = 4;
-    const VIEW_DTYPE: &'static str = "f4";
-    const VIEW_ELEMENT_SIZE: usize = 4;
+    const VIEW_FIELD_TYPE: FieldType = FieldType::F32;
 
     #[inline(always)]
     fn from_numpy_f32_slice(data: &[f32], index: usize) -> Self {
@@ -144,8 +132,7 @@ impl BatchableField for Quat {
     const ELEMENT_COUNT: usize = 4;
     const NUMPY_DTYPE: &'static str = "float32";
     const NUMPY_COLUMNS: usize = 4;
-    const VIEW_DTYPE: &'static str = "f4";
-    const VIEW_ELEMENT_SIZE: usize = 4;
+    const VIEW_FIELD_TYPE: FieldType = FieldType::F32;
 
     #[inline(always)]
     fn from_numpy_f32_slice(data: &[f32], index: usize) -> Self {
@@ -177,19 +164,19 @@ pub fn batch_field_meta_for<T: BatchableField>(_field: &T, name: &'static str) -
     }
 }
 
-/// View API metadata helper: returns (view_dtype, view_element_size) for a field type.
+/// View API metadata helper: returns the `FieldType` for a field type.
 ///
 /// Uses type inference to resolve T from a `&field` reference, then returns
-/// the dtype string and element size for View API FieldOffset construction.
+/// the `FieldType` for View API `FieldOffset` construction.
 ///
 /// Usage in macro-generated code:
 /// ```ignore
 /// let default = PointLight::default();
-/// let (dtype, elem_size) = field_offset_view_meta_for(&default.shadows_enabled);
-/// // T = bool → dtype = "u1", elem_size = 1
+/// let field_type = field_type_of(&default.shadows_enabled);
+/// // T = bool → FieldType::Bool
 /// ```
-pub fn field_offset_view_meta_for<T: BatchableField>(_field: &T) -> (&'static str, usize) {
-    (T::VIEW_DTYPE, T::VIEW_ELEMENT_SIZE)
+pub fn field_type_of<T: BatchableField>(_field: &T) -> FieldType {
+    T::VIEW_FIELD_TYPE
 }
 
 /// Assignment helper: compiler resolves T from `&mut field`.

--- a/crates/pybevy_core/src/registry/mod.rs
+++ b/crates/pybevy_core/src/registry/mod.rs
@@ -17,8 +17,7 @@ pub mod rust_batch;
 pub use asset_bridge::AssetBridge;
 pub use batch_bridge::BatchComponent;
 pub use batchable_field::{
-    BatchFieldMeta, BatchableField, batch_field_meta_for, field_offset_view_meta_for,
-    set_field_from_numpy,
+    BatchFieldMeta, BatchableField, batch_field_meta_for, field_type_of, set_field_from_numpy,
 };
 pub use component_bridge::{ComponentBridge, ExtractFn};
 pub use global_registry::{ComponentBatchInsertFn, ComponentBatchMeta};

--- a/crates/pybevy_macros/src/component.rs
+++ b/crates/pybevy_macros/src/component.rs
@@ -471,21 +471,24 @@ fn generate_bridge_tokens(
     let has_view_fields = view_fields.is_some() || view_only_fields.is_some();
     let view_bridge_impl = if has_view_fields {
         // Collect all view field names + match arms from view_fields
-        let vf_entries: Vec<_> = view_fields.iter().flat_map(|fs| fs.iter()).map(|f| {
-            let name_str = f.python_name.to_string();
-            let accessor = &f.rust_accessor;
-            let offset = &f.offset_path;
-            quote! {
-                #name_str => {
-                    let (dtype, element_size) = pybevy_core::field_offset_view_meta_for(&default_val #accessor);
-                    Some(pybevy_core::FieldOffset {
-                        offset: std::mem::offset_of!(#bevy_type, #offset),
-                        element_size,
-                        dtype,
-                    })
+        let vf_entries: Vec<_> = view_fields
+            .iter()
+            .flat_map(|fs| fs.iter())
+            .map(|f| {
+                let name_str = f.python_name.to_string();
+                let accessor = &f.rust_accessor;
+                let offset = &f.offset_path;
+                quote! {
+                    #name_str => {
+                        let field_type = pybevy_core::field_type_of(&default_val #accessor);
+                        Some(pybevy_core::FieldOffset {
+                            offset: std::mem::offset_of!(#bevy_type, #offset),
+                            field_type,
+                        })
+                    }
                 }
-            }
-        }).collect();
+            })
+            .collect();
 
         // Collect view_only_fields entries (use explicit type instead of type inference)
         let vof_entries: Vec<_> = view_only_fields.iter().flat_map(|fs| fs.iter()).map(|f| {
@@ -494,11 +497,9 @@ fn generate_bridge_tokens(
             let field_type = &f.field_type;
             quote! {
                 #name_str => {
-                    let (dtype, element_size) = (<#field_type as pybevy_core::BatchableField>::VIEW_DTYPE, <#field_type as pybevy_core::BatchableField>::VIEW_ELEMENT_SIZE);
                     Some(pybevy_core::FieldOffset {
                         offset: std::mem::offset_of!(#bevy_type, #offset),
-                        element_size,
-                        dtype,
+                        field_type: <#field_type as pybevy_core::BatchableField>::VIEW_FIELD_TYPE,
                     })
                 }
             }
@@ -528,7 +529,6 @@ fn generate_bridge_tokens(
 
         quote! {
             fn view_bridge(&self) -> Option<pybevy_core::ViewBridge> {
-                // Generate field_offset function with dtype/element_size metadata
                 fn field_offset_fn(field_name: &str) -> Option<pybevy_core::FieldOffset> {
                     #default_val_line
                     match field_name {

--- a/crates/pybevy_storage/src/lib.rs
+++ b/crates/pybevy_storage/src/lib.rs
@@ -35,4 +35,4 @@ pub use storage_error::StorageError;
 pub use storage_traits::{BorrowableStorage, FromBorrowedStorage};
 pub use validity_guard::{AccessMode, ValidityFlag, ValidityFlagWithMode, ValidityGuard};
 pub use value_storage::{ValueStorage, ValueStorageInner};
-pub use view_bridge::{FieldOffset, ViewBridge, ViewFieldAccess};
+pub use view_bridge::{FieldOffset, FieldType, ViewBridge, ViewFieldAccess};

--- a/crates/pybevy_storage/src/view_bridge.rs
+++ b/crates/pybevy_storage/src/view_bridge.rs
@@ -19,18 +19,63 @@
 
 use bevy::ecs::{component::ComponentId, storage::Column, world::World};
 
-/// Field metadata for View API access
+/// Primitive field types supported by the View API and bytecode VM.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FieldType {
+    F32,
+    F64,
+    I32,
+    I64,
+    U32,
+    U64,
+    Bool,
+    Vec2,
+    Vec3,
+    Vec4,
+}
+
+impl FieldType {
+    /// Size in bytes of this field type.
+    pub const fn size_bytes(&self) -> usize {
+        match self {
+            FieldType::F32 => 4,
+            FieldType::F64 => 8,
+            FieldType::I32 => 4,
+            FieldType::I64 => 8,
+            FieldType::U32 => 4,
+            FieldType::U64 => 8,
+            FieldType::Bool => 1,
+            FieldType::Vec2 => 8,
+            FieldType::Vec3 => 12,
+            FieldType::Vec4 => 16,
+        }
+    }
+
+    /// NumPy dtype string for this field type (e.g., "f4" for F32, "u1" for Bool).
+    pub const fn to_numpy_dtype_str(self) -> &'static str {
+        match self {
+            FieldType::F32 => "f4",
+            FieldType::F64 => "f8",
+            FieldType::I32 => "i4",
+            FieldType::I64 => "i8",
+            FieldType::U32 => "u4",
+            FieldType::U64 => "u8",
+            FieldType::Bool => "u1",
+            FieldType::Vec2 | FieldType::Vec3 | FieldType::Vec4 => "f4",
+        }
+    }
+}
+
+/// Field metadata for View API access.
 ///
-/// Contains the byte offset and type metadata of a field within a component struct.
+/// Contains the byte offset and type of a field within a component struct.
 /// Used for direct memory access in the View API bytecode VM.
 #[derive(Debug, Clone, Copy)]
 pub struct FieldOffset {
     /// Byte offset of the field within the component struct
     pub offset: usize,
-    /// Size in bytes of a single element (4 for f32, 1 for bool, etc.)
-    pub element_size: usize,
-    /// View API dtype string (e.g., "f4" for f32, "u1" for bool)
-    pub dtype: &'static str,
+    /// Type of the field
+    pub field_type: FieldType,
 }
 
 /// Trait for components that support View API field access
@@ -44,8 +89,8 @@ pub struct FieldOffset {
 /// impl ViewFieldAccess for PyPointLight {
 ///     fn field_offset(field_name: &str) -> Option<FieldOffset> {
 ///         match field_name {
-///             "intensity" => Some(FieldOffset { offset: offset_of!(PointLight, intensity), element_size: 4, dtype: "f4" }),
-///             "range" => Some(FieldOffset { offset: offset_of!(PointLight, range), element_size: 4, dtype: "f4" }),
+///             "intensity" => Some(FieldOffset { offset: offset_of!(PointLight, intensity), field_type: FieldType::F32 }),
+///             "range" => Some(FieldOffset { offset: offset_of!(PointLight, range), field_type: FieldType::F32 }),
 ///             _ => None,
 ///         }
 ///     }

--- a/src/ecs/view/view.rs
+++ b/src/ecs/view/view.rs
@@ -1023,19 +1023,7 @@ pub(crate) fn get_component_field_info(
                 ))
             })?;
 
-            // Map FieldOffset dtype to VM FieldType
-            let vm_field_type = match offset_info.dtype {
-                "u1" => VmFieldType::Bool,
-                "f4" => VmFieldType::F32,
-                "f8" => VmFieldType::F64,
-                "i4" => VmFieldType::I32,
-                "i8" => VmFieldType::I64,
-                "u4" => VmFieldType::U32,
-                "u8" => VmFieldType::U64,
-                _ => VmFieldType::F32,
-            };
-
-            Ok((offset_info.offset, vm_field_type))
+            Ok((offset_info.offset, offset_info.field_type))
         }
     }
 }
@@ -1056,6 +1044,7 @@ fn create_field_proxy<'py>(
     let field_type_str = format!("{:?}", field_type); // FieldType Debug prints as "F32", "I64", etc.
 
     // For Vec3/Vec2 fields (any component, including custom), return composite proxy
+    // Vec4 fields fall through to `_` - no Vec4Expr proxy yet
     match field_type {
         pybevy_bytecodevm::bytecode::FieldType::Vec3 => {
             let vec3_proxy = expr_module.getattr("Vec3Expr")?;
@@ -1542,15 +1531,12 @@ impl PyBatch {
             }
         };
 
-        let dtype = "struct".to_string();
-
         let view_column = unsafe {
             match comp_type {
                 PyComponentType::Custom(type_ptr) => PyViewColumn::from_raw_parts_with_type(
                     ptr,
                     entity_count,
                     stride,
-                    dtype,
                     self.validity_token.clone(),
                     type_ptr,
                 ),
@@ -1558,7 +1544,6 @@ impl PyBatch {
                     ptr,
                     entity_count,
                     stride,
-                    dtype,
                     self.validity_token.clone(),
                     comp_type,
                 ),
@@ -1684,15 +1669,12 @@ impl PyBatch {
             }
         };
 
-        let dtype = "struct".to_string();
-
         let view_column = unsafe {
             match comp_type {
                 PyComponentType::Custom(type_ptr) => PyViewColumn::from_raw_parts_with_type(
                     ptr,
                     entity_count,
                     stride,
-                    dtype,
                     self.validity_token.clone(),
                     type_ptr,
                 ),
@@ -1700,7 +1682,6 @@ impl PyBatch {
                     ptr,
                     entity_count,
                     stride,
-                    dtype,
                     self.validity_token.clone(),
                     comp_type,
                 ),

--- a/src/ecs/view/view_column.rs
+++ b/src/ecs/view/view_column.rs
@@ -8,15 +8,27 @@
 //! boundary (in the unbox() function) and in bulk read/write methods,
 //! preventing use-after-free bugs.
 
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
+use std::{
+    mem,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
+use bevy::transform::components::Transform;
+use pybevy_bytecodevm::bytecode::{read_field_value, write_field_value};
+use pybevy_core::FieldType;
 use pyo3::{
     exceptions::PyRuntimeError,
     prelude::*,
     types::{PyBytes, PyList},
+};
+
+use crate::ecs::{
+    component_layout::{ComponentLayout, PrimitiveType},
+    component_type::PyComponentType,
+    view::view::get_component_field_info,
 };
 
 /// Opaque column view that can only be accessed through Numba JIT.
@@ -55,8 +67,8 @@ pub struct PyViewColumn {
     /// Stride between elements in bytes.
     stride: usize,
 
-    /// NumPy dtype string (e.g., "f4" for float32, "i4" for int32).
-    dtype: String,
+    /// Field type (`None` for opaque whole-component views with no single representable type, e.g. Transform or Quat).
+    field_type: Option<FieldType>,
 
     /// Validity token shared across all views from the same batch.
     validity_token: Arc<AtomicBool>,
@@ -65,19 +77,24 @@ pub struct PyViewColumn {
     component_type: Option<*const pyo3::ffi::PyTypeObject>,
 
     /// Built-in component type for trait-based field access (None for custom/primitive columns)
-    builtin_component_type: Option<crate::ecs::component_type::PyComponentType>,
+    builtin_component_type: Option<PyComponentType>,
 
     /// Owned buffer for temporary arithmetic results (None = ECS-backed pointer)
     owned_data: Option<Vec<u8>>,
 }
 
 impl PyViewColumn {
-    /// Create a ViewColumn with component type info for dynamic field access
+    /// Create a ViewColumn with component type info for dynamic field access.
+    /// Whole-component columns are always opaque structs (field_type = None).
+    ///
+    /// # Safety
+    /// `ptr` must point to the first element of a valid ECS column with `len` elements
+    /// spaced `stride` bytes apart. The pointer must remain valid for the lifetime of
+    /// the validity token (i.e. until the system finishes execution).
     pub(crate) unsafe fn from_raw_parts_with_type(
         ptr: *const u8,
         len: usize,
         stride: usize,
-        dtype: String,
         validity_token: Arc<AtomicBool>,
         component_type: *const pyo3::ffi::PyTypeObject,
     ) -> Self {
@@ -85,7 +102,7 @@ impl PyViewColumn {
             ptr: ptr as *mut u8,
             len,
             stride,
-            dtype,
+            field_type: None,
             validity_token,
             component_type: Some(component_type),
             builtin_component_type: None,
@@ -93,20 +110,23 @@ impl PyViewColumn {
         }
     }
 
-    /// Create a ViewColumn with built-in component type for trait-based field access
+    /// Create a ViewColumn with built-in component type for trait-based field access.
+    /// Whole-component columns are always opaque structs (field_type = None).
+    ///
+    /// # Safety
+    /// Same requirements as `from_raw_parts_with_type`.
     pub(crate) unsafe fn from_raw_parts_with_builtin_type(
         ptr: *const u8,
         len: usize,
         stride: usize,
-        dtype: String,
         validity_token: Arc<AtomicBool>,
-        builtin_component_type: crate::ecs::component_type::PyComponentType,
+        builtin_component_type: PyComponentType,
     ) -> Self {
         Self {
             ptr: ptr as *mut u8,
             len,
             stride,
-            dtype,
+            field_type: None,
             validity_token,
             component_type: None,
             builtin_component_type: Some(builtin_component_type),
@@ -114,63 +134,58 @@ impl PyViewColumn {
         }
     }
 
-    /// Byte size for a given dtype string.
-    fn dtype_size(dtype: &str) -> PyResult<usize> {
-        match dtype {
-            "u1" => Ok(1),
-            "f4" | "i4" | "u4" => Ok(4),
-            "f8" | "i8" | "u8" => Ok(8),
-            _ => Err(PyRuntimeError::new_err(format!(
-                "Arithmetic not supported for dtype '{dtype}'"
-            ))),
-        }
-    }
-
-    /// Read element at `index` as f64, respecting stride and dtype.
+    /// Read element at `index` as f64, respecting stride and field type.
+    ///
+    /// # Panics
+    /// Panics if `field_type` is None or a composite variant. Callers must ensure
+    /// `check_numeric()` has been called first.
     fn read_f64_at(&self, index: usize) -> f64 {
+        let ft = self
+            .field_type
+            .expect("read_f64_at called on composite/struct column");
+        // Safety: `index < len` is enforced by all callers. `ptr` is valid for the
+        // system lifetime, guaranteed by the validity token checked in `check_numeric`.
         let ptr = unsafe { self.ptr.add(index * self.stride) };
-        unsafe {
-            match self.dtype.as_str() {
-                "u1" => *(ptr as *const u8) as f64,
-                "f4" => *(ptr as *const f32) as f64,
-                "f8" => *(ptr as *const f64),
-                "i4" => *(ptr as *const i32) as f64,
-                "i8" => *(ptr as *const i64) as f64,
-                "u4" => *(ptr as *const u32) as f64,
-                "u8" => *(ptr as *const u64) as f64,
-                _ => *(ptr as *const f32) as f64,
-            }
-        }
+        // Safety: ptr is aligned and valid for `ft`; `ft` is a scalar variant (not Vec2/Vec3/Vec4).
+        unsafe { read_field_value(ptr, ft) }
     }
 
-    /// Write f64 value at `index`, respecting stride and dtype.
+    /// Write f64 value at `index`, respecting stride and field type.
+    ///
+    /// # Panics
+    /// Panics if `field_type` is None or a composite variant. Callers must ensure
+    /// `check_numeric()` has been called first.
     fn write_f64_at(&self, index: usize, value: f64) {
+        let ft = self
+            .field_type
+            .expect("write_f64_at called on composite/struct column");
+        // Safety: same as `read_f64_at`.
         let ptr = unsafe { self.ptr.add(index * self.stride) };
-        unsafe {
-            match self.dtype.as_str() {
-                "u1" => *(ptr as *mut u8) = (value != 0.0) as u8,
-                "f4" => *(ptr as *mut f32) = value as f32,
-                "f8" => *(ptr as *mut f64) = value,
-                "i4" => *(ptr as *mut i32) = value as i32,
-                "i8" => *(ptr as *mut i64) = value as i64,
-                "u4" => *(ptr as *mut u32) = value as u32,
-                "u8" => *(ptr as *mut u64) = value as u64,
-                _ => *(ptr as *mut f32) = value as f32,
-            }
-        }
+        // Safety: ptr is aligned, valid, and not aliased for the duration of this write.
+        unsafe { write_field_value(ptr, value, ft) }
     }
 
-    /// Check validity and reject non-numeric dtypes.
-    fn check_numeric(&self) -> PyResult<()> {
+    /// Check validity and that this is a scalar field type. Returns the `FieldType` on success.
+    fn check_numeric(&self) -> PyResult<FieldType> {
         if !self.validity_token.load(Ordering::Relaxed) {
             return Err(PyRuntimeError::new_err("Accessing stale ViewColumn!"));
         }
-        match self.dtype.as_str() {
-            "f4" | "f8" | "i4" | "i8" | "u4" | "u8" | "u1" => Ok(()),
-            _ => Err(PyRuntimeError::new_err(format!(
-                "Arithmetic not supported for dtype '{}'",
-                self.dtype
-            ))),
+        match self.field_type {
+            Some(
+                ft @ (FieldType::F32
+                | FieldType::F64
+                | FieldType::I32
+                | FieldType::I64
+                | FieldType::U32
+                | FieldType::U64
+                | FieldType::Bool),
+            ) => Ok(ft),
+            Some(FieldType::Vec2) | Some(FieldType::Vec3) | Some(FieldType::Vec4) | None => {
+                Err(PyRuntimeError::new_err(format!(
+                    "Arithmetic not supported for dtype '{}'",
+                    self.dtype()
+                )))
+            }
         }
     }
 
@@ -178,31 +193,22 @@ impl PyViewColumn {
     fn from_f64_iter(
         iter: impl Iterator<Item = f64>,
         len: usize,
-        dtype: &str,
+        field_type: FieldType,
         validity_token: &Arc<AtomicBool>,
     ) -> PyResult<Self> {
-        let elem_size = Self::dtype_size(dtype)?;
+        let elem_size = field_type.size_bytes();
         let mut buf = vec![0u8; len * elem_size];
-        // Write using the target dtype
         for (i, val) in iter.enumerate() {
+            // Safety: `i * elem_size` is within `buf` (allocated as `len * elem_size` bytes).
             let ptr = unsafe { buf.as_mut_ptr().add(i * elem_size) };
-            unsafe {
-                match dtype {
-                    "f4" => *(ptr as *mut f32) = val as f32,
-                    "f8" => *(ptr as *mut f64) = val,
-                    "i4" => *(ptr as *mut i32) = val as i32,
-                    "i8" => *(ptr as *mut i64) = val as i64,
-                    "u4" => *(ptr as *mut u32) = val as u32,
-                    "u8" => *(ptr as *mut u64) = val as u64,
-                    _ => *(ptr as *mut f32) = val as f32,
-                }
-            }
+            // Safety: ptr is aligned for `field_type`; buf is exclusively owned here.
+            unsafe { write_field_value(ptr, val, field_type) };
         }
         Ok(Self {
             ptr: buf.as_mut_ptr(),
             len,
             stride: elem_size,
-            dtype: dtype.to_string(),
+            field_type: Some(field_type),
             validity_token: validity_token.clone(),
             component_type: None,
             builtin_component_type: None,
@@ -212,18 +218,18 @@ impl PyViewColumn {
 
     /// Apply a unary f64→f64 function element-wise, returning an owned ViewColumn.
     fn unary_op(&self, f: impl Fn(f64) -> f64) -> PyResult<Self> {
-        self.check_numeric()?;
+        let ft = self.check_numeric()?;
         Self::from_f64_iter(
             (0..self.len).map(|i| f(self.read_f64_at(i))),
             self.len,
-            &self.dtype,
+            ft,
             &self.validity_token,
         )
     }
 
     /// Apply a binary (col, col) → col function element-wise.
     fn binary_op_col(&self, other: &Self, f: impl Fn(f64, f64) -> f64) -> PyResult<Self> {
-        self.check_numeric()?;
+        let ft = self.check_numeric()?;
         other.check_numeric()?;
         if self.len != other.len {
             return Err(PyRuntimeError::new_err(format!(
@@ -234,35 +240,78 @@ impl PyViewColumn {
         Self::from_f64_iter(
             (0..self.len).map(|i| f(self.read_f64_at(i), other.read_f64_at(i))),
             self.len,
-            &self.dtype,
+            ft,
             &self.validity_token,
         )
     }
 
     /// Apply a binary (col, scalar) → col function element-wise.
     fn binary_op_scalar(&self, scalar: f64, f: impl Fn(f64, f64) -> f64) -> PyResult<Self> {
-        self.check_numeric()?;
+        let ft = self.check_numeric()?;
         Self::from_f64_iter(
             (0..self.len).map(|i| f(self.read_f64_at(i), scalar)),
             self.len,
-            &self.dtype,
+            ft,
             &self.validity_token,
         )
     }
 
     /// Apply a binary (scalar, col) → col function element-wise.
     fn binary_op_scalar_left(&self, scalar: f64, f: impl Fn(f64, f64) -> f64) -> PyResult<Self> {
-        self.check_numeric()?;
+        let ft = self.check_numeric()?;
         Self::from_f64_iter(
             (0..self.len).map(|i| f(scalar, self.read_f64_at(i))),
             self.len,
-            &self.dtype,
+            ft,
             &self.validity_token,
         )
     }
+
+    /// Create a sub-column view at a byte offset with a known `FieldType`.
+    ///
+    /// Internal API — Rust callers should prefer this over `at_offset` to avoid string parsing.
+    pub(crate) fn at_offset_typed(
+        &self,
+        offset: usize,
+        field_type: Option<FieldType>,
+    ) -> PyResult<Self> {
+        if self.owned_data.is_some() {
+            return Err(PyRuntimeError::new_err(
+                "Cannot access sub-columns on a temporary ViewColumn from arithmetic.\n\
+                 Assign it back to an ECS-backed column first.",
+            ));
+        }
+        // Validate against the element extent: for typed columns use the type's byte size,
+        // for opaque struct columns fall back to the stride.
+        let extent = match self.field_type {
+            Some(ft) => ft.size_bytes(),
+            None => self.stride,
+        };
+        if extent > 0 && offset >= extent {
+            return Err(PyRuntimeError::new_err(format!(
+                "Offset {offset} out of bounds for '{}' ({} bytes)",
+                self.dtype(),
+                extent,
+            )));
+        }
+        Ok(Self {
+            // Safety: `offset < extent <= stride`, so the resulting pointer is still within
+            // the same ECS column allocation. Validity is inherited via the shared token.
+            ptr: unsafe { self.ptr.add(offset) },
+            len: self.len,
+            stride: self.stride,
+            field_type,
+            validity_token: self.validity_token.clone(),
+            component_type: None,
+            builtin_component_type: None,
+            owned_data: None,
+        })
+    }
 }
 
-// Implement Sync + Send since we're manually managing the Arc
+// Safety: `ptr` is only accessed while the validity token is live (checked before every
+// read/write), and `Arc<AtomicBool>` coordinates access across threads. The raw pointer
+// is never aliased mutably while any shared reference exists.
 unsafe impl Send for PyViewColumn {}
 unsafe impl Sync for PyViewColumn {}
 
@@ -331,51 +380,46 @@ impl PyViewColumn {
         self.stride
     }
 
-    /// Get the NumPy dtype string.
+    /// Get the NumPy dtype string (e.g., "f4", "i8", "u1", "struct").
     #[getter]
-    fn dtype(&self) -> &str {
-        &self.dtype
+    fn dtype(&self) -> &'static str {
+        match self.field_type {
+            Some(ft) => ft.to_numpy_dtype_str(),
+            None => "struct",
+        }
     }
 
     /// Create a sub-column view at a byte offset (for field peeling).
     ///
-    /// This is used to implement `.translation.y` syntax by creating a new
-    /// view with adjusted pointer offset.
+    /// This is the Python-facing API; Rust internals should use `at_offset_typed`.
     ///
     /// # Arguments
     ///
     /// - `offset`: Byte offset from the current pointer
-    /// - `dtype`: NumPy dtype string for the sub-column
+    /// - `dtype`: NumPy dtype string (e.g., "f4", "i8", "u1") or "struct" for composite
     pub fn at_offset(&self, offset: usize, dtype: &str) -> PyResult<Self> {
-        if self.owned_data.is_some() {
-            return Err(PyRuntimeError::new_err(
-                "Cannot access sub-columns on a temporary ViewColumn from arithmetic.\n\
-                 Assign it back to an ECS-backed column first.",
-            ));
-        }
-        if self.stride > 0 && offset >= self.stride {
-            return Err(PyRuntimeError::new_err(format!(
-                "Offset {offset} exceeds stride {} — would read out of bounds",
-                self.stride
-            )));
-        }
-        Ok(Self {
-            ptr: unsafe { self.ptr.add(offset) },
-            len: self.len,
-            stride: self.stride,
-            dtype: dtype.to_string(),
-            validity_token: self.validity_token.clone(),
-            component_type: None,
-            builtin_component_type: None,
-            owned_data: None,
-        })
+        let field_type = match dtype {
+            "u1" => Some(FieldType::Bool),
+            "f4" => Some(FieldType::F32),
+            "f8" => Some(FieldType::F64),
+            "i4" => Some(FieldType::I32),
+            "i8" => Some(FieldType::I64),
+            "u4" => Some(FieldType::U32),
+            "u8" => Some(FieldType::U64),
+            "struct" => None,
+            _ => {
+                return Err(PyRuntimeError::new_err(format!(
+                    "Unknown dtype '{}'. Use one of: f4, f8, i4, i8, u4, u8, u1, struct",
+                    dtype
+                )));
+            }
+        };
+        self.at_offset_typed(offset, field_type)
     }
 
     /// Helper method for debugging: peek at a single value (with safety check).
     pub fn peek(&self, index: usize) -> PyResult<f64> {
-        if !self.is_valid() {
-            return Err(PyRuntimeError::new_err("Accessing stale ViewColumn!"));
-        }
+        self.check_numeric()?;
         if index >= self.len {
             return Err(PyRuntimeError::new_err(format!(
                 "Index {} out of bounds (len = {})",
@@ -387,9 +431,7 @@ impl PyViewColumn {
 
     /// Helper method for debugging: convert to Python list (with copy).
     pub fn to_list(&self, py: Python) -> PyResult<Py<PyAny>> {
-        if !self.is_valid() {
-            return Err(PyRuntimeError::new_err("Accessing stale ViewColumn!"));
-        }
+        self.check_numeric()?;
         let values: Vec<f64> = (0..self.len).map(|i| self.read_f64_at(i)).collect();
         Ok(PyList::new(py, values)?.into_any().unbind())
     }
@@ -399,12 +441,6 @@ impl PyViewColumn {
         // Priority 1: Built-in component with trait-based field access
         // Skip Transform here - it has composite fields (Vec3/Quat) that need special wrapper handling
         if let Some(ref comp_type) = self.builtin_component_type {
-            use pybevy_bytecodevm::bytecode::FieldType;
-
-            use crate::ecs::{
-                component_type::PyComponentType, view::view::get_component_field_info,
-            };
-
             // Transform has composite fields (Vec3/Quat), handle in hardcoded fallback
             let is_composite = match comp_type {
                 PyComponentType::Dynamic(type_ptr) => {
@@ -417,15 +453,8 @@ impl PyViewColumn {
             if !is_composite
                 && let Ok((offset, field_type)) = get_component_field_info(comp_type, name)
             {
-                let dtype = match field_type {
-                    FieldType::F32 => "f4",
-                    FieldType::F64 => "f8",
-                    FieldType::I32 => "i4",
-                    FieldType::I64 => "i8",
-                    FieldType::U32 => "u4",
-                    FieldType::U64 => "u8",
-                    FieldType::Bool => "u1",
-                    FieldType::Vec3 | FieldType::Vec2 => {
+                match field_type {
+                    FieldType::Vec2 | FieldType::Vec3 | FieldType::Vec4 => {
                         // Composite fields for built-in components shouldn't reach here
                         // (they use bridge which returns individual scalar sub-fields)
                         return Err(pyo3::exceptions::PyAttributeError::new_err(format!(
@@ -434,17 +463,18 @@ impl PyViewColumn {
                             name, name, name, name,
                         )));
                     }
-                };
-
-                let field_col = self.at_offset(offset, dtype)?;
-                return Ok(Py::new(py, field_col)?.into());
+                    _ => {
+                        let field_col = self.at_offset_typed(offset, Some(field_type))?;
+                        return Ok(Py::new(py, field_col)?.into());
+                    }
+                }
             }
         }
 
         // Priority 2: Custom component with dynamic field access
         if let Some(type_ptr) = self.component_type {
-            use crate::ecs::component_layout::{ComponentLayout, PrimitiveType};
-
+            // Safety: `type_ptr` was captured from a live Python type object and the GIL
+            // is held here, so the pointer is valid for the duration of this call.
             let py_type =
                 unsafe { pyo3::Bound::from_borrowed_ptr(py, type_ptr as *mut pyo3::ffi::PyObject) };
 
@@ -454,17 +484,10 @@ impl PyViewColumn {
                 // Find field in layout
                 for field in &layout.fields {
                     if field.name == name {
-                        // Determine dtype from field type
-                        let dtype = match field.field_type {
-                            PrimitiveType::F32 => "f4",
-                            PrimitiveType::F64 => "f8",
-                            PrimitiveType::I32 => "i4",
-                            PrimitiveType::I64 => "i8",
-                            PrimitiveType::U32 => "u4",
-                            PrimitiveType::U64 => "u8",
-                            PrimitiveType::Bool => "u1",
+                        match field.field_type {
                             PrimitiveType::Vec3 => {
-                                let vec3_col = self.at_offset(field.offset, "struct")?;
+                                let vec3_col =
+                                    self.at_offset_typed(field.offset, Some(FieldType::Vec3))?;
                                 let viewcolumn_accessors =
                                     py.import("pybevy.ecs.view_accessors")?;
                                 let vec3_wrapper =
@@ -472,17 +495,22 @@ impl PyViewColumn {
                                 return Ok(vec3_wrapper.call1((vec3_col,))?.into());
                             }
                             PrimitiveType::Vec2 => {
-                                let vec2_col = self.at_offset(field.offset, "struct")?;
+                                let vec2_col =
+                                    self.at_offset_typed(field.offset, Some(FieldType::Vec2))?;
                                 let viewcolumn_accessors =
                                     py.import("pybevy.ecs.view_accessors")?;
                                 let vec2_wrapper =
                                     viewcolumn_accessors.getattr("Vec2ViewColumn")?;
                                 return Ok(vec2_wrapper.call1((vec2_col,))?.into());
                             }
-                        };
-
-                        let field_col = self.at_offset(field.offset, dtype)?;
-                        return Ok(Py::new(py, field_col)?.into());
+                            _ => {
+                                let field_col = self.at_offset_typed(
+                                    field.offset,
+                                    Some(field.field_type.to_field_type()),
+                                )?;
+                                return Ok(Py::new(py, field_col)?.into());
+                            }
+                        }
                     }
                 }
 
@@ -500,40 +528,32 @@ impl PyViewColumn {
         let viewcolumn_accessors = py.import("pybevy.ecs.view_accessors")?;
 
         match name {
-            // Transform fields (Bevy layout: rotation @ 0, translation @ 16, scale @ 28)
+            // Transform fields — offsets derived from the actual type, validated by layout_assertions.rs
             "rotation" => {
-                let quat_col = self.at_offset(0, "struct")?;
+                let quat_col = self
+                    .at_offset_typed(mem::offset_of!(Transform, rotation), Some(FieldType::Vec4))?;
                 let quat_wrapper = viewcolumn_accessors.getattr("QuatViewColumn")?;
                 Ok(quat_wrapper.call1((quat_col,))?.into())
             }
             "translation" => {
-                let vec3_col = self.at_offset(16, "struct")?;
+                let vec3_col = self.at_offset_typed(
+                    mem::offset_of!(Transform, translation),
+                    Some(FieldType::Vec3),
+                )?;
                 let vec3_wrapper = viewcolumn_accessors.getattr("Vec3ViewColumn")?;
                 Ok(vec3_wrapper.call1((vec3_col,))?.into())
             }
             "scale" => {
-                let vec3_col = self.at_offset(28, "struct")?;
+                let vec3_col =
+                    self.at_offset_typed(mem::offset_of!(Transform, scale), Some(FieldType::Vec3))?;
                 let vec3_wrapper = viewcolumn_accessors.getattr("Vec3ViewColumn")?;
                 Ok(vec3_wrapper.call1((vec3_col,))?.into())
             }
-            // Vec3 fields
-            "x" => {
-                let x_col = self.at_offset(0, "f4")?;
-                Ok(Py::new(py, x_col)?.into())
-            }
-            "y" => {
-                let y_col = self.at_offset(4, "f4")?;
-                Ok(Py::new(py, y_col)?.into())
-            }
-            "z" => {
-                let z_col = self.at_offset(8, "f4")?;
-                Ok(Py::new(py, z_col)?.into())
-            }
-            // Quat w component (x, y, z already handled above)
-            "w" => {
-                let w_col = self.at_offset(12, "f4")?;
-                Ok(Py::new(py, w_col)?.into())
-            }
+            // Vec2/Vec3/Vec4 scalar sub-fields
+            "x" => Ok(Py::new(py, self.at_offset_typed(0, Some(FieldType::F32))?)?.into()),
+            "y" => Ok(Py::new(py, self.at_offset_typed(4, Some(FieldType::F32))?)?.into()),
+            "z" => Ok(Py::new(py, self.at_offset_typed(8, Some(FieldType::F32))?)?.into()),
+            "w" => Ok(Py::new(py, self.at_offset_typed(12, Some(FieldType::F32))?)?.into()),
             _ => Err(pyo3::exceptions::PyAttributeError::new_err(format!(
                 "ViewColumn has no attribute '{}'",
                 name
@@ -545,21 +565,23 @@ impl PyViewColumn {
         if self.is_valid() {
             format!(
                 "ViewColumn(len={}, stride={}, dtype='{}', valid=True)",
-                self.len, self.stride, self.dtype
+                self.len,
+                self.stride,
+                self.dtype()
             )
         } else {
             format!(
                 "ViewColumn(len={}, stride={}, dtype='{}', valid=False [STALE])",
-                self.len, self.stride, self.dtype
+                self.len,
+                self.stride,
+                self.dtype()
             )
         }
     }
 
     /// Support indexing for Numba JIT compatibility.
     fn __getitem__(&self, index: isize) -> PyResult<f64> {
-        if !self.is_valid() {
-            return Err(PyRuntimeError::new_err("Accessing stale ViewColumn!"));
-        }
+        self.check_numeric()?;
 
         let idx = if index < 0 {
             let neg_idx = (-index) as usize;
@@ -586,9 +608,7 @@ impl PyViewColumn {
 
     /// Support item assignment for Numba JIT compatibility.
     fn __setitem__(&mut self, index: isize, value: f64) -> PyResult<()> {
-        if !self.is_valid() {
-            return Err(PyRuntimeError::new_err("Accessing stale ViewColumn!"));
-        }
+        self.check_numeric()?;
 
         let idx = if index < 0 {
             let neg_idx = (-index) as usize;
@@ -623,10 +643,17 @@ impl PyViewColumn {
         if !self.is_valid() {
             return Err(PyRuntimeError::new_err("Accessing stale ViewColumn!"));
         }
-        let elem_size = Self::dtype_size(&self.dtype)?;
+        let elem_size = self
+            .field_type
+            .ok_or_else(|| {
+                PyRuntimeError::new_err("Cannot get bytes from a composite/struct column")
+            })?
+            .size_bytes();
         let mut buf = vec![0u8; self.len * elem_size];
         for i in 0..self.len {
             let dst_offset = i * elem_size;
+            // Safety: source pointer is within a valid ECS column (validity checked above);
+            // destination is within the exclusively-owned `buf`. Ranges don't overlap.
             unsafe {
                 std::ptr::copy_nonoverlapping(
                     self.ptr.add(i * self.stride),
@@ -646,7 +673,10 @@ impl PyViewColumn {
         if !self.validity_token.load(Ordering::Relaxed) {
             return Err(PyRuntimeError::new_err("Accessing stale ViewColumn!"));
         }
-        let elem_size = Self::dtype_size(&self.dtype)?;
+        let elem_size = self
+            .field_type
+            .ok_or_else(|| PyRuntimeError::new_err("Cannot write to a composite/struct column"))?
+            .size_bytes();
         let expected_len = self.len * elem_size;
         if data.len() != expected_len {
             return Err(PyRuntimeError::new_err(format!(
@@ -659,6 +689,8 @@ impl PyViewColumn {
         }
         for i in 0..self.len {
             let src_offset = i * elem_size;
+            // Safety: source is a validated slice of the correct length; destination is a
+            // valid ECS column pointer (validity checked above). Ranges don't overlap.
             unsafe {
                 std::ptr::copy_nonoverlapping(
                     data[src_offset..].as_ptr(),
@@ -908,15 +940,11 @@ impl PyViewColumn {
     /// Used by Python `__setattr__` on wrapper classes to enable:
     ///     batch.column_mut(Transform).translation.y = (col * 0.5).sin()
     pub fn set(&self, value: &Bound<PyAny>) -> PyResult<()> {
-        if !self.validity_token.load(Ordering::Relaxed) {
-            return Err(PyRuntimeError::new_err("Accessing stale ViewColumn!"));
-        }
+        self.check_numeric()?;
 
         if let Ok(col) = value.cast::<PyViewColumn>() {
             let src = col.borrow();
-            if !src.validity_token.load(Ordering::Relaxed) {
-                return Err(PyRuntimeError::new_err("Source ViewColumn is stale!"));
-            }
+            src.check_numeric()?;
             if self.len != src.len {
                 return Err(PyRuntimeError::new_err(format!(
                     "ViewColumn length mismatch: {} vs {}",


### PR DESCRIPTION
Instead of static strs in `VIEW_DTYPE`, migrate to `FieldType` as a enum-based source of truth for field types. Increase quality of variant checking.

Fixes #79 