### PR TITLE
Fix benchmarks - parameterized tests & new format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,9 @@ jobs:
       - name: Run tests with Pytest
         run: poetry run pytest --cov=pybevy --cov-report=xml
 
+      - name: Run benchmark lint with Pytest
+        run: poetry run pytest benches --benchmark-disable
+
   rust-coverage:
     timeout-minutes: 30
     runs-on: ubuntu-latest

--- a/benches/ecs/test_ecs_commands.py
+++ b/benches/ecs/test_ecs_commands.py
@@ -25,7 +25,8 @@ def _bench_batch_spawn(entity_count: int) -> None:
     app = App()
     app.add_plugins(ScheduleRunnerPlugin(RunMode.Once()))
     app.add_systems(Startup, setup_batch)
-    app.run()
+    app.initialize()
+    app.update()
 
 
 def _bench_normal_spawn(entity_count: int) -> None:
@@ -40,7 +41,8 @@ def _bench_normal_spawn(entity_count: int) -> None:
     app = App()
     app.add_plugins(ScheduleRunnerPlugin(RunMode.Once()))
     app.add_systems(Startup, setup_normal)
-    app.run()
+    app.initialize()
+    app.update()
 
 
 def _bench_batch_scaling(entity_count: int) -> None:
@@ -56,7 +58,8 @@ def _bench_batch_scaling(entity_count: int) -> None:
     app = App()
     app.add_plugins(ScheduleRunnerPlugin(RunMode.Once()))
     app.add_systems(Startup, setup)
-    app.run()
+    app.initialize()
+    app.update()
 
 
 def test_spawn_100_batch(benchmark: BenchmarkFixture) -> None:
@@ -135,7 +138,8 @@ def test_batch_spawn_with_full_transform_data(benchmark: BenchmarkFixture) -> No
         app = App()
         app.add_plugins(ScheduleRunnerPlugin(RunMode.Once()))
         app.add_systems(Startup, setup)
-        app.run()
+        app.initialize()
+        app.update()
 
     benchmark(bench)
 
@@ -153,6 +157,7 @@ def test_batch_spawn_positions_only(benchmark: BenchmarkFixture) -> None:
         app = App()
         app.add_plugins(ScheduleRunnerPlugin(RunMode.Once()))
         app.add_systems(Startup, setup)
-        app.run()
+        app.initialize()
+        app.update()
 
     benchmark(bench)

--- a/benches/ecs/test_ecs_expressions.py
+++ b/benches/ecs/test_ecs_expressions.py
@@ -13,7 +13,7 @@ from pytest_benchmark.fixture import BenchmarkFixture
 
 from pybevy.app import RunMode, ScheduleRunnerPlugin
 from pybevy.decorators import component
-from pybevy.ecs import Commands, Component, Query, View
+from pybevy.ecs import Commands, Component, Mut, Query, View
 from pybevy.expr import where
 from pybevy.prelude import *
 from pybevy.transform import Transform
@@ -30,10 +30,8 @@ def _spawn_entities(commands: Commands, count: int) -> None:
         commands.spawn(Marker(), Transform.from_xyz(float(i), float(i * 2), 0.0))
 
 
-def _bench_reduce_view(
-    operation: str, entity_count: int, verify_fn=None
-) -> tuple[float, App]:
-    """Helper to benchmark View reduction operations."""
+def _setup_reduce_view(operation: str, entity_count: int) -> App:
+    """Setup app for View reduction benchmark. Returns app ready for benchmark."""
     result = {}
 
     def setup(commands: Commands) -> None:
