### PR TITLE
ECS tests & bugfix in change tracking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
-  RUST_COVERAGE_THRESHOLD: 0
+  RUST_COVERAGE_THRESHOLD: 30
 
 concurrency:
   group: ${{github.workflow}}-${{github.ref}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,7 @@ jobs:
             -p pybevy_storage \
             -p pybevy_bytecodevm \
             -p pybevy_core \
+            -p pybevy_ecs \
             --summary-only 2>&1 | tee coverage-summary.txt
 
       - name: Check coverage threshold

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
-  RUST_COVERAGE_THRESHOLD: 30
+  RUST_COVERAGE_THRESHOLD: 29
 
 concurrency:
   group: ${{github.workflow}}-${{github.ref}}

--- a/crates/pybevy_ecs/src/shared/access_sets.rs
+++ b/crates/pybevy_ecs/src/shared/access_sets.rs
@@ -38,3 +38,170 @@ pub fn build_full_access_set(
     set.add(access);
     set
 }
+
+#[cfg(test)]
+mod tests {
+    use bevy::ecs::{component::Component, world::World};
+
+    use super::*;
+
+    #[derive(Component)]
+    struct A;
+    #[derive(Component)]
+    struct B;
+    #[derive(Component)]
+    struct C;
+
+    fn ids(world: &mut World) -> (ComponentId, ComponentId, ComponentId) {
+        (
+            world.register_component::<A>(),
+            world.register_component::<B>(),
+            world.register_component::<C>(),
+        )
+    }
+
+    #[test]
+    fn empty_inputs_produces_empty_set() {
+        let set = build_full_access_set(&[], &[], &[], &[], &[]);
+        assert!(!set.combined_access().has_any_component_read());
+        assert!(!set.combined_access().has_any_component_write());
+    }
+
+    #[test]
+    fn read_components_registered() {
+        let mut world = World::new();
+        let (a, b, _) = ids(&mut world);
+
+        let set = build_full_access_set(&[a, b], &[], &[], &[], &[]);
+        let combined = set.combined_access();
+        assert!(combined.has_component_read(a));
+        assert!(combined.has_component_read(b));
+        assert!(!combined.has_component_write(a));
+    }
+
+    #[test]
+    fn write_components_registered() {
+        let mut world = World::new();
+        let (a, _, _) = ids(&mut world);
+
+        let set = build_full_access_set(&[], &[a], &[], &[], &[]);
+        let combined = set.combined_access();
+        assert!(combined.has_component_write(a));
+    }
+
+    #[test]
+    fn read_and_write_together() {
+        let mut world = World::new();
+        let (a, b, _) = ids(&mut world);
+
+        let set = build_full_access_set(&[a], &[b], &[], &[], &[]);
+        let combined = set.combined_access();
+        assert!(combined.has_component_read(a));
+        assert!(combined.has_component_write(b));
+        assert!(!combined.has_component_write(a));
+    }
+
+    #[test]
+    fn unrelated_component_not_registered() {
+        let mut world = World::new();
+        let (a, b, _) = ids(&mut world);
+
+        let set = build_full_access_set(&[a], &[], &[], &[], &[]);
+        let combined = set.combined_access();
+        assert!(!combined.has_component_read(b));
+    }
+
+    #[test]
+    fn full_access_set_all_fields() {
+        let mut world = World::new();
+        let (a, b, c) = ids(&mut world);
+
+        // a: component read, b: component write, c: resource read
+        // also register a as resource write to test resource tracking
+        let set = build_full_access_set(&[a], &[b], &[], &[c], &[a]);
+        let combined = set.combined_access();
+        assert!(combined.has_component_read(a));
+        assert!(combined.has_component_write(b));
+        assert!(!combined.has_component_read(c));
+        assert!(combined.has_resource_read(c));
+        assert!(combined.has_resource_write(a));
+        assert!(!combined.has_resource_read(b));
+    }
+
+    #[test]
+    fn resource_read_registered() {
+        let mut world = World::new();
+        let (a, _, _) = ids(&mut world);
+
+        let set = build_full_access_set(&[], &[], &[], &[a], &[]);
+        let combined = set.combined_access();
+        assert!(combined.has_resource_read(a));
+        assert!(!combined.has_resource_write(a));
+    }
+
+    #[test]
+    fn resource_write_registered() {
+        let mut world = World::new();
+        let (a, _, _) = ids(&mut world);
+
+        let set = build_full_access_set(&[], &[], &[], &[], &[a]);
+        let combined = set.combined_access();
+        assert!(combined.has_resource_write(a));
+    }
+
+    #[test]
+    fn resource_and_component_together() {
+        let mut world = World::new();
+        let (a, b, _) = ids(&mut world);
+
+        let set = build_full_access_set(&[a], &[], &[], &[], &[b]);
+        let combined = set.combined_access();
+        assert!(combined.has_component_read(a));
+        assert!(combined.has_resource_write(b));
+    }
+
+    #[test]
+    fn two_resource_write_sets_conflict() {
+        let mut world = World::new();
+        let (a, _, _) = ids(&mut world);
+
+        let set1 = build_full_access_set(&[], &[], &[], &[], &[a]);
+        let set2 = build_full_access_set(&[], &[], &[], &[], &[a]);
+
+        // Combined access of set1 should conflict with set2's access
+        assert!(!set1.is_compatible(&set2));
+    }
+
+    #[test]
+    fn resource_read_and_write_conflict() {
+        let mut world = World::new();
+        let (a, _, _) = ids(&mut world);
+
+        let set1 = build_full_access_set(&[], &[], &[], &[a], &[]);
+        let set2 = build_full_access_set(&[], &[], &[], &[], &[a]);
+
+        assert!(!set1.is_compatible(&set2));
+    }
+
+    #[test]
+    fn resource_reads_compatible() {
+        let mut world = World::new();
+        let (a, _, _) = ids(&mut world);
+
+        let set1 = build_full_access_set(&[], &[], &[], &[a], &[]);
+        let set2 = build_full_access_set(&[], &[], &[], &[a], &[]);
+
+        assert!(set1.is_compatible(&set2));
+    }
+
+    #[test]
+    fn different_resources_write_compatible() {
+        let mut world = World::new();
+        let (a, b, _) = ids(&mut world);
+
+        let set1 = build_full_access_set(&[], &[], &[], &[], &[a]);
+        let set2 = build_full_access_set(&[], &[], &[], &[], &[b]);
+
+        assert!(set1.is_compatible(&set2));
+    }
+}

--- a/crates/pybevy_ecs/src/shared/access_validation.rs
+++ b/crates/pybevy_ecs/src/shared/access_validation.rs
@@ -262,3 +262,453 @@ pub fn validate_access<K: std::hash::Hash + Eq + Clone>(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn filters(with: &[&str], without: &[&str]) -> QueryFilters {
+        QueryFilters {
+            with: with.iter().map(|s| s.to_string()).collect(),
+            without: without.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    fn comp(key: &str, mutable: bool) -> ComponentAccess<String> {
+        ComponentAccess {
+            key: key.to_string(),
+            name: key.to_string(),
+            mutable,
+        }
+    }
+
+    fn query(components: Vec<ComponentAccess<String>>, f: QueryFilters) -> ParamAccess<String> {
+        ParamAccess::Components {
+            accesses: components,
+            filters: f,
+        }
+    }
+
+    fn res(key: usize, name: &str, mutable: bool) -> ParamAccess<String> {
+        ParamAccess::Resource {
+            key,
+            name: name.to_string(),
+            mutable,
+        }
+    }
+
+    fn assets(key: &str, mutable: bool) -> ParamAccess<String> {
+        ParamAccess::Assets {
+            key: key.to_string(),
+            name: key.to_string(),
+            mutable,
+        }
+    }
+
+    #[test]
+    fn empty_filters_not_disjoint() {
+        let a = QueryFilters::default();
+        let b = QueryFilters::default();
+        assert!(!a.is_disjoint_from(&b));
+    }
+
+    #[test]
+    fn with_vs_without_is_disjoint() {
+        let a = filters(&["Transform"], &[]);
+        let b = filters(&[], &["Transform"]);
+        assert!(a.is_disjoint_from(&b));
+    }
+
+    #[test]
+    fn without_vs_with_is_disjoint() {
+        let a = filters(&[], &["Transform"]);
+        let b = filters(&["Transform"], &[]);
+        assert!(a.is_disjoint_from(&b));
+    }
+
+    #[test]
+    fn same_with_not_disjoint() {
+        let a = filters(&["Transform"], &[]);
+        let b = filters(&["Transform"], &[]);
+        assert!(!a.is_disjoint_from(&b));
+    }
+
+    #[test]
+    fn unrelated_filters_not_disjoint() {
+        let a = filters(&["Transform"], &[]);
+        let b = filters(&["Velocity"], &[]);
+        assert!(!a.is_disjoint_from(&b));
+    }
+
+    #[test]
+    fn partial_overlap_disjoint() {
+        // A: With[Player, Transform], Without[]
+        // B: With[Enemy], Without[Player]
+        // Player in A's with, Player in B's without → disjoint
+        let a = filters(&["Player", "Transform"], &[]);
+        let b = filters(&["Enemy"], &["Player"]);
+        assert!(a.is_disjoint_from(&b));
+    }
+
+    #[test]
+    fn empty_params_ok() {
+        assert!(validate_access::<String>(&[]).is_ok());
+    }
+
+    #[test]
+    fn single_readonly_query_ok() {
+        let params = [query(
+            vec![comp("Transform", false)],
+            filters(&["Transform"], &[]),
+        )];
+        assert!(validate_access(&params).is_ok());
+    }
+
+    #[test]
+    fn none_params_ignored() {
+        let params = [ParamAccess::<String>::None, ParamAccess::None];
+        assert!(validate_access(&params).is_ok());
+    }
+
+    #[test]
+    fn two_readonly_same_component_ok() {
+        let params = [
+            query(vec![comp("Transform", false)], filters(&["Transform"], &[])),
+            query(vec![comp("Transform", false)], filters(&["Transform"], &[])),
+        ];
+        assert!(validate_access(&params).is_ok());
+    }
+
+    #[test]
+    fn read_and_mut_same_component_conflicts() {
+        let params = [
+            query(vec![comp("Transform", false)], filters(&["Transform"], &[])),
+            query(vec![comp("Transform", true)], filters(&["Transform"], &[])),
+        ];
+        let err = validate_access(&params).unwrap_err();
+        assert_eq!(err.param_idx, 1);
+        assert_eq!(err.existing_idx, 0);
+        assert!(err.mutable);
+        assert_eq!(err.comp_name, "Transform");
+    }
+
+    #[test]
+    fn two_mut_same_component_conflicts() {
+        let params = [
+            query(vec![comp("Transform", true)], filters(&["Transform"], &[])),
+            query(vec![comp("Transform", true)], filters(&["Transform"], &[])),
+        ];
+        let err = validate_access(&params).unwrap_err();
+        assert_eq!(err.param_idx, 1);
+        assert_eq!(err.existing_idx, 0);
+    }
+
+    #[test]
+    fn mut_overlap_with_disjoint_filters_ok() {
+        // Query[Mut[Transform], With[Player]] vs Query[Mut[Transform], With[Enemy]]
+        // Disjoint because Player in A's With, Player absent from B → not disjoint
+        // BUT: With[Player] vs Without[Player] would be disjoint
+        // Actually need: A With[Player], B Without[Player]
+        let params = [
+            query(
+                vec![comp("Transform", true)],
+                filters(&["Transform", "Player"], &[]),
+            ),
+            query(
+                vec![comp("Transform", true)],
+                filters(&["Transform"], &["Player"]),
+            ),
+        ];
+        assert!(validate_access(&params).is_ok());
+    }
+
+    #[test]
+    fn mut_overlap_non_disjoint_filters_conflicts() {
+        // Both have With[Player] — not disjoint
+        let params = [
+            query(
+                vec![comp("Transform", true)],
+                filters(&["Transform", "Player"], &[]),
+            ),
+            query(
+                vec![comp("Transform", true)],
+                filters(&["Transform", "Player"], &[]),
+            ),
+        ];
+        assert!(validate_access(&params).is_err());
+    }
+
+    #[test]
+    fn different_components_ok() {
+        let params = [
+            query(vec![comp("Transform", true)], filters(&["Transform"], &[])),
+            query(vec![comp("Velocity", true)], filters(&["Velocity"], &[])),
+        ];
+        assert!(validate_access(&params).is_ok());
+    }
+
+    #[test]
+    fn multi_component_query_partial_overlap_conflicts() {
+        // Query[Mut[Transform], Velocity] vs Query[Mut[Transform], Health]
+        // Transform is mut in both → conflict
+        let params = [
+            query(
+                vec![comp("Transform", true), comp("Velocity", false)],
+                filters(&["Transform", "Velocity"], &[]),
+            ),
+            query(
+                vec![comp("Transform", true), comp("Health", false)],
+                filters(&["Transform", "Health"], &[]),
+            ),
+        ];
+        let err = validate_access(&params).unwrap_err();
+        assert_eq!(err.comp_name, "Transform");
+    }
+
+    #[test]
+    fn three_way_conflict_detected() {
+        // A: read Transform, B: read Transform, C: mut Transform
+        // A-B ok, A-C conflict (or B-C conflict — C is param_idx=2)
+        let params = [
+            query(vec![comp("Transform", false)], filters(&["Transform"], &[])),
+            query(vec![comp("Transform", false)], filters(&["Transform"], &[])),
+            query(vec![comp("Transform", true)], filters(&["Transform"], &[])),
+        ];
+        let err = validate_access(&params).unwrap_err();
+        assert_eq!(err.param_idx, 2);
+        // Conflicts with first reader (idx 0)
+        assert_eq!(err.existing_idx, 0);
+    }
+
+    #[test]
+    fn two_res_same_resource_ok() {
+        let params = [res(1, "Time", false), res(1, "Time", false)];
+        assert!(validate_access(&params).is_ok());
+    }
+
+    #[test]
+    fn res_and_resmut_same_resource_conflicts() {
+        let params = [res(1, "Time", false), res(1, "Time", true)];
+        let err = validate_access(&params).unwrap_err();
+        assert_eq!(err.param_idx, 1);
+        assert_eq!(err.existing_idx, 0);
+        assert!(err.mutable);
+    }
+
+    #[test]
+    fn resmut_and_res_same_resource_conflicts() {
+        let params = [res(1, "Time", true), res(1, "Time", false)];
+        let err = validate_access(&params).unwrap_err();
+        assert_eq!(err.param_idx, 1);
+        assert_eq!(err.existing_idx, 0);
+    }
+
+    #[test]
+    fn two_resmut_same_resource_conflicts() {
+        let params = [res(1, "Time", true), res(1, "Time", true)];
+        assert!(validate_access(&params).is_err());
+    }
+
+    #[test]
+    fn different_resources_ok() {
+        let params = [res(1, "Time", true), res(2, "Score", true)];
+        assert!(validate_access(&params).is_ok());
+    }
+
+    #[test]
+    fn two_res_assets_same_type_ok() {
+        let params = [assets("Mesh", false), assets("Mesh", false)];
+        assert!(validate_access(&params).is_ok());
+    }
+
+    #[test]
+    fn res_and_resmut_assets_same_type_conflicts() {
+        let params = [assets("Mesh", false), assets("Mesh", true)];
+        let err = validate_access(&params).unwrap_err();
+        assert_eq!(err.param_idx, 1);
+        assert!(err.comp_name.contains("Mesh"));
+    }
+
+    #[test]
+    fn different_asset_types_ok() {
+        let params = [assets("Mesh", true), assets("StandardMaterial", true)];
+        assert!(validate_access(&params).is_ok());
+    }
+
+    #[test]
+    fn world_alone_ok() {
+        let params = [ParamAccess::<String>::World];
+        assert!(validate_access(&params).is_ok());
+    }
+
+    #[test]
+    fn world_with_none_ok() {
+        let params = [ParamAccess::<String>::World, ParamAccess::None];
+        assert!(validate_access(&params).is_ok());
+    }
+
+    #[test]
+    fn world_after_query_conflicts() {
+        let params = [
+            query(vec![comp("Transform", false)], filters(&["Transform"], &[])),
+            ParamAccess::World,
+        ];
+        let err = validate_access(&params).unwrap_err();
+        assert_eq!(err.param_idx, 1);
+        assert_eq!(err.comp_name, "World");
+    }
+
+    #[test]
+    fn query_after_world_conflicts() {
+        let params = [
+            ParamAccess::World,
+            query(vec![comp("Transform", false)], filters(&["Transform"], &[])),
+        ];
+        let err = validate_access(&params).unwrap_err();
+        assert_eq!(err.param_idx, 1);
+        assert_eq!(err.existing_name, "World");
+    }
+
+    #[test]
+    fn world_after_res_conflicts() {
+        let params = [res(1, "Time", false), ParamAccess::World];
+        let err = validate_access(&params).unwrap_err();
+        assert_eq!(err.comp_name, "World");
+    }
+
+    #[test]
+    fn res_after_world_conflicts() {
+        let params = [ParamAccess::World, res(1, "Time", false)];
+        let err = validate_access(&params).unwrap_err();
+        assert_eq!(err.existing_name, "World");
+    }
+
+    #[test]
+    fn world_after_assets_conflicts() {
+        let params = [assets("Mesh", false), ParamAccess::World];
+        assert!(validate_access(&params).is_err());
+    }
+
+    #[test]
+    fn assets_after_world_conflicts() {
+        let params = [ParamAccess::World, assets("Mesh", false)];
+        let err = validate_access(&params).unwrap_err();
+        assert_eq!(err.existing_name, "World");
+    }
+
+    #[test]
+    fn two_worlds_conflict() {
+        let params = [ParamAccess::<String>::World, ParamAccess::World];
+        let err = validate_access(&params).unwrap_err();
+        assert_eq!(err.param_idx, 1);
+        assert_eq!(err.existing_idx, 0);
+        assert_eq!(err.comp_name, "World");
+        assert_eq!(err.existing_name, "World");
+    }
+
+    #[test]
+    fn query_plus_res_plus_commands_ok() {
+        let params = [
+            query(vec![comp("Transform", true)], filters(&["Transform"], &[])),
+            res(1, "Time", false),
+            ParamAccess::None, // Commands
+        ];
+        assert!(validate_access(&params).is_ok());
+    }
+
+    #[test]
+    fn query_plus_different_assets_ok() {
+        let params = [
+            query(vec![comp("Transform", true)], filters(&["Transform"], &[])),
+            assets("Mesh", true),
+            assets("StandardMaterial", false),
+            res(1, "Time", false),
+        ];
+        assert!(validate_access(&params).is_ok());
+    }
+
+    #[test]
+    fn complex_disjoint_system_ok() {
+        // Simulates: fn sys(
+        //   q1: Query[Mut[Transform], With[Player]],
+        //   q2: Query[Mut[Transform], Without[Player]],
+        //   time: Res[Time],
+        //   commands: Commands,
+        // )
+        let params = [
+            query(
+                vec![comp("Transform", true)],
+                filters(&["Transform", "Player"], &[]),
+            ),
+            query(
+                vec![comp("Transform", true)],
+                filters(&["Transform"], &["Player"]),
+            ),
+            res(1, "Time", false),
+            ParamAccess::None,
+        ];
+        assert!(validate_access(&params).is_ok());
+    }
+
+    #[test]
+    fn conflict_reports_correct_indices() {
+        // params: [None, Res(Time, ro), None, ResMut(Time)]
+        let params = [
+            ParamAccess::<String>::None,
+            res(1, "Time", false),
+            ParamAccess::None,
+            res(1, "Time", true),
+        ];
+        let err = validate_access(&params).unwrap_err();
+        assert_eq!(err.existing_idx, 1);
+        assert_eq!(err.param_idx, 3);
+    }
+
+    #[test]
+    fn n_way_disjoint_three_queries_ok() {
+        // Three mutually-disjoint queries on the same component:
+        //   Query[Mut[Transform], With[Player], Without[Enemy]]
+        //   Query[Mut[Transform], With[Enemy], Without[Player]]
+        //   Query[Mut[Transform], Without[Player], Without[Enemy]]
+        let params = [
+            query(
+                vec![comp("Transform", true)],
+                filters(&["Transform", "Player"], &["Enemy"]),
+            ),
+            query(
+                vec![comp("Transform", true)],
+                filters(&["Transform", "Enemy"], &["Player"]),
+            ),
+            query(
+                vec![comp("Transform", true)],
+                filters(&["Transform"], &["Player", "Enemy"]),
+            ),
+        ];
+        assert!(validate_access(&params).is_ok());
+    }
+
+    #[test]
+    fn n_way_third_query_conflicts_with_first() {
+        // Two disjoint + third overlaps with first:
+        //   Query[Mut[Transform], With[Player]]
+        //   Query[Mut[Transform], Without[Player]]  — disjoint with first
+        //   Query[Mut[Transform], With[Player]]      — conflicts with first
+        let params = [
+            query(
+                vec![comp("Transform", true)],
+                filters(&["Transform", "Player"], &[]),
+            ),
+            query(
+                vec![comp("Transform", true)],
+                filters(&["Transform"], &["Player"]),
+            ),
+            query(
+                vec![comp("Transform", true)],
+                filters(&["Transform", "Player"], &[]),
+            ),
+        ];
+        let err = validate_access(&params).unwrap_err();
+        assert_eq!(err.param_idx, 2);
+        assert_eq!(err.existing_idx, 0);
+    }
+}

--- a/crates/pybevy_ecs/src/shared/change_tracking.rs
+++ b/crates/pybevy_ecs/src/shared/change_tracking.rs
@@ -85,8 +85,9 @@ fn get_entity_context() -> (Option<Entity>, Option<*mut World>) {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use bevy::ecs::component::Component;
+
+    use super::*;
 
     #[derive(Component)]
     struct Health;
@@ -149,7 +150,10 @@ mod tests {
 
         // Before marking, component should not appear changed since last_run
         let this_run = world.read_change_tick();
-        let ticks = world.entity(entity).get_change_ticks_by_id(component_id).unwrap();
+        let ticks = world
+            .entity(entity)
+            .get_change_ticks_by_id(component_id)
+            .unwrap();
         assert!(!ticks.is_changed(last_run, this_run));
 
         // Mark it
@@ -158,7 +162,10 @@ mod tests {
 
         // Now it should appear changed
         let this_run = world.read_change_tick();
-        let ticks = world.entity(entity).get_change_ticks_by_id(component_id).unwrap();
+        let ticks = world
+            .entity(entity)
+            .get_change_ticks_by_id(component_id)
+            .unwrap();
         assert!(
             ticks.is_changed(last_run, this_run),
             "component should be marked as changed after mark_component_changed_explicit"
@@ -188,4 +195,3 @@ mod tests {
         unsafe { mark_component_changed_explicit(entity, world_ptr, component_id) };
     }
 }
-

--- a/crates/pybevy_ecs/src/shared/change_tracking.rs
+++ b/crates/pybevy_ecs/src/shared/change_tracking.rs
@@ -13,7 +13,9 @@
 
 use std::cell::Cell;
 
-use bevy::ecs::{component::ComponentId, entity::Entity, world::World};
+use bevy::ecs::{
+    change_detection::DetectChangesMut, component::ComponentId, entity::Entity, world::World,
+};
 
 thread_local! {
     /// Current entity being accessed during query iteration
@@ -58,9 +60,9 @@ pub unsafe fn mark_component_changed_explicit(
     unsafe {
         let world = &mut *world_ptr;
         if let Ok(mut entity_mut) = world.get_entity_mut(entity) {
-            // Mark component as changed by getting mutable access
-            // get_mut_by_id() triggers Bevy's DerefMut, which calls set_changed()
-            let _ = entity_mut.get_mut_by_id(component_id);
+            if let Ok(mut comp) = entity_mut.get_mut_by_id(component_id) {
+                comp.set_changed();
+            }
         }
     }
 }
@@ -72,3 +74,118 @@ pub fn clear_entity_context() {
     CURRENT_ENTITY.with(|e| e.set(None));
     WORLD_PTR.with(|w| w.set(None));
 }
+
+/// Read the current entity context (test-only).
+#[cfg(test)]
+fn get_entity_context() -> (Option<Entity>, Option<*mut World>) {
+    let entity = CURRENT_ENTITY.with(|e| e.get());
+    let world_ptr = WORLD_PTR.with(|w| w.get());
+    (entity, world_ptr)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::ecs::component::Component;
+
+    #[derive(Component)]
+    struct Health;
+
+    #[test]
+    fn context_initially_empty() {
+        clear_entity_context();
+        let (entity, world_ptr) = get_entity_context();
+        assert!(entity.is_none());
+        assert!(world_ptr.is_none());
+    }
+
+    #[test]
+    fn set_and_clear_context() {
+        let entity = Entity::from_bits(42);
+        set_entity_context(entity, std::ptr::null_mut());
+
+        let (e, w) = get_entity_context();
+        assert_eq!(e, Some(entity));
+        assert!(w.is_some());
+
+        clear_entity_context();
+        let (e, w) = get_entity_context();
+        assert!(e.is_none());
+        assert!(w.is_none());
+    }
+
+    #[test]
+    fn set_overwrites_previous_context() {
+        let a = Entity::from_bits(10);
+        let b = Entity::from_bits(20);
+
+        set_entity_context(a, std::ptr::null_mut());
+        set_entity_context(b, std::ptr::null_mut());
+
+        let (e, _) = get_entity_context();
+        assert_eq!(e, Some(b));
+
+        clear_entity_context();
+    }
+
+    #[test]
+    fn clear_is_idempotent() {
+        clear_entity_context();
+        clear_entity_context();
+        let (e, _) = get_entity_context();
+        assert!(e.is_none());
+    }
+
+    #[test]
+    fn mark_changed_updates_change_tick() {
+        let mut world = World::new();
+        let component_id = world.register_component::<Health>();
+        let entity = world.spawn(Health).id();
+
+        // Advance change ticks so the initial "added" change is in the past
+        let last_run = world.read_change_tick();
+        world.increment_change_tick();
+        world.increment_change_tick();
+
+        // Before marking, component should not appear changed since last_run
+        let this_run = world.read_change_tick();
+        let ticks = world.entity(entity).get_change_ticks_by_id(component_id).unwrap();
+        assert!(!ticks.is_changed(last_run, this_run));
+
+        // Mark it
+        let world_ptr: *mut World = &mut world;
+        unsafe { mark_component_changed_explicit(entity, world_ptr, component_id) };
+
+        // Now it should appear changed
+        let this_run = world.read_change_tick();
+        let ticks = world.entity(entity).get_change_ticks_by_id(component_id).unwrap();
+        assert!(
+            ticks.is_changed(last_run, this_run),
+            "component should be marked as changed after mark_component_changed_explicit"
+        );
+    }
+
+    #[test]
+    fn mark_changed_nonexistent_entity_does_not_panic() {
+        let mut world = World::new();
+        let component_id = world.register_component::<Health>();
+        let entity = Entity::from_bits(9999);
+
+        let world_ptr: *mut World = &mut world;
+        // Should silently do nothing
+        unsafe { mark_component_changed_explicit(entity, world_ptr, component_id) };
+    }
+
+    #[test]
+    fn mark_changed_missing_component_does_not_panic() {
+        let mut world = World::new();
+        let component_id = world.register_component::<Health>();
+        // Spawn entity without Health
+        let entity = world.spawn_empty().id();
+
+        let world_ptr: *mut World = &mut world;
+        // Should silently do nothing
+        unsafe { mark_component_changed_explicit(entity, world_ptr, component_id) };
+    }
+}
+

--- a/crates/pybevy_ecs/src/shared/command_queue_helpers.rs
+++ b/crates/pybevy_ecs/src/shared/command_queue_helpers.rs
@@ -17,3 +17,32 @@ pub fn create_commands_from_queue<'a>(
     let entities = world.entities();
     Commands::new_from_entities(queue, allocator, entities)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::ecs::{component::Component, world::World};
+
+    #[derive(Component)]
+    struct Marker;
+
+    #[test]
+    fn commands_can_spawn_and_flush() {
+        let mut world = World::new();
+        let mut queue = CommandQueue::default();
+
+        // Create commands and spawn an entity
+        {
+            let cell = world.as_unsafe_world_cell();
+            let mut commands = create_commands_from_queue(&mut queue, cell);
+            commands.spawn(Marker);
+        }
+
+        // Before flush, entity shouldn't exist yet
+        assert_eq!(world.query::<&Marker>().iter(&world).count(), 0);
+
+        // After flush, entity should exist
+        queue.apply(&mut world);
+        assert_eq!(world.query::<&Marker>().iter(&world).count(), 1);
+    }
+}

--- a/crates/pybevy_ecs/src/shared/command_queue_helpers.rs
+++ b/crates/pybevy_ecs/src/shared/command_queue_helpers.rs
@@ -20,8 +20,9 @@ pub fn create_commands_from_queue<'a>(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use bevy::ecs::{component::Component, world::World};
+
+    use super::*;
 
     #[derive(Component)]
     struct Marker;

--- a/crates/pybevy_ecs/src/shared/query_builder_ext.rs
+++ b/crates/pybevy_ecs/src/shared/query_builder_ext.rs
@@ -64,16 +64,14 @@ fn apply_filters<D: QueryData>(builder: &mut QueryBuilder<D>, spec: &QueryBuildS
     }
 }
 
-/// Build a Bevy `QueryState<FilteredEntityMut>` from a specification.
+/// Configure a `QueryBuilder<FilteredEntityMut>` from a specification.
 ///
-/// Callers resolve their parameter types to `ComponentId`s, then call this
-/// function to build the QueryState.
-pub fn build_query_state<'a>(
-    world: &'a mut World,
+/// Registers component access (ref or mut, required or optional) and applies
+/// all filters. Call `builder.build()` afterwards to obtain the `QueryState`.
+pub fn configure_mut_query(
+    builder: &mut QueryBuilder<FilteredEntityMut>,
     spec: &QueryBuildSpec,
-) -> QueryState<FilteredEntityMut<'a, 'a>> {
-    let mut builder = QueryBuilder::<FilteredEntityMut>::new(world);
-
+) {
     for comp in &spec.components {
         if comp.optional {
             builder.optional(|b| {
@@ -90,7 +88,43 @@ pub fn build_query_state<'a>(
         }
     }
 
-    apply_filters(&mut builder, spec);
+    apply_filters(builder, spec);
+}
+
+/// Configure a `QueryBuilder<FilteredEntityRef>` from a read-only specification.
+///
+/// This should only be called when `spec.is_read_only()` returns true.
+pub fn configure_ref_query(
+    builder: &mut QueryBuilder<FilteredEntityRef>,
+    spec: &QueryBuildSpec,
+) {
+    for comp in &spec.components {
+        debug_assert!(
+            !comp.mutable,
+            "configure_ref_query called with mutable component"
+        );
+        if comp.optional {
+            builder.optional(|b| {
+                b.ref_id(comp.id);
+            });
+        } else {
+            builder.ref_id(comp.id);
+        }
+    }
+
+    apply_filters(builder, spec);
+}
+
+/// Build a Bevy `QueryState<FilteredEntityMut>` from a specification.
+///
+/// Callers resolve their parameter types to `ComponentId`s, then call this
+/// function to build the QueryState.
+pub fn build_query_state<'a>(
+    world: &'a mut World,
+    spec: &QueryBuildSpec,
+) -> QueryState<FilteredEntityMut<'a, 'a>> {
+    let mut builder = QueryBuilder::<FilteredEntityMut>::new(world);
+    configure_mut_query(&mut builder, spec);
     builder.build()
 }
 
@@ -104,21 +138,193 @@ pub fn build_query_state_ref<'a>(
     spec: &QueryBuildSpec,
 ) -> QueryState<FilteredEntityRef<'a, 'a>> {
     let mut builder = QueryBuilder::<FilteredEntityRef>::new(world);
+    configure_ref_query(&mut builder, spec);
+    builder.build()
+}
 
-    for comp in &spec.components {
-        debug_assert!(
-            !comp.mutable,
-            "build_query_state_ref called with mutable component"
-        );
-        if comp.optional {
-            builder.optional(|b| {
-                b.ref_id(comp.id);
-            });
-        } else {
-            builder.ref_id(comp.id);
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::ecs::component::Component;
+
+    #[derive(Component)]
+    struct A;
+    #[derive(Component)]
+    struct B;
+    #[derive(Component)]
+    struct C;
+
+    fn ids(world: &mut World) -> (ComponentId, ComponentId, ComponentId) {
+        (
+            world.register_component::<A>(),
+            world.register_component::<B>(),
+            world.register_component::<C>(),
+        )
+    }
+
+    fn spec_with(components: Vec<QueryComponent>) -> QueryBuildSpec {
+        QueryBuildSpec {
+            components,
+            with_filters: vec![],
+            without_filters: vec![],
+            changed_filters: vec![],
+            added_filters: vec![],
+            anyof_filters: vec![],
         }
     }
 
-    apply_filters(&mut builder, spec);
-    builder.build()
+    #[test]
+    fn is_read_only_empty() {
+        let spec = spec_with(vec![]);
+        assert!(spec.is_read_only());
+    }
+
+    #[test]
+    fn is_read_only_all_refs() {
+        let mut world = World::new();
+        let (a, b, _) = ids(&mut world);
+        let spec = spec_with(vec![
+            QueryComponent { id: a, optional: false, mutable: false },
+            QueryComponent { id: b, optional: false, mutable: false },
+        ]);
+        assert!(spec.is_read_only());
+    }
+
+    #[test]
+    fn is_read_only_one_mutable() {
+        let mut world = World::new();
+        let (a, b, _) = ids(&mut world);
+        let spec = spec_with(vec![
+            QueryComponent { id: a, optional: false, mutable: false },
+            QueryComponent { id: b, optional: false, mutable: true },
+        ]);
+        assert!(!spec.is_read_only());
+    }
+
+    #[test]
+    fn build_query_matches_entities() {
+        let mut world = World::new();
+        let (a_id, _, _) = ids(&mut world);
+
+        world.spawn(A);
+        world.spawn(B); // should not match
+        world.spawn((A, B));
+
+        let spec = spec_with(vec![
+            QueryComponent { id: a_id, optional: false, mutable: false },
+        ]);
+        let mut builder = QueryBuilder::<FilteredEntityRef>::new(&mut world);
+        configure_ref_query(&mut builder, &spec);
+        let mut state = builder.build();
+        assert_eq!(state.iter(&world).count(), 2);
+    }
+
+    #[test]
+    fn build_query_with_filter() {
+        let mut world = World::new();
+        let (a_id, b_id, _) = ids(&mut world);
+
+        world.spawn(A);
+        world.spawn((A, B));
+
+        let spec = QueryBuildSpec {
+            components: vec![
+                QueryComponent { id: a_id, optional: false, mutable: false },
+            ],
+            with_filters: vec![b_id],
+            without_filters: vec![],
+            changed_filters: vec![],
+            added_filters: vec![],
+            anyof_filters: vec![],
+        };
+        let mut builder = QueryBuilder::<FilteredEntityRef>::new(&mut world);
+        configure_ref_query(&mut builder, &spec);
+        let mut state = builder.build();
+        assert_eq!(state.iter(&world).count(), 1);
+    }
+
+    #[test]
+    fn build_query_without_filter() {
+        let mut world = World::new();
+        let (a_id, b_id, _) = ids(&mut world);
+
+        world.spawn(A);
+        world.spawn((A, B));
+
+        let spec = QueryBuildSpec {
+            components: vec![
+                QueryComponent { id: a_id, optional: false, mutable: false },
+            ],
+            with_filters: vec![],
+            without_filters: vec![b_id],
+            changed_filters: vec![],
+            added_filters: vec![],
+            anyof_filters: vec![],
+        };
+        let mut builder = QueryBuilder::<FilteredEntityRef>::new(&mut world);
+        configure_ref_query(&mut builder, &spec);
+        let mut state = builder.build();
+        assert_eq!(state.iter(&world).count(), 1);
+    }
+
+    #[test]
+    fn build_query_optional_component() {
+        let mut world = World::new();
+        let (a_id, b_id, _) = ids(&mut world);
+
+        world.spawn(A);
+        world.spawn((A, B));
+
+        // A required, B optional - should match both entities
+        let spec = spec_with(vec![
+            QueryComponent { id: a_id, optional: false, mutable: false },
+            QueryComponent { id: b_id, optional: true, mutable: false },
+        ]);
+        let mut builder = QueryBuilder::<FilteredEntityRef>::new(&mut world);
+        configure_ref_query(&mut builder, &spec);
+        let mut state = builder.build();
+        assert_eq!(state.iter(&world).count(), 2);
+    }
+
+    #[test]
+    fn build_query_mutable_access() {
+        let mut world = World::new();
+        let (a_id, _, _) = ids(&mut world);
+
+        world.spawn(A);
+
+        let spec = spec_with(vec![
+            QueryComponent { id: a_id, optional: false, mutable: true },
+        ]);
+        let mut builder = QueryBuilder::<FilteredEntityMut>::new(&mut world);
+        configure_mut_query(&mut builder, &spec);
+        let mut state = builder.build();
+        assert_eq!(state.iter_mut(&mut world).count(), 1);
+    }
+
+    #[test]
+    fn build_query_anyof_filter() {
+        let mut world = World::new();
+        let (a_id, b_id, c_id) = ids(&mut world);
+
+        world.spawn(A);         // has A but no B or C -> no match
+        world.spawn((A, B));    // has B -> matches
+        world.spawn((A, C));    // has C -> matches
+        world.spawn(B);         // no A -> no match
+
+        let spec = QueryBuildSpec {
+            components: vec![
+                QueryComponent { id: a_id, optional: false, mutable: false },
+            ],
+            with_filters: vec![],
+            without_filters: vec![],
+            changed_filters: vec![],
+            added_filters: vec![],
+            anyof_filters: vec![b_id, c_id],
+        };
+        let mut builder = QueryBuilder::<FilteredEntityRef>::new(&mut world);
+        configure_ref_query(&mut builder, &spec);
+        let mut state = builder.build();
+        assert_eq!(state.iter(&world).count(), 2);
+    }
 }

--- a/crates/pybevy_ecs/src/shared/query_builder_ext.rs
+++ b/crates/pybevy_ecs/src/shared/query_builder_ext.rs
@@ -68,10 +68,7 @@ fn apply_filters<D: QueryData>(builder: &mut QueryBuilder<D>, spec: &QueryBuildS
 ///
 /// Registers component access (ref or mut, required or optional) and applies
 /// all filters. Call `builder.build()` afterwards to obtain the `QueryState`.
-pub fn configure_mut_query(
-    builder: &mut QueryBuilder<FilteredEntityMut>,
-    spec: &QueryBuildSpec,
-) {
+pub fn configure_mut_query(builder: &mut QueryBuilder<FilteredEntityMut>, spec: &QueryBuildSpec) {
     for comp in &spec.components {
         if comp.optional {
             builder.optional(|b| {
@@ -94,10 +91,7 @@ pub fn configure_mut_query(
 /// Configure a `QueryBuilder<FilteredEntityRef>` from a read-only specification.
 ///
 /// This should only be called when `spec.is_read_only()` returns true.
-pub fn configure_ref_query(
-    builder: &mut QueryBuilder<FilteredEntityRef>,
-    spec: &QueryBuildSpec,
-) {
+pub fn configure_ref_query(builder: &mut QueryBuilder<FilteredEntityRef>, spec: &QueryBuildSpec) {
     for comp in &spec.components {
         debug_assert!(
             !comp.mutable,
@@ -144,8 +138,9 @@ pub fn build_query_state_ref<'a>(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use bevy::ecs::component::Component;
+
+    use super::*;
 
     #[derive(Component)]
     struct A;
@@ -184,8 +179,16 @@ mod tests {
         let mut world = World::new();
         let (a, b, _) = ids(&mut world);
         let spec = spec_with(vec![
-            QueryComponent { id: a, optional: false, mutable: false },
-            QueryComponent { id: b, optional: false, mutable: false },
+            QueryComponent {
+                id: a,
+                optional: false,
+                mutable: false,
+            },
+            QueryComponent {
+                id: b,
+                optional: false,
+                mutable: false,
+            },
         ]);
         assert!(spec.is_read_only());
     }
@@ -195,8 +198,16 @@ mod tests {
         let mut world = World::new();
         let (a, b, _) = ids(&mut world);
         let spec = spec_with(vec![
-            QueryComponent { id: a, optional: false, mutable: false },
-            QueryComponent { id: b, optional: false, mutable: true },
+            QueryComponent {
+                id: a,
+                optional: false,
+                mutable: false,
+            },
+            QueryComponent {
+                id: b,
+                optional: false,
+                mutable: true,
+            },
         ]);
         assert!(!spec.is_read_only());
     }
@@ -210,9 +221,11 @@ mod tests {
         world.spawn(B); // should not match
         world.spawn((A, B));
 
-        let spec = spec_with(vec![
-            QueryComponent { id: a_id, optional: false, mutable: false },
-        ]);
+        let spec = spec_with(vec![QueryComponent {
+            id: a_id,
+            optional: false,
+            mutable: false,
+        }]);
         let mut builder = QueryBuilder::<FilteredEntityRef>::new(&mut world);
         configure_ref_query(&mut builder, &spec);
         let mut state = builder.build();
@@ -228,9 +241,11 @@ mod tests {
         world.spawn((A, B));
 
         let spec = QueryBuildSpec {
-            components: vec![
-                QueryComponent { id: a_id, optional: false, mutable: false },
-            ],
+            components: vec![QueryComponent {
+                id: a_id,
+                optional: false,
+                mutable: false,
+            }],
             with_filters: vec![b_id],
             without_filters: vec![],
             changed_filters: vec![],
@@ -252,9 +267,11 @@ mod tests {
         world.spawn((A, B));
 
         let spec = QueryBuildSpec {
-            components: vec![
-                QueryComponent { id: a_id, optional: false, mutable: false },
-            ],
+            components: vec![QueryComponent {
+                id: a_id,
+                optional: false,
+                mutable: false,
+            }],
             with_filters: vec![],
             without_filters: vec![b_id],
             changed_filters: vec![],
@@ -277,8 +294,16 @@ mod tests {
 
         // A required, B optional - should match both entities
         let spec = spec_with(vec![
-            QueryComponent { id: a_id, optional: false, mutable: false },
-            QueryComponent { id: b_id, optional: true, mutable: false },
+            QueryComponent {
+                id: a_id,
+                optional: false,
+                mutable: false,
+            },
+            QueryComponent {
+                id: b_id,
+                optional: true,
+                mutable: false,
+            },
         ]);
         let mut builder = QueryBuilder::<FilteredEntityRef>::new(&mut world);
         configure_ref_query(&mut builder, &spec);
@@ -293,9 +318,11 @@ mod tests {
 
         world.spawn(A);
 
-        let spec = spec_with(vec![
-            QueryComponent { id: a_id, optional: false, mutable: true },
-        ]);
+        let spec = spec_with(vec![QueryComponent {
+            id: a_id,
+            optional: false,
+            mutable: true,
+        }]);
         let mut builder = QueryBuilder::<FilteredEntityMut>::new(&mut world);
         configure_mut_query(&mut builder, &spec);
         let mut state = builder.build();
@@ -307,15 +334,17 @@ mod tests {
         let mut world = World::new();
         let (a_id, b_id, c_id) = ids(&mut world);
 
-        world.spawn(A);         // has A but no B or C -> no match
-        world.spawn((A, B));    // has B -> matches
-        world.spawn((A, C));    // has C -> matches
-        world.spawn(B);         // no A -> no match
+        world.spawn(A); // has A but no B or C -> no match
+        world.spawn((A, B)); // has B -> matches
+        world.spawn((A, C)); // has C -> matches
+        world.spawn(B); // no A -> no match
 
         let spec = QueryBuildSpec {
-            components: vec![
-                QueryComponent { id: a_id, optional: false, mutable: false },
-            ],
+            components: vec![QueryComponent {
+                id: a_id,
+                optional: false,
+                mutable: false,
+            }],
             with_filters: vec![],
             without_filters: vec![],
             changed_filters: vec![],

--- a/crates/pybevy_ecs/src/shared/system_flags.rs
+++ b/crates/pybevy_ecs/src/shared/system_flags.rs
@@ -13,3 +13,33 @@ pub fn compute_system_flags(needs_exclusive: bool, needs_commands: bool) -> Syst
         SystemStateFlags::empty()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exclusive_takes_priority_over_commands() {
+        let flags = compute_system_flags(true, true);
+        assert!(flags.contains(SystemStateFlags::EXCLUSIVE));
+    }
+
+    #[test]
+    fn exclusive_without_commands() {
+        let flags = compute_system_flags(true, false);
+        assert!(flags.contains(SystemStateFlags::EXCLUSIVE));
+    }
+
+    #[test]
+    fn commands_only() {
+        let flags = compute_system_flags(false, true);
+        assert!(flags.contains(SystemStateFlags::DEFERRED));
+        assert!(!flags.contains(SystemStateFlags::EXCLUSIVE));
+    }
+
+    #[test]
+    fn neither_exclusive_nor_commands() {
+        let flags = compute_system_flags(false, false);
+        assert!(flags.is_empty());
+    }
+}


### PR DESCRIPTION
`let _ = ..` did not mark component as changed in bevy code. Fixed.

Also adding full ECS rust test set.