@@ -55,19 +53,14 @@ def _bench_reduce_view(
     app.add_plugins(ScheduleRunnerPlugin(RunMode.Once()))
     app.add_systems(Startup, setup)
     app.add_systems(Update, reduce_system)
-    app.run()
+    app.initialize()
+    app.update()
 
-    value = result["value"]
-    if verify_fn:
-        verify_fn(value, entity_count)
-
-    return value, app
+    return app
 
 
-def _bench_reduce_query(
-    operation: str, entity_count: int, verify_fn=None
-) -> tuple[float, App]:
-    """Helper to benchmark Query reduction operations."""
+def _setup_reduce_query(operation: str, entity_count: int) -> App:
+    """Setup app for Query reduction benchmark. Returns app ready for benchmark."""
     result = {}
 
     def setup(commands: Commands) -> None:
@@ -101,13 +94,10 @@ def _bench_reduce_query(
     app.add_plugins(ScheduleRunnerPlugin(RunMode.Once()))
     app.add_systems(Startup, setup)
     app.add_systems(Update, query_system)
-    app.run()
+    app.initialize()
+    app.update()
 
-    value = result["value"]
-    if verify_fn:
-        verify_fn(value, entity_count)
-
-    return value, app
+    return app
 
 
 def _bench_comparison_operator(operator_fn, setup_fn) -> App:
@@ -127,111 +117,57 @@ ENTITY_COUNTS = [100, 1000, 10000]
 @pytest.mark.parametrize("entity_count", ENTITY_COUNTS)
 def test_reduce_sum_view(benchmark: BenchmarkFixture, entity_count: int) -> None:
     """Benchmark reduce_sum using View API."""
-
-    def verify(value, count):
-        expected = sum(range(count))
-        assert abs(value - expected) / expected < 0.001
-
-    def bench():
-        return _bench_reduce_view("sum", entity_count, verify)[0]
-
-    benchmark(bench)
+    app = _setup_reduce_view("sum", entity_count)
+    benchmark(app.update)
 
 
 @pytest.mark.parametrize("entity_count", ENTITY_COUNTS)
 def test_reduce_sum_query(benchmark: BenchmarkFixture, entity_count: int) -> None:
     """Benchmark sum using traditional Query iteration."""
-
-    def verify(value, count):
-        expected = sum(range(count))
-        assert abs(value - expected) / expected < 0.001
-
-    def bench():
-        return _bench_reduce_query("sum", entity_count, verify)[0]
-
-    benchmark(bench)
+    app = _setup_reduce_query("sum", entity_count)
+    benchmark(app.update)
 
 
 @pytest.mark.parametrize("entity_count", ENTITY_COUNTS)
 def test_reduce_mean_view(benchmark: BenchmarkFixture, entity_count: int) -> None:
     """Benchmark reduce_mean using View API."""
-
-    def verify(value, count):
-        expected = sum(range(count)) / count
-        assert abs(value - expected) / expected < 0.001
-
-    def bench():
-        return _bench_reduce_view("mean", entity_count, verify)[0]
-
-    benchmark(bench)
+    app = _setup_reduce_view("mean", entity_count)
+    benchmark(app.update)
 
 
 @pytest.mark.parametrize("entity_count", ENTITY_COUNTS)
 def test_reduce_mean_query(benchmark: BenchmarkFixture, entity_count: int) -> None:
     """Benchmark mean using traditional Query iteration."""
-
-    def verify(value, count):
-        expected = sum(range(count)) / count
-        assert abs(value - expected) / expected < 0.001
-
-    def bench():
-        return _bench_reduce_query("mean", entity_count, verify)[0]
-
-    benchmark(bench)
+    app = _setup_reduce_query("mean", entity_count)
+    benchmark(app.update)
 
 
 @pytest.mark.parametrize("entity_count", ENTITY_COUNTS)
 def test_reduce_max_view(benchmark: BenchmarkFixture, entity_count: int) -> None:
     """Benchmark reduce_max using View API."""
-
-    def verify(value, count):
-        expected = float(count - 1)
-        assert abs(value - expected) / expected < 0.001
-
-    def bench():
-        return _bench_reduce_view("max", entity_count, verify)[0]
-
-    benchmark(bench)
+    app = _setup_reduce_view("max", entity_count)
+    benchmark(app.update)
 
 
 @pytest.mark.parametrize("entity_count", ENTITY_COUNTS)
 def test_reduce_max_query(benchmark: BenchmarkFixture, entity_count: int) -> None:
     """Benchmark max using traditional Query iteration."""
-
-    def verify(value, count):
-        expected = float(count - 1)
-        assert abs(value - expected) / expected < 0.001
-
-    def bench():
-        return _bench_reduce_query("max", entity_count, verify)[0]
-
-    benchmark(bench)
+    app = _setup_reduce_query("max", entity_count)
+    benchmark(app.update)
 
 
 @pytest.mark.parametrize("entity_count", ENTITY_COUNTS)
 def test_reduce_count_view(benchmark: BenchmarkFixture, entity_count: int) -> None:
     """Benchmark reduce_count using View API."""
-
-    def verify(value, count):
-        assert value == count
-
-    def bench():
-        return _bench_reduce_view("count", entity_count, verify)[0]
-
-    benchmark(bench)
+    app = _setup_reduce_view("count", entity_count)
+    benchmark(app.update)
 
 
 @pytest.mark.parametrize("entity_count", ENTITY_COUNTS)
 def test_reduce_count_query(benchmark: BenchmarkFixture, entity_count: int) -> None:
     """Benchmark count using traditional Query iteration."""
-
-    def verify(value, count):
-        assert value == count
-
-    def bench():
-        return _bench_reduce_query("count", entity_count, verify)[0]
-
-    benchmark(bench)
+    app = _setup_reduce_query("count", entity_count)
+    benchmark(app.update)
 
 
 NUM_ENTITIES = 100_000
@@ -245,7 +181,7 @@ def test_compare_equal_100000(benchmark: BenchmarkFixture) -> None:
             x = float(i % 100)
             commands.spawn(Transform.from_xyz(x, x if i % 2 == 0 else x + 1, 0.0))
 
-    def compare_equal(view: View[Transform]) -> None:
+    def compare_equal(view: View[Mut[Transform]]) -> None:
         transform = view.column_mut(Transform)
         x = transform.translation.x
         y = transform.translation.y
@@ -263,7 +199,7 @@ def test_compare_not_equal_100000(benchmark: BenchmarkFixture) -> None:
             x = float(i % 100)
             commands.spawn(Transform.from_xyz(x, x + 1, 0.0))
 
-    def compare_not_equal(view: View[Transform]) -> None:
+    def compare_not_equal(view: View[Mut[Transform]]) -> None:
         transform = view.column_mut(Transform)
         x = transform.translation.x
         y = transform.translation.y
@@ -281,7 +217,7 @@ def test_compare_less_than_100000(benchmark: BenchmarkFixture) -> None:
             x = float(i % 100)
             commands.spawn(Transform.from_xyz(x, x + 10, 0.0))
 
-    def compare_less_than(view: View[Transform]) -> None:
+    def compare_less_than(view: View[Mut[Transform]]) -> None:
         transform = view.column_mut(Transform)
         x = transform.translation.x
         y = transform.translation.y
@@ -299,7 +235,7 @@ def test_compare_greater_than_100000(benchmark: BenchmarkFixture) -> None:
             x = float(i % 100)
             commands.spawn(Transform.from_xyz(x, x - 10, 0.0))
 
-    def compare_greater_than(view: View[Transform]) -> None:
+    def compare_greater_than(view: View[Mut[Transform]]) -> None:
         transform = view.column_mut(Transform)
         x = transform.translation.x
         y = transform.translation.y
@@ -317,7 +253,7 @@ def test_where_constants_100000(benchmark: BenchmarkFixture) -> None:
             x = float(i % 200 - 100)
             commands.spawn(Transform.from_xyz(x, 0.0, 0.0))
 
-    def where_constants(view: View[Transform]) -> None:
+    def where_constants(view: View[Mut[Transform]]) -> None:
         transform = view.column_mut(Transform)
         x = transform.translation.x
         transform.translation.y = where(x > 0.0, 10.0, -10.0)
@@ -334,7 +270,7 @@ def test_where_expressions_100000(benchmark: BenchmarkFixture) -> None:
             x = float(i % 200 - 100)
             commands.spawn(Transform.from_xyz(x, 0.0, 0.0))
 
-    def where_expressions(view: View[Transform]) -> None:
+    def where_expressions(view: View[Mut[Transform]]) -> None:
         transform = view.column_mut(Transform)
         x = transform.translation.x
         transform.translation.y = where(x > 0.0, x * 2.0, x * -1.0)
@@ -351,7 +287,7 @@ def test_where_nested_2_levels_100000(benchmark: BenchmarkFixture) -> None:
             x = float(i % 300 - 150)
             commands.spawn(Transform.from_xyz(x, 0.0, 0.0))
 
-    def nested_where_2(view: View[Transform]) -> None:
+    def nested_where_2(view: View[Mut[Transform]]) -> None:
         transform = view.column_mut(Transform)
         x = transform.translation.x
         transform.translation.y = where(x < 0.0, 1.0, where(x == 0.0, 2.0, 3.0))
@@ -368,7 +304,7 @@ def test_where_nested_3_levels_100000(benchmark: BenchmarkFixture) -> None:
             x = float(i % 400 - 200)
             commands.spawn(Transform.from_xyz(x, 0.0, 0.0))
 
-    def nested_where_3(view: View[Transform]) -> None:
+    def nested_where_3(view: View[Mut[Transform]]) -> None:
         transform = view.column_mut(Transform)
         x = transform.translation.x
         transform.translation.y = where(
@@ -392,7 +328,7 @@ def test_logical_and_100000(benchmark: BenchmarkFixture) -> None:
             shield = random.uniform(0.0, 100.0)
             commands.spawn(Transform.from_xyz(health, shield, 0.0))
 
-    def and_operator(view: View[Transform]) -> None:
+    def and_operator(view: View[Mut[Transform]]) -> None:
         transform = view.column_mut(Transform)
         health = transform.translation.x
         shield = transform.translation.y
@@ -414,7 +350,7 @@ def test_logical_or_100000(benchmark: BenchmarkFixture) -> None:
             shield = random.uniform(0.0, 100.0)
             commands.spawn(Transform.from_xyz(health, shield, 0.0))
 
-    def or_operator(view: View[Transform]) -> None:
+    def or_operator(view: View[Mut[Transform]]) -> None:
         transform = view.column_mut(Transform)
         health = transform.translation.x
         shield = transform.translation.y
@@ -435,7 +371,7 @@ def test_logical_not_100000(benchmark: BenchmarkFixture) -> None:
             health = random.uniform(0.0, 100.0)
             commands.spawn(Transform.from_xyz(health, 0.0, 0.0))
 
-    def not_operator(view: View[Transform]) -> None:
+    def not_operator(view: View[Mut[Transform]]) -> None:
         transform = view.column_mut(Transform)
         health = transform.translation.x
         is_critical = health < 20.0
@@ -457,7 +393,7 @@ def test_logical_complex_and_or_100000(benchmark: BenchmarkFixture) -> None:
             shield = random.uniform(0.0, 100.0)
             commands.spawn(Transform.from_xyz(health, shield, 0.0))
 
-    def complex_and_or(view: View[Transform]) -> None:
+    def complex_and_or(view: View[Mut[Transform]]) -> None:
         transform = view.column_mut(Transform)
         health = transform.translation.x
         shield = transform.translation.y
@@ -481,7 +417,7 @@ def test_logical_multiple_and_100000(benchmark: BenchmarkFixture) -> None:
             shield = random.uniform(0.0, 100.0)
             commands.spawn(Transform.from_xyz(health, shield, 0.0))
 
-    def multiple_and(view: View[Transform]) -> None:
+    def multiple_and(view: View[Mut[Transform]]) -> None:
         transform = view.column_mut(Transform)
         health = transform.translation.x
         shield = transform.translation.y
@@ -503,7 +439,7 @@ def test_logical_complex_nested_100000(benchmark: BenchmarkFixture) -> None:
             shield = random.uniform(0.0, 100.0)
             commands.spawn(Transform.from_xyz(health, shield, 0.0))
 
-    def complex_nested(view: View[Transform]) -> None:
+    def complex_nested(view: View[Mut[Transform]]) -> None:
         transform = view.column_mut(Transform)
         health = transform.translation.x
         shield = transform.translation.y
@@ -524,7 +460,7 @@ def test_conditional_view_100000(benchmark: BenchmarkFixture) -> None:
             x = float(i % 200 - 100)
             commands.spawn(Transform.from_xyz(x, 0.0, 0.0))
 
-    def view_conditional(view: View[Transform]) -> None:
+    def view_conditional(view: View[Mut[Transform]]) -> None:
         transform = view.column_mut(Transform)
         x = transform.translation.x
         transform.translation.y = where(x > 0.0, x * 2.0, x * -1.0)
@@ -541,7 +477,7 @@ def test_conditional_query_100000(benchmark: BenchmarkFixture) -> None:
             x = float(i % 200 - 100)
             commands.spawn(Transform.from_xyz(x, 0.0, 0.0))
 
-    def query_conditional(query: Query[Transform]) -> None:
+    def query_conditional(query: Query[Mut[Transform]]) -> None:
         for transform in query:
             x = transform.translation.x
             if x > 0.0:

--- a/benches/ecs/test_ecs_jit.py
+++ b/benches/ecs/test_ecs_jit.py
@@ -46,25 +46,12 @@ def _spawn_entities(commands: Commands, count: int) -> None:
         commands.spawn(Transform.from_xyz(x, 0.0, 0.0), Marker())
 
 
-def _bench_view_simple(entity_count: int) -> None:
-    """Helper to benchmark View simple operation."""
-
-    def spawn(commands: Commands) -> None:
-        _spawn_entities(commands, entity_count)
-
-    def bench_view(view: View[Mut[Transform], With[Marker]]) -> None:
-        transform = view.column_mut(Transform)
-        transform.translation.x = transform.translation.x * 2.0 + 5.0
-
-    app = App()
-    app.add_plugins(ScheduleRunnerPlugin(RunMode.Once()))
-    app.add_systems(Startup, spawn)
-    app.add_systems(Update, bench_view)
-    app.run()
+ENTITY_COUNTS = [100, 1000, 10000]
 
 
-def _bench_query_simple(entity_count: int) -> None:
-    """Helper to benchmark Query simple operation."""
+@pytest.mark.parametrize("entity_count", ENTITY_COUNTS)
+def test_simple_query(benchmark: BenchmarkFixture, entity_count: int) -> None:
+    """Benchmark Query simple operation (x = x * 2 + 5)."""
 
     def spawn(commands: Commands) -> None:
         _spawn_entities(commands, entity_count)
@@ -77,32 +64,36 @@ def _bench_query_simple(entity_count: int) -> None:
     app.add_plugins(ScheduleRunnerPlugin(RunMode.Once()))
     app.add_systems(Startup, spawn)
     app.add_systems(Update, bench_query)
-    app.run()
+    app.initialize()
+    app.update()
+
+    benchmark(app.update)
 
 
-def _bench_view_multi_field(entity_count: int) -> None:
-    """Helper to benchmark View multi-field operation."""
+@pytest.mark.parametrize("entity_count", ENTITY_COUNTS)
+def test_simple_view(benchmark: BenchmarkFixture, entity_count: int) -> None:
+    """Benchmark View simple operation (x = x * 2 + 5)."""
 
     def spawn(commands: Commands) -> None:
-        for i in range(entity_count):
-            x = float(i % 100)
-            commands.spawn(Transform.from_xyz(x, x * 0.5, x * 0.3), Marker())
+        _spawn_entities(commands, entity_count)
 
     def bench_view(view: View[Mut[Transform], With[Marker]]) -> None:
         transform = view.column_mut(Transform)
-        transform.translation.x = transform.translation.x * 0.99
-        transform.translation.y = transform.translation.y * 0.99
-        transform.translation.z = transform.translation.z * 0.99
+        transform.translation.x = transform.translation.x * 2.0 + 5.0
 
     app = App()
     app.add_plugins(ScheduleRunnerPlugin(RunMode.Once()))
     app.add_systems(Startup, spawn)
     app.add_systems(Update, bench_view)
-    app.run()
+    app.initialize()
+    app.update()
+
+    benchmark(app.update)
 
 
-def _bench_query_multi_field(entity_count: int) -> None:
-    """Helper to benchmark Query multi-field operation."""
+@pytest.mark.parametrize("entity_count", ENTITY_COUNTS)
+def test_multi_field_query(benchmark: BenchmarkFixture, entity_count: int) -> None:
+    """Benchmark Query multi-field operation (x, y, z *= 0.99)."""
 
     def spawn(commands: Commands) -> None:
         for i in range(entity_count):
@@ -119,34 +110,35 @@ def _bench_query_multi_field(entity_count: int) -> None:
     app.add_plugins(ScheduleRunnerPlugin(RunMode.Once()))
     app.add_systems(Startup, spawn)
     app.add_systems(Update, bench_query)
-    app.run()
+    app.initialize()
+    app.update()
 
-
-ENTITY_COUNTS = [100, 1000, 10000]
-
-
-@pytest.mark.parametrize("entity_count", ENTITY_COUNTS)
-def test_simple_query(benchmark: BenchmarkFixture, entity_count: int) -> None:
-    """Benchmark Query simple operation (x = x * 2 + 5)."""
-    benchmark(_bench_query_simple, entity_count)
-
-
-@pytest.mark.parametrize("entity_count", ENTITY_COUNTS)
-def test_simple_view(benchmark: BenchmarkFixture, entity_count: int) -> None:
-    """Benchmark View simple operation (x = x * 2 + 5)."""
-    benchmark(_bench_view_simple, entity_count)
-
-
-@pytest.mark.parametrize("entity_count", ENTITY_COUNTS)
-def test_multi_field_query(benchmark: BenchmarkFixture, entity_count: int) -> None:
-    """Benchmark Query multi-field operation (x, y, z *= 0.99)."""
-    benchmark(_bench_query_multi_field, entity_count)
+    benchmark(app.update)
 
 
 @pytest.mark.parametrize("entity_count", ENTITY_COUNTS)
 def test_multi_field_view(benchmark: BenchmarkFixture, entity_count: int) -> None:
     """Benchmark View multi-field operation (x, y, z *= 0.99)."""
-    benchmark(_bench_view_multi_field, entity_count)
+
+    def spawn(commands: Commands) -> None:
+        for i in range(entity_count):
+            x = float(i % 100)
+            commands.spawn(Transform.from_xyz(x, x * 0.5, x * 0.3), Marker())
+
+    def bench_view(view: View[Mut[Transform], With[Marker]]) -> None:
+        transform = view.column_mut(Transform)
+        transform.translation.x = transform.translation.x * 0.99
+        transform.translation.y = transform.translation.y * 0.99
+        transform.translation.z = transform.translation.z * 0.99
+
+    app = App()
+    app.add_plugins(ScheduleRunnerPlugin(RunMode.Once()))
+    app.add_systems(Startup, spawn)
+    app.add_systems(Update, bench_view)
+    app.initialize()
+    app.update()
+
+    benchmark(app.update)
 
 
 @pytest.mark.skipif(not NUMBA_AVAILABLE, reason="Numba not installed")
@@ -190,7 +182,8 @@ def test_jit_api_available() -> None:
     app.add_plugins(ScheduleRunnerPlugin(RunMode.Once()))
     app.add_systems(Startup, spawn)
     app.add_systems(Update, try_jit)
-    app.run()
+    app.initialize()
+    app.update()
 
     # Either it worked or we got the expected error
     assert jit_called[0] or (
@@ -221,7 +214,8 @@ def test_view_correctness() -> None:
     app.add_systems(Startup, spawn)
     app.add_systems(Update, calc_view)
     app.add_systems(Last, verify)
-    app.run()
+    app.initialize()
+    app.update()
 
     assert len(results) == entity_count
     for i, value in enumerate(results):

--- a/benches/ecs/test_ecs_memory.py
+++ b/benches/ecs/test_ecs_memory.py
@@ -176,21 +176,22 @@ COMPARISONS: list[tuple[str, str, str, str]] = [
 ]
 
 
+import pytest
+
+_RUST_BINARY_PATH = PROJECT_ROOT / "target" / "release" / "examples" / RUST_BINARY
+
+
+@pytest.mark.skipif(
+    not _RUST_BINARY_PATH.exists(),
+    reason=f"Rust binary not found at {_RUST_BINARY_PATH}. "
+    "Build it: cargo build --example memory_baseline --release --features linux-display",
+)
 class TestMemoryComparison:
     """PyBevy vs Rust Bevy memory comparison. Run with -s to see output."""
 
-    def _check_rust_binary(self) -> None:
-        binary = PROJECT_ROOT / "target" / "release" / "examples" / RUST_BINARY
-        if not binary.exists():
-            raise FileNotFoundError(
-                f"Rust binary not found at {binary}\n"
-                "Build it first:\n"
-                "  cargo build --example memory_baseline --release --features linux-display"
-            )
-
     def test_transform_comparison(self) -> None:
         """Transform: PyBevy vs pure Rust Bevy."""
-        self._check_rust_binary()
+
         rust = _measure_rust("transform", ENTITY_COUNT)
         py = _measure_pybevy("transform", ENTITY_COUNT)
         overhead = py["bpe"] - rust["bpe"]
@@ -200,7 +201,7 @@ class TestMemoryComparison:
 
     def test_velocity_wrapper_comparison(self) -> None:
         """Vec3-like component: wrapper storage vs Rust."""
-        self._check_rust_binary()
+
         rust = _measure_rust("velocity_small", ENTITY_COUNT)
         py = _measure_pybevy("velocity_small", ENTITY_COUNT)
         overhead = py["bpe"] - rust["bpe"]
@@ -210,7 +211,7 @@ class TestMemoryComparison:
 
     def test_velocity_pyobject_comparison(self) -> None:
         """Vec3-like component: PyObject storage vs Rust."""
-        self._check_rust_binary()
+
         rust = _measure_rust("velocity_small", ENTITY_COUNT)
         py = _measure_pybevy("velocity_small_pyobject", ENTITY_COUNT)
         overhead = py["bpe"] - rust["bpe"]
@@ -220,7 +221,7 @@ class TestMemoryComparison:
 
     def test_velocity_string_comparison(self) -> None:
         """Vec3+String: PyObject storage vs Rust."""
-        self._check_rust_binary()
+
         rust = _measure_rust("velocity_string", ENTITY_COUNT)
         py = _measure_pybevy("velocity_string", ENTITY_COUNT)
         overhead = py["bpe"] - rust["bpe"]
@@ -230,7 +231,7 @@ class TestMemoryComparison:
 
     def test_summary_table(self) -> None:
         """Print full comparison table: PyBevy vs pure Rust Bevy."""
-        self._check_rust_binary()
+
         n = ENTITY_COUNT
 
         print(f"\n{'='*90}")

--- a/benches/ecs/test_ecs_observers.py
+++ b/benches/ecs/test_ecs_observers.py
@@ -30,7 +30,8 @@ app.add_observer(on_add_{i})
             commands.spawn(Transform.from_xyz(1.0, 2.0, 3.0))
 
         app.add_systems(Update, spawn_entity)
-        app.run()
+        app.initialize()
+        app.update()
 
     benchmark(create_and_trigger)
 
@@ -56,7 +57,8 @@ def test_performance_many_entities_lifecycle_events(benchmark) -> None:
                 commands.spawn(Transform.from_xyz(float(i), 0.0, 0.0))
 
         app.add_systems(Update, spawn_entities)
-        app.run()
+        app.initialize()
+        app.update()
 
         assert len(call_count) == num_entities
 
@@ -82,7 +84,8 @@ def test_performance_lifecycle_event_overhead(benchmark) -> None:
                 commands.spawn(Transform.from_xyz(float(i), 0.0, 0.0))
 
         app.add_systems(Update, spawn_entities)
-        app.run()
+        app.initialize()
+        app.update()
 
     benchmark(spawn_with_observers)
 
@@ -123,7 +126,8 @@ def test_performance_insert_remove_lifecycle(benchmark) -> None:
 
         app.add_systems(Startup, setup)
         app.add_systems(Update, insert_remove)
-        app.run()
+        app.initialize()
+        app.update()
 
         assert len(insert_count) == num_operations
         assert len(remove_count) == num_operations
@@ -163,7 +167,8 @@ def test_performance_filtered_observers(benchmark) -> None:
                     commands.spawn(Transform.from_xyz(float(i), 0.0, 0.0))
 
         app.add_systems(Update, spawn_entities)
-        app.run()
+        app.initialize()
+        app.update()
 
         assert len(filtered_count) == num_entities
 
@@ -199,7 +204,8 @@ def test_performance_despawn_lifecycle(benchmark) -> None:
 
         app.add_systems(Startup, spawn_entities)
         app.add_systems(Update, despawn_entities)
-        app.run()
+        app.initialize()
+        app.update()
 
         assert len(despawn_count) == num_entities
 
@@ -220,6 +226,7 @@ def test_performance_no_observers_baseline(benchmark) -> None:
                 commands.spawn(Transform.from_xyz(float(i), 0.0, 0.0))
 
         app.add_systems(Update, spawn_entities)
-        app.run()
+        app.initialize()
+        app.update()
 
     benchmark(spawn_no_observers)

--- a/benches/ecs/test_ecs_query.py
+++ b/benches/ecs/test_ecs_query.py
@@ -9,8 +9,12 @@ from pybevy.math import Quat, Vec3
 from pybevy.transform import Transform
 
 
-def _bench_query_minimal_iteration(entity_count: int) -> None:
-    """Helper to benchmark minimal query iteration overhead."""
+ENTITY_COUNTS = [1000, 10000]
+
+
+@pytest.mark.parametrize("entity_count", ENTITY_COUNTS)
+def test_iteration_minimal(benchmark: BenchmarkFixture, entity_count: int) -> None:
+    """Benchmark minimal query iteration overhead."""
 
     def setup(commands: Commands) -> None:
         for _ in range(entity_count):
@@ -27,9 +31,12 @@ def _bench_query_minimal_iteration(entity_count: int) -> None:
     app.initialize()
     app.update()
 
+    benchmark(app.update)
 
-def _bench_query_count(entity_count: int) -> int:
-    """Helper to benchmark query iteration with counting."""
+
+@pytest.mark.parametrize("entity_count", ENTITY_COUNTS)
+def test_iteration_count(benchmark: BenchmarkFixture, entity_count: int) -> None:
+    """Benchmark query iteration with counting."""
 
     def setup(commands: Commands) -> None:
         for _ in range(entity_count):
@@ -49,11 +56,13 @@ def _bench_query_count(entity_count: int) -> int:
     app.initialize()
     app.update()
 
-    return count[0]
+    benchmark(app.update)
+    assert count[0] == entity_count
 
 
-def _bench_query_read_translation(entity_count: int) -> None:
-    """Helper to benchmark reading translation."""
+@pytest.mark.parametrize("entity_count", ENTITY_COUNTS)
+def test_translation_read(benchmark: BenchmarkFixture, entity_count: int) -> None:
+    """Benchmark reading translation from transforms."""
 
     def setup(commands: Commands) -> None:
         for i in range(entity_count):
@@ -73,15 +82,18 @@ def _bench_query_read_translation(entity_count: int) -> None:
     app.initialize()
     app.update()
 
+    benchmark(app.update)
 
-def _bench_query_write_translation(entity_count: int) -> None:
-    """Helper to benchmark writing translation."""
+
+@pytest.mark.parametrize("entity_count", ENTITY_COUNTS)
+def test_translation_write(benchmark: BenchmarkFixture, entity_count: int) -> None:
+    """Benchmark writing translation to transforms."""
 
     def setup(commands: Commands) -> None:
         for _ in range(entity_count):
             commands.spawn(Transform())
 
-    def write_translations(query: Query[Transform]) -> None:
+    def write_translations(query: Query[Mut[Transform]]) -> None:
         for i, transform in enumerate(query):
             transform.translation = Vec3(float(i), 1.0, 2.0)
 
@@ -92,15 +104,21 @@ def _bench_query_write_translation(entity_count: int) -> None:
     app.initialize()
     app.update()
 
+    benchmark(app.update)
 
-def _bench_query_rotate(entity_count: int, axis: str) -> None:
-    """Helper to benchmark rotation operations."""
+
+@pytest.mark.parametrize("entity_count", [1000, 10000])
+@pytest.mark.parametrize("axis", ["x", "y", "z", "local_x", "quat"])
+def test_rotate(
+    benchmark: BenchmarkFixture, entity_count: int, axis: str
+) -> None:
+    """Benchmark rotation operations."""
 
     def setup(commands: Commands) -> None:
         for _ in range(entity_count):
             commands.spawn(Transform())
 
-    def rotate_transforms(query: Query[Transform]) -> None:
+    def rotate_transforms(query: Query[Mut[Transform]]) -> None:
         for transform in query:
             if axis == "x":
                 transform.rotate_x(0.01)
@@ -120,9 +138,12 @@ def _bench_query_rotate(entity_count: int, axis: str) -> None:
     app.initialize()
     app.update()
 
+    benchmark(app.update)
 
-def _bench_query_mutate_transform(entity_count: int) -> int:
-    """Helper to benchmark Transform mutation via query."""
+
+@pytest.mark.parametrize("entity_count", ENTITY_COUNTS)
+def test_mutate_transform(benchmark: BenchmarkFixture, entity_count: int) -> None:
+    """Benchmark Transform mutation via Mut[Transform]."""
     addition = Vec3(0.1, 0.2, 0.3)
 
     def setup(commands: Commands) -> None:
@@ -144,51 +165,8 @@ def _bench_query_mutate_transform(entity_count: int) -> int:
     app.initialize()
     app.update()
 
-    return count[0]
-
-
-ENTITY_COUNTS = [1000, 10000]
-
-
-@pytest.mark.parametrize("entity_count", ENTITY_COUNTS)
-def test_iteration_minimal(benchmark: BenchmarkFixture, entity_count: int) -> None:
-    """Benchmark minimal query iteration overhead."""
-    benchmark(_bench_query_minimal_iteration, entity_count)
-
-
-@pytest.mark.parametrize("entity_count", ENTITY_COUNTS)
-def test_iteration_count(benchmark: BenchmarkFixture, entity_count: int) -> None:
-    """Benchmark query iteration with counting."""
-    count = benchmark(_bench_query_count, entity_count)
-    assert count == entity_count
-
-
-@pytest.mark.parametrize("entity_count", ENTITY_COUNTS)
-def test_translation_read(benchmark: BenchmarkFixture, entity_count: int) -> None:
-    """Benchmark reading translation from transforms."""
-    benchmark(_bench_query_read_translation, entity_count)
-
-
-@pytest.mark.parametrize("entity_count", ENTITY_COUNTS)
-def test_translation_write(benchmark: BenchmarkFixture, entity_count: int) -> None:
-    """Benchmark writing translation to transforms."""
-    benchmark(_bench_query_write_translation, entity_count)
-
-
-@pytest.mark.parametrize("entity_count", [1000, 10000])
-@pytest.mark.parametrize("axis", ["x", "y", "z", "local_x", "quat"])
-def test_rotate(
-    benchmark: BenchmarkFixture, entity_count: int, axis: str
-) -> None:
-    """Benchmark rotation operations."""
-    benchmark(_bench_query_rotate, entity_count, axis)
-
-
-@pytest.mark.parametrize("entity_count", ENTITY_COUNTS)
-def test_mutate_transform(benchmark: BenchmarkFixture, entity_count: int) -> None:
-    """Benchmark Transform mutation via Mut[Transform]."""
-    count = benchmark(_bench_query_mutate_transform, entity_count)
-    assert count == entity_count
+    benchmark(app.update)
+    assert count[0] == entity_count
 
 
 def test_look_at_10000(benchmark: BenchmarkFixture) -> None:
@@ -202,7 +180,7 @@ def test_look_at_10000(benchmark: BenchmarkFixture) -> None:
     target = Vec3(1.0, 0.0, 0.0)
     up = Vec3.Y
 
-    def look_at_transforms(query: Query[Transform]) -> None:
+    def look_at_transforms(query: Query[Mut[Transform]]) -> None:
         for transform in query:
             transform.look_at(target, up)
 
@@ -282,7 +260,7 @@ def test_mixed_operations_10000(benchmark: BenchmarkFixture) -> None:
         for i in range(entity_count):
             commands.spawn(Transform.from_xyz(float(i), 0.0, 0.0))
 
-    def mixed_operations(query: Query[Transform]) -> None:
+    def mixed_operations(query: Query[Mut[Transform]]) -> None:
         for i, transform in enumerate(query):
             pos = transform.translation
 

--- a/benches/ecs/test_ecs_query.py
+++ b/benches/ecs/test_ecs_query.py
@@ -8,7 +8,6 @@ from pybevy.ecs import Commands, Entity, Mut, Query
 from pybevy.math import Quat, Vec3
 from pybevy.transform import Transform
 
-
 ENTITY_COUNTS = [1000, 10000]
 
 

--- a/benches/ecs/test_ecs_storage.py
+++ b/benches/ecs/test_ecs_storage.py
@@ -67,6 +67,7 @@ def _setup_query_wrapper_read(entity_count: int) -> App:
     app.add_systems(Startup, spawn)
     app.add_systems(Update, query_read)
     app.initialize()
+    app.update()
     return app
 
 
@@ -91,6 +92,7 @@ def _setup_query_pyobject_read(entity_count: int) -> App:
     app.add_systems(Startup, spawn)
     app.add_systems(Update, query_read)
     app.initialize()
+    app.update()
     return app
 
 
@@ -114,6 +116,7 @@ def _setup_query_wrapper_write(entity_count: int) -> App:
     app.add_systems(Startup, spawn)
     app.add_systems(Update, query_write)
     app.initialize()
+    app.update()
     return app
 
 
@@ -129,7 +132,7 @@ def _setup_query_pyobject_write(entity_count: int) -> App:
                 Marker(),
             )
 
-    def query_write(query: Query[PyObjectPosition]) -> None:
+    def query_write(query: Query[Mut[PyObjectPosition]]) -> None:
         for pos in query:
             pos.x = pos.x * 2.0 + 1.0
             pos.y = pos.y * 1.5 + 0.5
@@ -140,6 +143,7 @@ def _setup_query_pyobject_write(entity_count: int) -> App:
     app.add_systems(Startup, spawn)
     app.add_systems(Update, query_write)
     app.initialize()
+    app.update()
     return app
 
 
@@ -163,6 +167,7 @@ def _setup_view_wrapper_write(entity_count: int) -> App:
     app.add_systems(Startup, spawn)
     app.add_systems(Update, view_write)
     app.initialize()
+    app.update()
     return app
 
 

--- a/benches/ecs/test_ecs_view.py
+++ b/benches/ecs/test_ecs_view.py
@@ -76,7 +76,8 @@ def _warmup_numba() -> None:
 
     app.add_systems(Startup, setup)
     app.add_systems(Update, warmup)
-    app.run()
+    app.initialize()
+    app.update()
     _numba_warmed_up = True
 
 
@@ -99,6 +100,7 @@ def _setup_view_numba_sum(entity_count: int) -> App:
     app.add_systems(Startup, setup)
     app.add_systems(Update, measure_view)
     app.initialize()
+    app.update()
     return app
 
 
@@ -119,6 +121,7 @@ def _setup_query_sum(entity_count: int) -> App:
     app.add_systems(Startup, setup)
     app.add_systems(Update, measure_query)
     app.initialize()
+    app.update()
     return app
 
 
@@ -143,6 +146,7 @@ def _setup_view_batch_ops(entity_count: int) -> App:
     app.add_systems(Startup, setup)
     app.add_systems(Update, batch_ops)
     app.initialize()
+    app.update()
     return app
 
 
@@ -167,6 +171,7 @@ def _setup_query_batch_ops(entity_count: int) -> App:
     app.add_systems(Startup, setup)
     app.add_systems(Update, iter_ops)
     app.initialize()
+    app.update()
     return app
 
 
@@ -189,6 +194,7 @@ def _setup_view_complex_ops(entity_count: int) -> App:
     app.add_systems(Startup, setup)
     app.add_systems(Update, complex_ops)
     app.initialize()
+    app.update()
     return app
 
 
@@ -214,6 +220,7 @@ def _setup_query_complex_ops(entity_count: int) -> App:
     app.add_systems(Startup, setup)
     app.add_systems(Update, complex_ops)
     app.initialize()
+    app.update()
     return app
 
 

--- a/benches/image/test_image.py
+++ b/benches/image/test_image.py
@@ -14,7 +14,7 @@ image_height = 2160
 pixel_count = image_width * image_height * 4
 
 
-def setup(images: Assets[Image], commands: Commands) -> None:
+def setup(images: ResMut[Assets[Image]], commands: Commands) -> None:
     data = np.random.randint(0, 255, size=pixel_count, dtype=np.uint8)
     image = Image(Extent3d(image_width, image_height, 1), data)
     commands.spawn(Sprite(images.add(image)))

--- a/benches/mesh/test_mesh.py
+++ b/benches/mesh/test_mesh.py
@@ -16,7 +16,7 @@ vertex_count = 10_000_000
 indices_count = vertex_count * 3
 
 
-def setup(meshes: Assets[Mesh], commands: Commands) -> None:
+def setup(meshes: ResMut[Assets[Mesh]], commands: Commands) -> None:
     mesh = (
         Mesh(PrimitiveTopology.TriangleList)
         .with_inserted_attribute(

--- a/pybevy/pbr.pyi
+++ b/pybevy/pbr.pyi
@@ -34,6 +34,8 @@ class OpaqueRendererMethod:
     DEFERRED: ClassVar[OpaqueRendererMethod]
     AUTO: ClassVar[OpaqueRendererMethod]
 
+    def __int__(self) -> int: ...
+
 class ParallaxMappingMethod:
     OCCLUSION: ClassVar[ParallaxMappingMethod]
 


### PR DESCRIPTION
Some benchmarks were broken, due to API changes.

Also some benchmarks were incorrectly measuring setup + update path, whereas the intent was to benchmark only the update path. Fixes #76 

Adding also benchmarks to the CI pipeline (syntax check).