### PR TITLE
Migrate fully qualified imports to top-level imports

### DIFF
--- a/crates/pybevy_audio/src/audio_player.rs
+++ b/crates/pybevy_audio/src/audio_player.rs
@@ -1,4 +1,7 @@
-use bevy::audio::{AudioPlayer, AudioSource};
+use bevy::{
+    asset::Handle,
+    audio::{AudioPlayer, AudioSource},
+};
 use pybevy_core::{ComponentStorage, PyComponent, handle::PyHandle};
 use pybevy_macros::pycomponent;
 use pyo3::prelude::*;
@@ -14,7 +17,7 @@ pub struct PyAudioPlayer {
 impl PyAudioPlayer {
     #[new]
     pub fn new(handle: PyHandle) -> PyResult<(Self, PyComponent)> {
-        let bevy_handle = bevy::asset::Handle::<AudioSource>::try_from(&handle)?;
+        let bevy_handle = Handle::<AudioSource>::try_from(&handle)?;
         let component = AudioPlayer(bevy_handle);
         Ok(Self::from_owned(component))
     }

--- a/crates/pybevy_camera/src/normalized_render_target.rs
+++ b/crates/pybevy_camera/src/normalized_render_target.rs
@@ -1,6 +1,7 @@
 use std::hash::{Hash, Hasher};
 
 use bevy::{
+    asset::Handle,
     camera::{ImageRenderTarget, ManualTextureViewHandle, NormalizedRenderTarget},
     ecs::entity::ContainsEntity,
     image::Image,
@@ -17,7 +18,7 @@ impl PyNormalizedRenderTarget {
     #[staticmethod]
     #[pyo3(signature = (handle, scale_factor = 1.0))]
     pub fn image(handle: &PyHandle, scale_factor: f32) -> PyResult<Self> {
-        let image_handle = bevy::asset::Handle::<Image>::try_from(handle)?;
+        let image_handle = Handle::<Image>::try_from(handle)?;
         Ok(PyNormalizedRenderTarget(NormalizedRenderTarget::Image(
             ImageRenderTarget {
                 handle: image_handle,

--- a/crates/pybevy_control/src/bridge.rs
+++ b/crates/pybevy_control/src/bridge.rs
@@ -880,6 +880,7 @@ mod tests {
     use std::sync::Once;
 
     use bevy::{ecs::entity::Entity, prelude::Transform};
+    use pybevy_core::bridge_inventory::collect_all;
     use pyo3::Python;
 
     use super::*;

--- a/crates/pybevy_control/src/bridge.rs
+++ b/crates/pybevy_control/src/bridge.rs
@@ -1051,7 +1051,7 @@ mod tests {
         static INIT: Once = Once::new();
         INIT.call_once(|| {
             Python::initialize();
-            pybevy_core::bridge_inventory::collect_all();
+            collect_all();
         });
 
         Python::attach(|py| {

--- a/crates/pybevy_control/src/handlers/pyo3/execute.rs
+++ b/crates/pybevy_control/src/handlers/pyo3/execute.rs
@@ -1,4 +1,4 @@
-use std::sync::OnceLock;
+use std::{ffi::CString, sync::OnceLock};
 
 use bevy::ecs::world::World;
 use pybevy_core::{ValidityFlag, ValidityGuard};
@@ -81,7 +81,7 @@ finally:
             escaped_code = code.replace('\'', "\\'")
         );
 
-        let c_code = std::ffi::CString::new(capture_code)
+        let c_code = CString::new(capture_code)
             .map_err(|e| ControlError::invalid_params(format!("Invalid code: {e}")))?;
 
         match py.run(&c_code, Some(&globals), None) {

--- a/crates/pybevy_control/src/handlers/pyo3/mutate.rs
+++ b/crates/pybevy_control/src/handlers/pyo3/mutate.rs
@@ -1221,12 +1221,14 @@ pub(crate) fn json_to_py(py: Python<'_>, value: &serde_json::Value) -> Result<Py
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Once;
+    use std::{alloc::Layout, ffi::CString, ptr, sync::Once};
 
     use bevy::ecs::{
         component::{ComponentCloneBehavior, ComponentDescriptor, ComponentId, StorageType},
         name::Name,
     };
+    use pybevy_core::{CustomComponentEntry, CustomResourceEntry};
+    use pyo3::types::PyInt;
 
     use super::*;
     use crate::bridge::ErrorCode;

--- a/crates/pybevy_control/src/handlers/pyo3/mutate.rs
+++ b/crates/pybevy_control/src/handlers/pyo3/mutate.rs
@@ -1,8 +1,12 @@
-use std::sync::Arc;
+use std::{mem, ptr, sync::Arc};
 
 use bevy::ecs::world::World;
-use pybevy_core::ComponentBridge;
-use pyo3::{prelude::*, types::PyModule};
+use pybevy_core::{ComponentBridge, CustomComponentInfo, CustomResourceInfo, PyResourceStorage};
+use pyo3::{
+    ffi::PyObject,
+    prelude::*,
+    types::{PyDict, PyList, PyModule, PyType},
+};
 
 use super::scene::resolve_entity;
 use crate::{
@@ -168,7 +172,7 @@ fn spawn_component_python(
             }
             Err(_) if !fields.is_empty() => {
                 // Default constructor failed — try passing fields as kwargs
-                let kwargs = pyo3::types::PyDict::new(py);
+                let kwargs = PyDict::new(py);
                 for (field_name, field_value) in fields {
                     match json_to_py(py, field_value) {
                         Ok(py_value) => {
@@ -399,7 +403,7 @@ fn set_custom_component(
 ) -> Result<serde_json::Value, ControlError> {
     // Find the custom component's ComponentId — try exact name match first
     let custom_info = world
-        .get_resource::<pybevy_core::CustomComponentInfo>()
+        .get_resource::<CustomComponentInfo>()
         .and_then(|info| {
             info.iter()
                 .find(|(_, entry)| entry.name == component)
@@ -409,7 +413,7 @@ fn set_custom_component(
     // Fallback: check for qualified name variants (e.g. "module.Oscillator" vs "Oscillator")
     // and scan the entity's archetype for matching custom components
     let custom_info = custom_info.or_else(|| {
-        let info = world.get_resource::<pybevy_core::CustomComponentInfo>()?;
+        let info = world.get_resource::<CustomComponentInfo>()?;
         let entity_ref = world.get_entity(entity).ok()?;
 
         // Check if any registered custom component matches by short name
@@ -465,7 +469,7 @@ fn set_custom_component(
     let Some((comp_id, is_pyobject_storage)) = custom_info else {
         // Build a helpful error with available custom components
         let available = world
-            .get_resource::<pybevy_core::CustomComponentInfo>()
+            .get_resource::<CustomComponentInfo>()
             .map(|info| {
                 info.iter()
                     .map(|(_, entry)| entry.name.clone())
@@ -565,14 +569,13 @@ fn insert_custom_component(
 ) -> Result<serde_json::Value, ControlError> {
     // Get the type pointer from CustomComponentInfo
     let type_ptr = world
-        .get_resource::<pybevy_core::CustomComponentInfo>()
+        .get_resource::<CustomComponentInfo>()
         .and_then(|info| info.get(comp_id).map(|entry| entry.type_ptr))
         .ok_or_else(|| ControlError::internal("Custom component info lost".to_string()))?;
 
     Python::attach(|py| {
-        let py_type =
-            unsafe { pyo3::Bound::from_borrowed_ptr(py, type_ptr as *mut pyo3::ffi::PyObject) };
-        let Ok(cls) = py_type.cast::<pyo3::types::PyType>() else {
+        let py_type = unsafe { pyo3::Bound::from_borrowed_ptr(py, type_ptr as *mut PyObject) };
+        let Ok(cls) = py_type.cast::<PyType>() else {
             return Err(ControlError::internal(
                 "Custom component type pointer is invalid".to_string(),
             ));
@@ -602,7 +605,7 @@ fn insert_custom_component(
             }
             Err(_) if !field_obj.is_empty() => {
                 // Default constructor failed — try passing fields as kwargs
-                let kwargs = pyo3::types::PyDict::new(py);
+                let kwargs = PyDict::new(py);
                 let mut updated = Vec::new();
                 for (field_name, field_value) in field_obj {
                     match json_to_py(py, field_value) {
@@ -641,11 +644,11 @@ fn insert_custom_component(
         // SAFETY: comp_id is a registered custom component with PyObject storage.
         // The component layout matches Py<PyAny> which was registered during app setup.
         unsafe {
-            let ptr = std::ptr::addr_of!(py_obj) as *const u8;
+            let ptr = ptr::addr_of!(py_obj) as *const u8;
             let data = core::ptr::NonNull::new_unchecked(ptr as *mut u8);
             entity_mut.insert_by_id(comp_id, bevy::ptr::OwningPtr::new(data));
         }
-        std::mem::forget(py_obj); // Ownership transferred to ECS
+        mem::forget(py_obj); // Ownership transferred to ECS
 
         Ok(serde_json::json!({
             "entity_id": entity_id,
@@ -684,7 +687,7 @@ pub fn remove_component(
 
     // Fallback: check custom Python components via CustomComponentInfo
     let custom_comp_id = world
-        .get_resource::<pybevy_core::CustomComponentInfo>()
+        .get_resource::<CustomComponentInfo>()
         .and_then(|info| {
             info.iter()
                 .find(|(_, entry)| entry.name == component)
@@ -815,18 +818,16 @@ pub fn insert_resource(
     }
 
     // Fallback: check custom Python resources via CustomResourceInfo
-    let custom_entry = world
-        .get_resource::<pybevy_core::CustomResourceInfo>()
-        .and_then(|info| {
-            info.iter()
-                .find(|(_, entry)| entry.name == resource_type)
-                .map(|(id, entry)| (id, entry.type_ptr))
-        });
+    let custom_entry = world.get_resource::<CustomResourceInfo>().and_then(|info| {
+        info.iter()
+            .find(|(_, entry)| entry.name == resource_type)
+            .map(|(id, entry)| (id, entry.type_ptr))
+    });
 
     if let Some((comp_id, type_ptr)) = custom_entry {
         Python::attach(|py| {
             // Patch semantics: if custom resource already exists, mutate in-place
-            if let Some(storage) = world.get_resource::<pybevy_core::PyResourceStorage>()
+            if let Some(storage) = world.get_resource::<PyResourceStorage>()
                 && let Some(existing) = storage.resources.get(&comp_id)
             {
                 let bound = existing.bind(py);
@@ -855,9 +856,8 @@ pub fn insert_resource(
             }
 
             // Resource doesn't exist yet: create default and apply fields
-            let py_type =
-                unsafe { pyo3::Bound::from_borrowed_ptr(py, type_ptr as *mut pyo3::ffi::PyObject) };
-            let Ok(cls) = py_type.cast::<pyo3::types::PyType>() else {
+            let py_type = unsafe { pyo3::Bound::from_borrowed_ptr(py, type_ptr as *mut PyObject) };
+            let Ok(cls) = py_type.cast::<PyType>() else {
                 return Err(ControlError::internal(
                     "Custom resource type pointer is invalid".to_string(),
                 ));
@@ -887,11 +887,11 @@ pub fn insert_resource(
             }
 
             // Store in PyResourceStorage
-            if !world.contains_resource::<pybevy_core::PyResourceStorage>() {
-                world.insert_resource(pybevy_core::PyResourceStorage::default());
+            if !world.contains_resource::<PyResourceStorage>() {
+                world.insert_resource(PyResourceStorage::default());
             }
             world
-                .resource_mut::<pybevy_core::PyResourceStorage>()
+                .resource_mut::<PyResourceStorage>()
                 .resources
                 .insert(comp_id, instance.unbind());
 
@@ -922,16 +922,14 @@ pub fn remove_resource(
     }
 
     // Fallback: check custom Python resources via CustomResourceInfo
-    let custom_comp_id = world
-        .get_resource::<pybevy_core::CustomResourceInfo>()
-        .and_then(|info| {
-            info.iter()
-                .find(|(_, entry)| entry.name == resource_type)
-                .map(|(id, _)| id)
-        });
+    let custom_comp_id = world.get_resource::<CustomResourceInfo>().and_then(|info| {
+        info.iter()
+            .find(|(_, entry)| entry.name == resource_type)
+            .map(|(id, _)| id)
+    });
 
     if let Some(comp_id) = custom_comp_id {
-        if let Some(storage) = world.get_resource_mut::<pybevy_core::PyResourceStorage>() {
+        if let Some(storage) = world.get_resource_mut::<PyResourceStorage>() {
             storage.into_inner().resources.remove(&comp_id);
         }
         return Ok(serde_json::json!({
@@ -1203,7 +1201,7 @@ pub(crate) fn json_to_py(py: Python<'_>, value: &serde_json::Value) -> Result<Py
             .into_any()
             .unbind()),
         serde_json::Value::Array(arr) => {
-            let list = pyo3::types::PyList::empty(py);
+            let list = PyList::empty(py);
             for item in arr {
                 let py_item = json_to_py(py, item)?;
                 list.append(py_item).map_err(|e| e.to_string())?;
@@ -1211,7 +1209,7 @@ pub(crate) fn json_to_py(py: Python<'_>, value: &serde_json::Value) -> Result<Py
             Ok(list.into_any().unbind())
         }
         serde_json::Value::Object(obj) => {
-            let dict = pyo3::types::PyDict::new(py);
+            let dict = PyDict::new(py);
             for (k, v) in obj {
                 let py_value = json_to_py(py, v)?;
                 dict.set_item(k, py_value).map_err(|e| e.to_string())?;
@@ -1246,7 +1244,7 @@ mod tests {
         setup_python();
         Python::attach(|py| {
             // Create a mock Color class with a srgba static method
-            let code = std::ffi::CString::new(
+            let code = CString::new(
                 r#"
 import types, sys
 
@@ -1281,7 +1279,7 @@ holder = Holder()
             )
             .unwrap();
 
-            let globals = pyo3::types::PyDict::new(py);
+            let globals = PyDict::new(py);
             py.run(&code, Some(&globals), None).unwrap();
 
             let holder = globals.get_item("holder").unwrap().unwrap();
@@ -1312,7 +1310,7 @@ holder = Holder()
     fn convert_field_value_color_wrong_array_length() {
         setup_python();
         Python::attach(|py| {
-            let code = std::ffi::CString::new(
+            let code = CString::new(
                 r#"
 import types, sys
 
@@ -1347,7 +1345,7 @@ holder = Holder()
             )
             .unwrap();
 
-            let globals = pyo3::types::PyDict::new(py);
+            let globals = PyDict::new(py);
             py.run(&code, Some(&globals), None).unwrap();
 
             let holder = globals.get_item("holder").unwrap().unwrap();
@@ -1372,7 +1370,7 @@ holder = Holder()
     fn convert_field_value_non_color_falls_through() {
         setup_python();
         Python::attach(|py| {
-            let code = std::ffi::CString::new(
+            let code = CString::new(
                 r#"
 class Holder:
     def __init__(self):
@@ -1383,7 +1381,7 @@ holder = Holder()
             )
             .unwrap();
 
-            let globals = pyo3::types::PyDict::new(py);
+            let globals = PyDict::new(py);
             py.run(&code, Some(&globals), None).unwrap();
 
             let holder = globals.get_item("holder").unwrap().unwrap();
@@ -1767,7 +1765,7 @@ holder = Holder()
             ComponentDescriptor::new_with_layout(
                 "CustomComp",
                 StorageType::Table,
-                std::alloc::Layout::new::<u8>(),
+                Layout::new::<u8>(),
                 None,
                 false,
                 ComponentCloneBehavior::Default,
@@ -1775,11 +1773,11 @@ holder = Holder()
             )
         });
 
-        let mut info = pybevy_core::CustomComponentInfo::default();
+        let mut info = CustomComponentInfo::default();
         info.insert(
             comp_id,
-            pybevy_core::CustomComponentEntry {
-                type_ptr: std::ptr::null(),
+            CustomComponentEntry {
+                type_ptr: ptr::null(),
                 name: "CustomComp".to_string(),
                 is_pyobject_storage: true,
             },
@@ -1891,7 +1889,7 @@ holder = Holder()
             ComponentDescriptor::new_with_layout(
                 "GameScore",
                 StorageType::Table,
-                std::alloc::Layout::new::<u8>(),
+                Layout::new::<u8>(),
                 None,
                 false,
                 ComponentCloneBehavior::Default,
@@ -1901,14 +1899,14 @@ holder = Holder()
 
         // Use a real Python type pointer so PyO3 doesn't crash on null
         let type_ptr = Python::attach(|py| {
-            let int_type = py.get_type::<pyo3::types::PyInt>();
+            let int_type = py.get_type::<PyInt>();
             int_type.as_type_ptr()
         });
 
-        let mut info = pybevy_core::CustomResourceInfo::default();
+        let mut info = CustomResourceInfo::default();
         info.insert(
             comp_id,
-            pybevy_core::CustomResourceEntry {
+            CustomResourceEntry {
                 type_ptr,
                 name: "GameScore".to_string(),
             },
@@ -1926,7 +1924,7 @@ holder = Holder()
         assert_eq!(result.unwrap()["custom"], true);
 
         // Verify PyResourceStorage was populated
-        let storage = world.get_resource::<pybevy_core::PyResourceStorage>();
+        let storage = world.get_resource::<PyResourceStorage>();
         assert!(storage.is_some(), "PyResourceStorage should exist");
         assert!(
             storage.unwrap().resources.contains_key(&comp_id),
@@ -1976,7 +1974,7 @@ holder = Holder()
             ComponentDescriptor::new_with_layout(
                 "MyCustomRes",
                 StorageType::Table,
-                std::alloc::Layout::new::<u8>(),
+                Layout::new::<u8>(),
                 None,
                 false,
                 ComponentCloneBehavior::Default,
@@ -1986,14 +1984,14 @@ holder = Holder()
 
         // Create CustomResourceInfo with the entry
         let type_ptr = Python::attach(|py| {
-            let int_type = py.get_type::<pyo3::types::PyInt>();
+            let int_type = py.get_type::<PyInt>();
             int_type.as_type_ptr()
         });
 
-        let mut info = pybevy_core::CustomResourceInfo::default();
+        let mut info = CustomResourceInfo::default();
         info.insert(
             comp_id,
-            pybevy_core::CustomResourceEntry {
+            CustomResourceEntry {
                 type_ptr,
                 name: "MyCustomRes".to_string(),
             },
@@ -2002,14 +2000,14 @@ holder = Holder()
 
         // Pre-populate PyResourceStorage with a matching entry
         let py_obj = Python::attach(|py| 42i64.into_pyobject(py).unwrap().into_any().unbind());
-        let mut storage = pybevy_core::PyResourceStorage::default();
+        let mut storage = PyResourceStorage::default();
         storage.resources.insert(comp_id, py_obj);
         world.insert_resource(storage);
 
         // Verify resource is present before removal
         assert!(
             world
-                .get_resource::<pybevy_core::PyResourceStorage>()
+                .get_resource::<PyResourceStorage>()
                 .unwrap()
                 .resources
                 .contains_key(&comp_id),
@@ -2022,9 +2020,7 @@ holder = Holder()
         assert_eq!(result.unwrap()["removed"], "MyCustomRes");
 
         // Verify it was removed from PyResourceStorage
-        let storage = world
-            .get_resource::<pybevy_core::PyResourceStorage>()
-            .unwrap();
+        let storage = world.get_resource::<PyResourceStorage>().unwrap();
         assert!(
             !storage.resources.contains_key(&comp_id),
             "Resource should be removed from PyResourceStorage"
@@ -2069,11 +2065,11 @@ holder = Holder()
         let entity = world.spawn(Name::new("Target")).id();
 
         // Add CustomComponentInfo with entries so the error message includes them
-        let mut info = pybevy_core::CustomComponentInfo::default();
+        let mut info = CustomComponentInfo::default();
         info.insert(
             ComponentId::new(77777),
-            pybevy_core::CustomComponentEntry {
-                type_ptr: std::ptr::null(),
+            CustomComponentEntry {
+                type_ptr: ptr::null(),
                 name: "Health".to_string(),
                 is_pyobject_storage: true,
             },
@@ -2101,12 +2097,12 @@ holder = Holder()
         let entity = world.spawn(Name::new("Target")).id();
 
         // Register a custom component with qualified name (module.ClassName)
-        let mut info = pybevy_core::CustomComponentInfo::default();
+        let mut info = CustomComponentInfo::default();
         let fake_id = ComponentId::new(88888);
         info.insert(
             fake_id,
-            pybevy_core::CustomComponentEntry {
-                type_ptr: std::ptr::null(),
+            CustomComponentEntry {
+                type_ptr: ptr::null(),
                 name: "mymod.Oscillator".to_string(),
                 is_pyobject_storage: true,
             },
@@ -2169,7 +2165,7 @@ holder = Holder()
             ComponentDescriptor::new_with_layout(
                 "WrapperComp",
                 StorageType::Table,
-                std::alloc::Layout::new::<u8>(),
+                Layout::new::<u8>(),
                 None,
                 false,
                 ComponentCloneBehavior::Default,
@@ -2177,11 +2173,11 @@ holder = Holder()
             )
         });
 
-        let mut info = pybevy_core::CustomComponentInfo::default();
+        let mut info = CustomComponentInfo::default();
         info.insert(
             comp_id,
-            pybevy_core::CustomComponentEntry {
-                type_ptr: std::ptr::null(),
+            CustomComponentEntry {
+                type_ptr: ptr::null(),
                 name: "WrapperComp".to_string(),
                 is_pyobject_storage: false,
             },
@@ -2229,7 +2225,7 @@ holder = Holder()
             ComponentDescriptor::new_with_layout(
                 "ReinsertComp",
                 StorageType::Table,
-                std::alloc::Layout::new::<u8>(),
+                Layout::new::<u8>(),
                 None,
                 false,
                 ComponentCloneBehavior::Default,
@@ -2239,14 +2235,14 @@ holder = Holder()
 
         // Register as pyobject-storage custom component
         let type_ptr = Python::attach(|py| {
-            let int_type = py.get_type::<pyo3::types::PyInt>();
+            let int_type = py.get_type::<PyInt>();
             int_type.as_type_ptr()
         });
 
-        let mut info = pybevy_core::CustomComponentInfo::default();
+        let mut info = CustomComponentInfo::default();
         info.insert(
             comp_id,
-            pybevy_core::CustomComponentEntry {
+            CustomComponentEntry {
                 type_ptr,
                 name: "ReinsertComp".to_string(),
                 is_pyobject_storage: true,

--- a/crates/pybevy_control/src/handlers/pyo3/scene.rs
+++ b/crates/pybevy_control/src/handlers/pyo3/scene.rs
@@ -1284,7 +1284,7 @@ pub fn resolve_entity(world: &mut World, entity_ref: &EntityRef) -> Result<Entit
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Once;
+    use std::{ptr, sync::Once};
 
     use bevy::{
         camera::primitives::Aabb,
@@ -1292,6 +1292,7 @@ mod tests {
         math::Vec3,
         prelude::{GlobalTransform, Transform},
     };
+    use pyo3::types::PyList;
 
     // Force linker to include pybevy_transform (its inventory entries register Transform bridge)
     extern crate pybevy_transform;

--- a/crates/pybevy_control/src/handlers/pyo3/scene.rs
+++ b/crates/pybevy_control/src/handlers/pyo3/scene.rs
@@ -1,10 +1,23 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use bevy::{
-    ecs::{entity::Entity, hierarchy::ChildOf, name::Name, reflect::AppTypeRegistry, world::World},
+    ecs::{
+        component::ComponentId,
+        entity::Entity,
+        hierarchy::ChildOf,
+        name::Name,
+        reflect::{AppTypeRegistry, ReflectComponent},
+        schedule::Schedules,
+        world::{EntityRef as BevyEntityRef, World},
+    },
     reflect::TypeInfo,
 };
-use pyo3::prelude::*;
+use pybevy_core::registry::global_registry::{all_component_bridges, all_resource_bridges};
+use pyo3::{
+    ffi,
+    prelude::*,
+    types::{PyDict, PyType},
+};
 
 use crate::bridge::{ControlError, EntityRef};
 
@@ -32,8 +45,8 @@ fn get_custom_component_names(world: &World, entity: Entity) -> Vec<String> {
 /// Returns a JSON map of field_name → field_repr.
 fn extract_custom_component_fields(
     py: Python<'_>,
-    entity_ref: &bevy::ecs::world::EntityRef,
-    component_id: bevy::ecs::component::ComponentId,
+    entity_ref: &BevyEntityRef,
+    component_id: ComponentId,
     is_pyobject_storage: bool,
 ) -> Option<serde_json::Map<String, serde_json::Value>> {
     if !is_pyobject_storage {
@@ -52,7 +65,7 @@ fn extract_custom_component_fields(
     let ptr = entity_ref.get_by_id(component_id).ok()?;
 
     // For PyObject storage, the raw data is a Py<PyAny>
-    let py_obj: &pyo3::Py<PyAny> = unsafe { &*(ptr.as_ptr() as *const pyo3::Py<PyAny>) };
+    let py_obj: &Py<PyAny> = unsafe { &*(ptr.as_ptr() as *const Py<PyAny>) };
     let bound = py_obj.bind(py);
 
     let mut map = serde_json::Map::new();
@@ -87,7 +100,7 @@ fn extract_custom_component_fields(
     // Fallback: try __dict__
     if let Ok(dict) = bound.getattr("__dict__") {
         #[allow(clippy::collapsible_if)]
-        if let Ok(py_dict) = dict.cast::<pyo3::types::PyDict>() {
+        if let Ok(py_dict) = dict.cast::<PyDict>() {
             for (key, value) in py_dict.iter() {
                 if let Ok(k) = key.extract::<String>() {
                     if !k.starts_with('_') {
@@ -193,7 +206,7 @@ fn extract_bridge_fields_inner(
 /// Check if a Python type has any writable getset_descriptor properties (non-underscore).
 /// This detects types like Text2d that have settable PyO3 properties even when
 /// Bevy's reflection says they are not editable (e.g. TupleStruct types).
-fn has_writable_properties(py: Python<'_>, py_type: &Bound<'_, pyo3::types::PyType>) -> bool {
+fn has_writable_properties(py: Python<'_>, py_type: &Bound<'_, PyType>) -> bool {
     let Ok(dir_list) = py_type.dir() else {
         return false;
     };
@@ -239,7 +252,7 @@ fn extract_bridge_fields(
 /// List all entities with their component types and Names
 pub fn list_entities(world: &mut World) -> Result<serde_json::Value, ControlError> {
     let mut entities = Vec::new();
-    let bridges = pybevy_core::registry::global_registry::all_component_bridges();
+    let bridges = all_component_bridges();
 
     let mut query_state = world.query::<Entity>();
     let entity_list: Vec<Entity> = query_state.iter(world).collect();
@@ -300,8 +313,8 @@ pub fn list_entities(world: &mut World) -> Result<serde_json::Value, ControlErro
 
 /// Debug tool: get registry state and entity diagnostics
 pub fn debug_registry(world: &mut World) -> Result<serde_json::Value, ControlError> {
-    let bridges = pybevy_core::registry::global_registry::all_component_bridges();
-    let resource_bridges = pybevy_core::registry::global_registry::all_resource_bridges();
+    let bridges = all_component_bridges();
+    let resource_bridges = all_resource_bridges();
 
     let bridge_names: Vec<String> = bridges.iter().map(|b| b.name().to_string()).collect();
 
@@ -367,7 +380,7 @@ pub fn get_entity(
         let validity_flag = pybevy_core::ValidityFlag::new_read();
         let validity = validity_flag.with_access_mode(pybevy_core::AccessMode::Read);
 
-        for bridge in pybevy_core::registry::global_registry::all_component_bridges() {
+        for bridge in all_component_bridges() {
             if let Ok(entity_ref) = world.get_entity(entity)
                 && bridge.entity_contains(&entity_ref)
             {
@@ -470,7 +483,7 @@ pub fn get_component(
         let validity_flag = pybevy_core::ValidityFlag::new_read();
         let validity = validity_flag.with_access_mode(pybevy_core::AccessMode::Read);
 
-        for bridge in pybevy_core::registry::global_registry::all_component_bridges() {
+        for bridge in all_component_bridges() {
             if bridge.name() != component {
                 continue;
             }
@@ -545,7 +558,7 @@ pub fn query_entities(
     with_filters: Vec<String>,
     without_filters: Vec<String>,
 ) -> Result<serde_json::Value, ControlError> {
-    let bridges = pybevy_core::registry::global_registry::all_component_bridges();
+    let bridges = all_component_bridges();
 
     let mut query_state = world.query::<Entity>();
     let all_entities: Vec<Entity> = query_state.iter(world).collect();
@@ -681,7 +694,7 @@ fn extract_custom_resource_fields(
     // Fallback: try __dict__
     if let Ok(dict) = bound.getattr("__dict__") {
         #[allow(clippy::collapsible_if)]
-        if let Ok(py_dict) = dict.cast::<pyo3::types::PyDict>() {
+        if let Ok(py_dict) = dict.cast::<PyDict>() {
             for (key, value) in py_dict.iter() {
                 if let Ok(k) = key.extract::<String>() {
                     if !k.starts_with('_') {
@@ -704,7 +717,7 @@ pub fn list_resources(world: &mut World) -> Result<serde_json::Value, ControlErr
     let mut resources = Vec::new();
 
     // Built-in resources (from bridge registry)
-    for bridge in pybevy_core::registry::global_registry::all_resource_bridges() {
+    for bridge in all_resource_bridges() {
         let name = bridge.name().to_string();
         let present = bridge.contains_in_world(world);
 
@@ -737,13 +750,13 @@ pub fn list_resources(world: &mut World) -> Result<serde_json::Value, ControlErr
     }
 
     // Custom Python resources (from CustomResourceInfo)
-    let bridge_names: std::collections::HashSet<String> = resources
+    let bridge_names: HashSet<String> = resources
         .iter()
         .filter_map(|r| r["name"].as_str().map(String::from))
         .collect();
 
     // Collect custom resource entries before accessing PyResourceStorage
-    let custom_entries: Vec<(bevy::ecs::component::ComponentId, String)> = world
+    let custom_entries: Vec<(ComponentId, String)> = world
         .get_resource::<pybevy_core::CustomResourceInfo>()
         .map(|custom_info| {
             custom_info
@@ -790,7 +803,7 @@ pub fn list_resources(world: &mut World) -> Result<serde_json::Value, ControlErr
 pub fn list_systems(world: &mut World) -> Result<serde_json::Value, ControlError> {
     let mut stages = serde_json::Map::new();
 
-    if let Some(schedules) = world.get_resource::<bevy::ecs::schedule::Schedules>() {
+    if let Some(schedules) = world.get_resource::<Schedules>() {
         for (label, schedule) in schedules.iter() {
             let system_count = schedule.systems_len();
             stages.insert(
@@ -823,7 +836,7 @@ pub fn get_component_schema(
     }
 
     // Find the component bridge by name
-    for bridge in pybevy_core::registry::global_registry::all_component_bridges() {
+    for bridge in all_component_bridges() {
         if bridge.name() == name {
             // Try to get Bevy reflection type info for richer schema
             let reflection_info = world.get_resource::<AppTypeRegistry>().and_then(|reg| {
@@ -831,9 +844,7 @@ pub fn get_component_schema(
                 let type_id = bridge.bevy_type_id();
                 type_registry.get(type_id).map(|registration| {
                     let type_info = registration.type_info();
-                    let has_reflect_component = registration
-                        .data::<bevy::ecs::reflect::ReflectComponent>()
-                        .is_some();
+                    let has_reflect_component = registration.data::<ReflectComponent>().is_some();
                     let is_struct = matches!(type_info, TypeInfo::Struct(_));
                     // NOTE: This misses components that have settable Python properties
                     // (e.g. Text2d). A more complete check would inspect for @property
@@ -901,12 +912,9 @@ pub fn get_component_schema(
             if entry.name == name {
                 let schema = Python::attach(|py| {
                     let py_type = unsafe {
-                        pyo3::Bound::from_borrowed_ptr(
-                            py,
-                            entry.type_ptr as *mut pyo3::ffi::PyObject,
-                        )
+                        Bound::from_borrowed_ptr(py, entry.type_ptr as *mut ffi::PyObject)
                     };
-                    let fields = if let Ok(cls) = py_type.cast::<pyo3::types::PyType>() {
+                    let fields = if let Ok(cls) = py_type.cast::<PyType>() {
                         get_class_fields(py, cls)
                     } else {
                         serde_json::json!({})
@@ -964,12 +972,12 @@ fn normalize_type_repr(s: &str) -> String {
 }
 
 /// Extract field information from a Python class
-fn get_class_fields(py: Python<'_>, py_type: &Bound<'_, pyo3::types::PyType>) -> serde_json::Value {
+fn get_class_fields(py: Python<'_>, py_type: &Bound<'_, PyType>) -> serde_json::Value {
     let mut fields = serde_json::Map::new();
 
     // Try __annotations__
     if let Ok(annotations) = py_type.getattr("__annotations__")
-        && let Ok(dict) = annotations.cast::<pyo3::types::PyDict>()
+        && let Ok(dict) = annotations.cast::<PyDict>()
     {
         for (key, value) in dict.iter() {
             if let Ok(k) = key.extract::<String>() {
@@ -1133,7 +1141,7 @@ pub fn scene_summary(world: &mut World) -> Result<serde_json::Value, ControlErro
         "AudioPlayer",
     ];
 
-    let bridges = pybevy_core::registry::global_registry::all_component_bridges();
+    let bridges = all_component_bridges();
 
     let mut query_state = world.query::<Entity>();
     let entity_list: Vec<Entity> = query_state.iter(world).collect();
@@ -1510,7 +1518,7 @@ mod tests {
         info.insert(
             ComponentId::new(99999),
             pybevy_core::CustomResourceEntry {
-                type_ptr: std::ptr::null(),
+                type_ptr: ptr::null(),
                 name: "GameScore".to_string(),
             },
         );
@@ -1565,7 +1573,7 @@ mod tests {
         info.insert(
             ComponentId::new(88888),
             pybevy_core::CustomComponentEntry {
-                type_ptr: std::ptr::null(),
+                type_ptr: ptr::null(),
                 name: "PlayerStats".to_string(),
                 is_pyobject_storage: true,
             },
@@ -1865,7 +1873,7 @@ mod tests {
     fn py_value_to_json_list() {
         setup();
         Python::attach(|py| {
-            let list = pyo3::types::PyList::new(py, [1i64, 2, 3]).unwrap();
+            let list = PyList::new(py, [1i64, 2, 3]).unwrap();
             let result = py_value_to_json(list.as_any());
             assert!(result.is_array());
             let arr = result.as_array().unwrap();
@@ -1889,7 +1897,7 @@ mod tests {
             let entity = world.spawn(Transform::from_xyz(1.0, 2.0, 3.0)).id();
 
             // Extract the Transform component and check its fields are proper JSON
-            for bridge in pybevy_core::registry::global_registry::all_component_bridges() {
+            for bridge in all_component_bridges() {
                 if bridge.name() != "Transform" {
                     continue;
                 }
@@ -1941,7 +1949,7 @@ mod tests {
             let mut world = World::new();
             let entity = world.spawn(Transform::from_xyz(5.0, 10.0, 0.0)).id();
 
-            for bridge in pybevy_core::registry::global_registry::all_component_bridges() {
+            for bridge in all_component_bridges() {
                 if bridge.name() != "Transform" {
                     continue;
                 }
@@ -1975,7 +1983,7 @@ mod tests {
         setup();
         // Transform has writable getset_descriptor properties (translation, rotation, scale)
         Python::attach(|py| {
-            for bridge in pybevy_core::registry::global_registry::all_component_bridges() {
+            for bridge in all_component_bridges() {
                 if bridge.name() == "Transform" {
                     let py_type = bridge.py_type(py);
                     assert!(
@@ -1996,11 +2004,11 @@ mod tests {
         Python::attach(|py| {
             // Create a minimal Python class with no properties
             let empty_class = py
-                .run(pyo3::ffi::c_str!("class _Empty: pass"), None, None)
+                .run(ffi::c_str!("class _Empty: pass"), None, None)
                 .unwrap();
             let _ = empty_class;
-            let cls = py.eval(pyo3::ffi::c_str!("_Empty"), None, None).unwrap();
-            let py_type = cls.cast::<pyo3::types::PyType>().unwrap();
+            let cls = py.eval(ffi::c_str!("_Empty"), None, None).unwrap();
+            let py_type = cls.cast::<PyType>().unwrap();
             assert!(
                 !has_writable_properties(py, py_type),
                 "Empty class should not have writable properties"

--- a/crates/pybevy_core/src/handle.rs
+++ b/crates/pybevy_core/src/handle.rs
@@ -18,7 +18,7 @@ use std::any::TypeId;
 
 use bevy::asset::{Asset, AssetId, Handle, UntypedAssetId, UntypedHandle};
 use pyo3::{
-    IntoPyObjectExt, exceptions::PyValueError, ffi::PyTypeObject, prelude::*, types::PyType,
+    IntoPyObjectExt, exceptions::PyValueError, ffi, ffi::PyTypeObject, prelude::*, types::PyType,
 };
 use uuid::Uuid;
 
@@ -314,7 +314,7 @@ impl PyHandle {
             } else {
                 // Return the stored type pointer directly
                 unsafe {
-                    Bound::from_borrowed_ptr(py, self.type_ptr as *mut pyo3::ffi::PyObject)
+                    Bound::from_borrowed_ptr(py, self.type_ptr as *mut ffi::PyObject)
                         .cast_into_unchecked::<PyType>()
                         .unbind()
                 }

--- a/crates/pybevy_core/src/lib.rs
+++ b/crates/pybevy_core/src/lib.rs
@@ -48,31 +48,31 @@ pub use pybevy_storage::{
 
 pybevy_storage::impl_py_list!(PyF32List, "F32List", f32);
 
+use std::any::TypeId;
+
 use bevy::ecs::{
     component::ComponentId,
     entity::Entity,
     hierarchy::{ChildOf, Children},
-    world::World,
+    world::{EntityRef, EntityWorldMut, World},
 };
-use pyo3::prelude::*;
+use pyo3::{PyTypeInfo, exceptions::PyRuntimeError, ffi::PyTypeObject, prelude::*, types::PyType};
 
 // Manual implementation of ChildOfBridge because #[pycomponent(..., bridge)]
 // uses pybevy_core:: paths which don't work inside pybevy_core itself.
 pub struct ChildOfBridge;
 
 impl ComponentBridge for ChildOfBridge {
-    fn bevy_type_id(&self) -> std::any::TypeId {
-        std::any::TypeId::of::<ChildOf>()
+    fn bevy_type_id(&self) -> TypeId {
+        TypeId::of::<ChildOf>()
     }
 
-    fn py_type_ptr(&self) -> *const pyo3::ffi::PyTypeObject {
-        Python::attach(|py| {
-            <hierarchy::PyChildOf as pyo3::PyTypeInfo>::type_object(py).as_type_ptr()
-        })
+    fn py_type_ptr(&self) -> *const PyTypeObject {
+        Python::attach(|py| <hierarchy::PyChildOf as PyTypeInfo>::type_object(py).as_type_ptr())
     }
 
-    fn py_type<'py>(&self, py: Python<'py>) -> pyo3::Bound<'py, pyo3::types::PyType> {
-        <hierarchy::PyChildOf as pyo3::PyTypeInfo>::type_object(py)
+    fn py_type<'py>(&self, py: Python<'py>) -> Bound<'py, PyType> {
+        <hierarchy::PyChildOf as PyTypeInfo>::type_object(py)
     }
 
     fn name(&self) -> &'static str {
@@ -95,7 +95,7 @@ impl ComponentBridge for ChildOfBridge {
         // and return an owned copy rather than a borrowed reference.
         let ptr = entity
             .get_by_id(component_id)
-            .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("ChildOf not found"))?;
+            .ok_or_else(|| PyRuntimeError::new_err("ChildOf not found"))?;
 
         let component = unsafe { ptr.deref::<ChildOf>() };
         let py_component = hierarchy::PyChildOf::try_from(component)?;
@@ -103,13 +103,8 @@ impl ComponentBridge for ChildOfBridge {
         Ok(obj.into_any())
     }
 
-    fn insert(
-        &self,
-        world: &mut World,
-        entity: Entity,
-        component: &pyo3::Bound<PyAny>,
-    ) -> PyResult<()> {
-        let py_component = component.extract::<pyo3::PyRef<hierarchy::PyChildOf>>()?;
+    fn insert(&self, world: &mut World, entity: Entity, component: &Bound<PyAny>) -> PyResult<()> {
+        let py_component = component.extract::<PyRef<hierarchy::PyChildOf>>()?;
         let native: ChildOf = py_component.storage.as_ref()?.clone();
 
         world.entity_mut(entity).insert(native);
@@ -118,10 +113,10 @@ impl ComponentBridge for ChildOfBridge {
 
     fn insert_into_entity(
         &self,
-        entity: &mut bevy::ecs::world::EntityWorldMut,
-        component: &pyo3::Bound<PyAny>,
+        entity: &mut EntityWorldMut,
+        component: &Bound<PyAny>,
     ) -> PyResult<()> {
-        let py_component = component.extract::<pyo3::PyRef<hierarchy::PyChildOf>>()?;
+        let py_component = component.extract::<PyRef<hierarchy::PyChildOf>>()?;
         let native: ChildOf = py_component.storage.as_ref()?.clone();
 
         entity.insert(native);
@@ -140,9 +135,9 @@ impl ComponentBridge for ChildOfBridge {
             // and return an owned copy rather than a borrowed reference.
             let ptr = entity
                 .get_by_id(component_id)
-                .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("ChildOf not found"))?;
+                .ok_or_else(|| PyRuntimeError::new_err("ChildOf not found"))?;
 
-            let component = unsafe { ptr.deref::<bevy::ecs::hierarchy::ChildOf>() };
+            let component = unsafe { ptr.deref::<ChildOf>() };
             let py_component = crate::hierarchy::PyChildOf::try_from(component)?;
             let obj = Py::new(py, (py_component, crate::component::PyComponent))?;
             Ok(obj.into_any())
@@ -150,13 +145,13 @@ impl ComponentBridge for ChildOfBridge {
         extract_impl
     }
 
-    fn entity_contains(&self, entity: &bevy::ecs::world::EntityRef) -> bool {
+    fn entity_contains(&self, entity: &EntityRef) -> bool {
         entity.contains::<ChildOf>()
     }
 
     fn extract_from_entity_ref(
         &self,
-        entity: &bevy::ecs::world::EntityRef,
+        entity: &EntityRef,
         validity: ValidityFlagWithMode,
         py: Python,
     ) -> PyResult<Option<Py<PyAny>>> {
@@ -173,7 +168,7 @@ impl ComponentBridge for ChildOfBridge {
 
     fn extract_from_entity_mut(
         &self,
-        entity: &mut bevy::ecs::world::EntityWorldMut,
+        entity: &mut EntityWorldMut,
         _validity: ValidityFlagWithMode,
         py: Python,
     ) -> PyResult<Option<Py<PyAny>>> {
@@ -192,18 +187,16 @@ impl ComponentBridge for ChildOfBridge {
 pub struct ChildrenBridge;
 
 impl ComponentBridge for ChildrenBridge {
-    fn bevy_type_id(&self) -> std::any::TypeId {
-        std::any::TypeId::of::<Children>()
+    fn bevy_type_id(&self) -> TypeId {
+        TypeId::of::<Children>()
     }
 
-    fn py_type_ptr(&self) -> *const pyo3::ffi::PyTypeObject {
-        Python::attach(|py| {
-            <hierarchy::PyChildren as pyo3::PyTypeInfo>::type_object(py).as_type_ptr()
-        })
+    fn py_type_ptr(&self) -> *const PyTypeObject {
+        Python::attach(|py| <hierarchy::PyChildren as PyTypeInfo>::type_object(py).as_type_ptr())
     }
 
-    fn py_type<'py>(&self, py: Python<'py>) -> pyo3::Bound<'py, pyo3::types::PyType> {
-        <hierarchy::PyChildren as pyo3::PyTypeInfo>::type_object(py)
+    fn py_type<'py>(&self, py: Python<'py>) -> Bound<'py, PyType> {
+        <hierarchy::PyChildren as PyTypeInfo>::type_object(py)
     }
 
     fn name(&self) -> &'static str {
@@ -225,7 +218,7 @@ impl ComponentBridge for ChildrenBridge {
         // Children is read-only, use get_by_id and return an owned copy
         let ptr = entity
             .get_by_id(component_id)
-            .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("Children not found"))?;
+            .ok_or_else(|| PyRuntimeError::new_err("Children not found"))?;
 
         let component = unsafe { ptr.deref::<Children>() };
         let py_component = hierarchy::PyChildren::try_from(component)?;
@@ -237,7 +230,7 @@ impl ComponentBridge for ChildrenBridge {
         &self,
         _world: &mut World,
         _entity: Entity,
-        _component: &pyo3::Bound<PyAny>,
+        _component: &Bound<PyAny>,
     ) -> PyResult<()> {
         Err(pyo3::exceptions::PyNotImplementedError::new_err(
             "Children cannot be spawned from Python - it is auto-managed by Bevy",
@@ -246,8 +239,8 @@ impl ComponentBridge for ChildrenBridge {
 
     fn insert_into_entity(
         &self,
-        _entity: &mut bevy::ecs::world::EntityWorldMut,
-        _component: &pyo3::Bound<PyAny>,
+        _entity: &mut EntityWorldMut,
+        _component: &Bound<PyAny>,
     ) -> PyResult<()> {
         Err(pyo3::exceptions::PyNotImplementedError::new_err(
             "Children cannot be spawned from Python - it is auto-managed by Bevy",
@@ -264,9 +257,9 @@ impl ComponentBridge for ChildrenBridge {
         ) -> PyResult<Py<PyAny>> {
             let ptr = entity
                 .get_by_id(component_id)
-                .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("Children not found"))?;
+                .ok_or_else(|| PyRuntimeError::new_err("Children not found"))?;
 
-            let component = unsafe { ptr.deref::<bevy::ecs::hierarchy::Children>() };
+            let component = unsafe { ptr.deref::<Children>() };
             let py_component = crate::hierarchy::PyChildren::try_from(component)?;
             let obj = Py::new(py, (py_component, crate::component::PyComponent))?;
             Ok(obj.into_any())
@@ -274,13 +267,13 @@ impl ComponentBridge for ChildrenBridge {
         extract_impl
     }
 
-    fn entity_contains(&self, entity: &bevy::ecs::world::EntityRef) -> bool {
+    fn entity_contains(&self, entity: &EntityRef) -> bool {
         entity.contains::<Children>()
     }
 
     fn extract_from_entity_ref(
         &self,
-        entity: &bevy::ecs::world::EntityRef,
+        entity: &EntityRef,
         _validity: ValidityFlagWithMode,
         py: Python,
     ) -> PyResult<Option<Py<PyAny>>> {
@@ -295,7 +288,7 @@ impl ComponentBridge for ChildrenBridge {
 
     fn extract_from_entity_mut(
         &self,
-        entity: &mut bevy::ecs::world::EntityWorldMut,
+        entity: &mut EntityWorldMut,
         _validity: ValidityFlagWithMode,
         py: Python,
     ) -> PyResult<Option<Py<PyAny>>> {

--- a/crates/pybevy_core/src/registry/global_registry.rs
+++ b/crates/pybevy_core/src/registry/global_registry.rs
@@ -19,6 +19,7 @@
 //! The RwLock allows concurrent reads (common case) with exclusive writes (registration).
 
 use std::{
+    any::TypeId,
     collections::HashMap,
     sync::{Arc, OnceLock, RwLock},
 };
@@ -192,7 +193,7 @@ struct GlobalAssetBridgeRegistry {
     /// PyTypeObject* → Bridge
     by_py_type: HashMap<*const PyTypeObject, Arc<dyn AssetBridge>>,
     /// TypeId → Bridge (for lookups from Bevy types)
-    by_type_id: HashMap<std::any::TypeId, Arc<dyn AssetBridge>>,
+    by_type_id: HashMap<TypeId, Arc<dyn AssetBridge>>,
 }
 
 // SAFETY: PyTypeObject pointers are stable for the lifetime of the Python interpreter
@@ -261,7 +262,7 @@ pub fn asset_bridge_count() -> usize {
 ///
 /// Returns the bridge if found, None otherwise.
 /// Used by From<Handle<A>> for PyHandle to get the Python type info.
-pub fn get_asset_bridge_by_type_id(type_id: std::any::TypeId) -> Option<Arc<dyn AssetBridge>> {
+pub fn get_asset_bridge_by_type_id(type_id: TypeId) -> Option<Arc<dyn AssetBridge>> {
     let registry = get_global_asset_registry();
     let guard = registry
         .read()
@@ -294,7 +295,7 @@ static GLOBAL_TYPE_ID_REGISTRY: OnceLock<RwLock<TypeIdRegistry>> = OnceLock::new
 #[derive(Default)]
 struct TypeIdRegistry {
     /// PyTypeObject* → TypeId
-    by_py_type: HashMap<*const PyTypeObject, std::any::TypeId>,
+    by_py_type: HashMap<*const PyTypeObject, TypeId>,
 }
 
 // SAFETY: PyTypeObject pointers are stable for the lifetime of the Python interpreter
@@ -314,7 +315,7 @@ fn get_type_id_registry() -> &'static RwLock<TypeIdRegistry> {
 pub fn register_type_id<P: pyo3::PyTypeInfo, B: 'static>() {
     pyo3::Python::attach(|py| {
         let ptr = P::type_object(py).as_type_ptr();
-        let type_id = std::any::TypeId::of::<B>();
+        let type_id = TypeId::of::<B>();
         let registry = get_type_id_registry();
         let mut guard = registry.write().expect("TypeId registry lock poisoned");
         guard.by_py_type.insert(ptr, type_id);
@@ -325,7 +326,7 @@ pub fn register_type_id<P: pyo3::PyTypeInfo, B: 'static>() {
 ///
 /// First checks the component bridge registry, then falls back to the TypeId registry.
 /// Returns None if the type is not registered.
-pub fn get_type_id_by_py_type(ptr: *const PyTypeObject) -> Option<std::any::TypeId> {
+pub fn get_type_id_by_py_type(ptr: *const PyTypeObject) -> Option<TypeId> {
     // First check bridge registry (feature crate components)
     if let Some(bridge) = get_bridge_by_py_type(ptr) {
         return Some(bridge.bevy_type_id());
@@ -347,7 +348,7 @@ struct GlobalMessageBridgeRegistry {
     /// PyTypeObject* → Bridge
     by_py_type: HashMap<*const PyTypeObject, Arc<dyn MessageBridge>>,
     /// TypeId → Bridge (for lookups from Bevy types)
-    by_type_id: HashMap<std::any::TypeId, Arc<dyn MessageBridge>>,
+    by_type_id: HashMap<TypeId, Arc<dyn MessageBridge>>,
 }
 
 // SAFETY: PyTypeObject pointers are stable for the lifetime of the Python interpreter
@@ -416,7 +417,7 @@ pub fn message_bridge_count() -> usize {
 ///
 /// Returns the bridge if found, None otherwise.
 /// Used for iterating messages by type.
-pub fn get_message_bridge_by_type_id(type_id: std::any::TypeId) -> Option<Arc<dyn MessageBridge>> {
+pub fn get_message_bridge_by_type_id(type_id: TypeId) -> Option<Arc<dyn MessageBridge>> {
     let registry = get_global_message_registry();
     let guard = registry
         .read()
@@ -614,11 +615,11 @@ mod tests {
     #[test]
     fn test_empty_registry() {
         // Registry should be accessible
-        assert!(get_bridge_by_py_type(std::ptr::null()).is_none());
+        assert!(get_bridge_by_py_type(ptr::null()).is_none());
     }
 
     #[test]
     fn test_null_pointer_not_found() {
-        assert!(!contains_py_type(std::ptr::null()));
+        assert!(!contains_py_type(ptr::null()));
     }
 }

--- a/crates/pybevy_core/src/registry/global_registry.rs
+++ b/crates/pybevy_core/src/registry/global_registry.rs
@@ -607,6 +607,8 @@ pub fn run_system_once(
 
 #[cfg(test)]
 mod tests {
+    use std::ptr;
+
     use super::*;
 
     // Note: Can't easily test registration without a real ComponentBridge impl

--- a/crates/pybevy_core/src/reload_request.rs
+++ b/crates/pybevy_core/src/reload_request.rs
@@ -188,6 +188,8 @@ unsafe impl Sync for PyResourceStorage {}
 
 #[cfg(test)]
 mod tests {
+    use std::ptr;
+
     use super::*;
 
     fn make_component_id(index: usize) -> ComponentId {

--- a/crates/pybevy_core/src/reload_request.rs
+++ b/crates/pybevy_core/src/reload_request.rs
@@ -196,7 +196,7 @@ mod tests {
 
     fn make_entry(name: &str) -> CustomComponentEntry {
         CustomComponentEntry {
-            type_ptr: std::ptr::null(),
+            type_ptr: ptr::null(),
             name: name.to_string(),
             is_pyobject_storage: false,
         }
@@ -204,7 +204,7 @@ mod tests {
 
     fn make_resource_entry(name: &str) -> CustomResourceEntry {
         CustomResourceEntry {
-            type_ptr: std::ptr::null(),
+            type_ptr: ptr::null(),
             name: name.to_string(),
         }
     }

--- a/crates/pybevy_image/src/texture_atlas_sources.rs
+++ b/crates/pybevy_image/src/texture_atlas_sources.rs
@@ -1,4 +1,5 @@
 use bevy::{
+    asset::Handle,
     image::{Image, TextureAtlasLayout, TextureAtlasSources},
     platform::collections::HashMap,
 };
@@ -25,13 +26,13 @@ impl PyTextureAtlasSources {
     }
 
     pub fn texture_index(&self, texture: PyHandle) -> PyResult<Option<usize>> {
-        let handle: bevy::asset::Handle<Image> = texture.try_into()?;
+        let handle: Handle<Image> = texture.try_into()?;
         Ok(self.inner.texture_index(&handle))
     }
 
     pub fn handle(&self, layout: PyHandle, texture: PyHandle) -> PyResult<Option<PyTextureAtlas>> {
-        let layout_handle: bevy::asset::Handle<TextureAtlasLayout> = layout.try_into()?;
-        let texture_handle: bevy::asset::Handle<Image> = texture.try_into()?;
+        let layout_handle: Handle<TextureAtlasLayout> = layout.try_into()?;
+        let texture_handle: Handle<Image> = texture.try_into()?;
         Ok(self
             .inner
             .handle(layout_handle, &texture_handle)

--- a/crates/pybevy_light/src/ambient_light.rs
+++ b/crates/pybevy_light/src/ambient_light.rs
@@ -1,3 +1,5 @@
+use std::ptr;
+
 use bevy::{
     ecs::resource::Resource,
     light::{AmbientLight, GlobalAmbientLight},
@@ -30,7 +32,7 @@ impl PartialEq for PyGlobalAmbientLight {
             (
                 ResourceStorageInner::Borrowed { ptr: a, .. },
                 ResourceStorageInner::Borrowed { ptr: b, .. },
-            ) => std::ptr::eq(
+            ) => ptr::eq(
                 *a as *const GlobalAmbientLight,
                 *b as *const GlobalAmbientLight,
             ),

--- a/crates/pybevy_light/src/clustered_decal.rs
+++ b/crates/pybevy_light/src/clustered_decal.rs
@@ -1,10 +1,8 @@
-use bevy::light::ClusteredDecal;
+use bevy::{asset::Handle, image::Image, light::ClusteredDecal};
 use pybevy_core::{ComponentStorage, PyComponent, PyHandle, extract_handle_from_any};
 use pybevy_macros::pycomponent;
 use pyo3::prelude::*;
-fn convert_optional_handle(
-    handle: Option<&Bound<'_, PyAny>>,
-) -> PyResult<Option<bevy::asset::Handle<bevy::image::Image>>> {
+fn convert_optional_handle(handle: Option<&Bound<'_, PyAny>>) -> PyResult<Option<Handle<Image>>> {
     match handle {
         Some(h) => {
             let py_handle = extract_handle_from_any(h)?;

--- a/crates/pybevy_mesh/src/mesh.rs
+++ b/crates/pybevy_mesh/src/mesh.rs
@@ -57,44 +57,44 @@ macro_rules! mesh_with_mut {
 #[pymethods]
 impl PyMesh {
     #[classattr]
-    #[allow(non_snake_case)]
-    pub fn ATTRIBUTE_POSITION(py: Python<'_>) -> PyResult<Py<PyMeshVertexAttribute>> {
+    #[pyo3(name = "ATTRIBUTE_POSITION")]
+    pub fn attribute_position(py: Python<'_>) -> PyResult<Py<PyMeshVertexAttribute>> {
         Py::new(py, PyMeshVertexAttribute::from(Mesh::ATTRIBUTE_POSITION))
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
-    pub fn ATTRIBUTE_NORMAL(py: Python<'_>) -> PyResult<Py<PyMeshVertexAttribute>> {
+    #[pyo3(name = "ATTRIBUTE_NORMAL")]
+    pub fn attribute_normal(py: Python<'_>) -> PyResult<Py<PyMeshVertexAttribute>> {
         Py::new(py, PyMeshVertexAttribute::from(Mesh::ATTRIBUTE_NORMAL))
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
-    pub fn ATTRIBUTE_UV_0(py: Python<'_>) -> PyResult<Py<PyMeshVertexAttribute>> {
+    #[pyo3(name = "ATTRIBUTE_UV_0")]
+    pub fn attribute_uv_0(py: Python<'_>) -> PyResult<Py<PyMeshVertexAttribute>> {
         Py::new(py, PyMeshVertexAttribute::from(Mesh::ATTRIBUTE_UV_0))
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
-    pub fn ATTRIBUTE_UV_1(py: Python<'_>) -> PyResult<Py<PyMeshVertexAttribute>> {
+    #[pyo3(name = "ATTRIBUTE_UV_1")]
+    pub fn attribute_uv_1(py: Python<'_>) -> PyResult<Py<PyMeshVertexAttribute>> {
         Py::new(py, PyMeshVertexAttribute::from(Mesh::ATTRIBUTE_UV_1))
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
-    pub fn ATTRIBUTE_TANGENT(py: Python<'_>) -> PyResult<Py<PyMeshVertexAttribute>> {
+    #[pyo3(name = "ATTRIBUTE_TANGENT")]
+    pub fn attribute_tangent(py: Python<'_>) -> PyResult<Py<PyMeshVertexAttribute>> {
         Py::new(py, PyMeshVertexAttribute::from(Mesh::ATTRIBUTE_TANGENT))
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
-    pub fn ATTRIBUTE_COLOR(py: Python<'_>) -> PyResult<Py<PyMeshVertexAttribute>> {
+    #[pyo3(name = "ATTRIBUTE_COLOR")]
+    pub fn attribute_color(py: Python<'_>) -> PyResult<Py<PyMeshVertexAttribute>> {
         Py::new(py, PyMeshVertexAttribute::from(Mesh::ATTRIBUTE_COLOR))
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
-    pub fn ATTRIBUTE_JOINT_WEIGHT(py: Python<'_>) -> PyResult<Py<PyMeshVertexAttribute>> {
+    #[pyo3(name = "ATTRIBUTE_JOINT_WEIGHT")]
+    pub fn attribute_joint_weight(py: Python<'_>) -> PyResult<Py<PyMeshVertexAttribute>> {
         Py::new(
             py,
             PyMeshVertexAttribute::from(Mesh::ATTRIBUTE_JOINT_WEIGHT),
@@ -102,8 +102,8 @@ impl PyMesh {
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
-    pub fn ATTRIBUTE_JOINT_INDEX(py: Python<'_>) -> PyResult<Py<PyMeshVertexAttribute>> {
+    #[pyo3(name = "ATTRIBUTE_JOINT_INDEX")]
+    pub fn attribute_joint_index(py: Python<'_>) -> PyResult<Py<PyMeshVertexAttribute>> {
         Py::new(py, PyMeshVertexAttribute::from(Mesh::ATTRIBUTE_JOINT_INDEX))
     }
 

--- a/crates/pybevy_mesh/src/vertex_attribute.rs
+++ b/crates/pybevy_mesh/src/vertex_attribute.rs
@@ -1,3 +1,5 @@
+use std::ptr;
+
 use bevy::mesh::{MeshVertexAttribute, VertexAttributeValues};
 use numpy::{PyReadonlyArray1, PyReadonlyArray2, PyUntypedArrayMethods};
 use pyo3::{exceptions::PyTypeError, prelude::*, types::PyAny};
@@ -81,7 +83,7 @@ impl PyVertexAttributeValues {
                         // - [f32; 2] and [f32] have same alignment
                         let out: Vec<[f32; 2]> = unsafe {
                             let mut out = Vec::with_capacity(n);
-                            std::ptr::copy_nonoverlapping(
+                            ptr::copy_nonoverlapping(
                                 flat.as_ptr(),
                                 out.as_mut_ptr() as *mut f32,
                                 n * 2,
@@ -101,7 +103,7 @@ impl PyVertexAttributeValues {
                         // - [f32; 3] and [f32] have same alignment
                         let out: Vec<[f32; 3]> = unsafe {
                             let mut out = Vec::with_capacity(n);
-                            std::ptr::copy_nonoverlapping(
+                            ptr::copy_nonoverlapping(
                                 flat.as_ptr(),
                                 out.as_mut_ptr() as *mut f32,
                                 n * 3,
@@ -121,7 +123,7 @@ impl PyVertexAttributeValues {
                         // - [f32; 4] and [f32] have same alignment
                         let out: Vec<[f32; 4]> = unsafe {
                             let mut out = Vec::with_capacity(n);
-                            std::ptr::copy_nonoverlapping(
+                            ptr::copy_nonoverlapping(
                                 flat.as_ptr(),
                                 out.as_mut_ptr() as *mut f32,
                                 n * 4,

--- a/crates/pybevy_pbr/src/lightmap.rs
+++ b/crates/pybevy_pbr/src/lightmap.rs
@@ -1,4 +1,4 @@
-use bevy::pbr::Lightmap;
+use bevy::{math::Rect, pbr::Lightmap};
 use pybevy_core::{ComponentStorage, PyComponent, PyHandle, extract_handle_from_any};
 use pybevy_macros::pycomponent;
 use pybevy_math::rect::PyRect;
@@ -25,7 +25,7 @@ impl PyLightmap {
             image: handle.try_into()?,
             uv_rect: uv_rect
                 .map(Into::into)
-                .unwrap_or(bevy::math::Rect::new(0.0, 0.0, 1.0, 1.0)),
+                .unwrap_or(Rect::new(0.0, 0.0, 1.0, 1.0)),
             bicubic_sampling,
         }))
     }

--- a/crates/pybevy_pbr/src/shader_material_py.rs
+++ b/crates/pybevy_pbr/src/shader_material_py.rs
@@ -1,6 +1,8 @@
 use bevy::{
+    app::{App, Last},
+    asset::Handle,
     image::Image,
-    pbr::{MeshMaterial3d, StandardMaterial},
+    pbr::{MaterialPlugin, MeshMaterial3d, StandardMaterial},
 };
 use pybevy_core::{
     AssetInputConverter, AssetStorage, NativeAsset, PluginBuild, PyAsset, PyComponent, PyHandle,
@@ -10,6 +12,7 @@ use pybevy_macros::{pyasset, pyhandle, pyplugin};
 use pyo3::{
     exceptions::{PyIndexError, PyTypeError},
     prelude::*,
+    types::PyList,
 };
 
 use crate::{
@@ -50,7 +53,7 @@ impl PyShaderMaterial {
         data: Option<Vec<f32>>,
         shader_defs: u32,
         shader_def_names: Option<Vec<String>>,
-        textures: Option<Py<pyo3::types::PyList>>,
+        textures: Option<Py<PyList>>,
         bindings_wgsl: Option<String>,
     ) -> PyResult<(Self, PyAsset)> {
         let mut py_mat = base.extract::<PyRefMut<'_, PyStandardMaterial>>()?;
@@ -73,8 +76,7 @@ impl PyShaderMaterial {
         }
 
         // Extract texture handles from Python list [handle_or_None, ...]
-        let mut tex_handles: [Option<bevy::asset::Handle<Image>>; MAX_TEXTURE_SLOTS] =
-            Default::default();
+        let mut tex_handles: [Option<Handle<Image>>; MAX_TEXTURE_SLOTS] = Default::default();
 
         if let Some(tex_list) = textures {
             let list = tex_list.bind(py);
@@ -87,7 +89,7 @@ impl PyShaderMaterial {
                 }
                 if !item.is_none() {
                     let py_handle = extract_handle_from_any(&item)?;
-                    let typed: bevy::asset::Handle<Image> = (&py_handle).try_into()?;
+                    let typed: Handle<Image> = (&py_handle).try_into()?;
                     tex_handles[i] = Some(typed);
                 }
             }
@@ -122,7 +124,7 @@ impl PyShaderMaterial {
 
     fn set_texture(&mut self, slot: usize, handle: &Bound<'_, PyAny>) -> PyResult<()> {
         let py_handle = extract_handle_from_any(handle)?;
-        let typed: bevy::asset::Handle<Image> = (&py_handle).try_into()?;
+        let typed: Handle<Image> = (&py_handle).try_into()?;
         let mat = self.as_mut()?;
         match slot {
             0 => mat.extension.texture_0 = Some(typed),
@@ -215,7 +217,7 @@ impl PyShaderMaterial {
     }
 }
 
-#[pyplugin(bevy::pbr::MaterialPlugin::<ShaderMaterial>)]
+#[pyplugin(MaterialPlugin::<ShaderMaterial>)]
 #[pyclass(name = "ShaderMaterialPlugin", extends = PyPlugin, frozen)]
 #[derive(Debug, Clone)]
 pub struct PyShaderMaterialPlugin;
@@ -230,10 +232,10 @@ impl PyShaderMaterialPlugin {
 }
 
 impl PluginBuild for PyShaderMaterialPlugin {
-    fn build(_py_plugin: &Bound<'_, PyAny>, app: &mut bevy::app::App) -> PyResult<()> {
+    fn build(_py_plugin: &Bound<'_, PyAny>, app: &mut App) -> PyResult<()> {
         crate::shader_material::clear_shader_registries();
-        app.add_plugins(bevy::pbr::MaterialPlugin::<ShaderMaterial>::default());
-        app.add_systems(bevy::app::Last, crate::shader_material::sync_shader_handles);
+        app.add_plugins(MaterialPlugin::<ShaderMaterial>::default());
+        app.add_systems(Last, crate::shader_material::sync_shader_handles);
         Ok(())
     }
 }

--- a/crates/pybevy_pbr/src/standard_material.rs
+++ b/crates/pybevy_pbr/src/standard_material.rs
@@ -1,5 +1,7 @@
 use bevy::{
+    asset::Handle,
     color::{Color, LinearRgba},
+    image::Image,
     pbr::StandardMaterial,
 };
 use pybevy_color::{color::PyColor, linear_rgba::PyLinearRgba};
@@ -26,9 +28,7 @@ fn extract_linear_rgba(value: &Bound<'_, PyAny>) -> PyResult<LinearRgba> {
     }
 }
 
-fn convert_optional_handle(
-    handle: Option<&Bound<'_, PyAny>>,
-) -> PyResult<Option<bevy::asset::Handle<bevy::image::Image>>> {
+fn convert_optional_handle(handle: Option<&Bound<'_, PyAny>>) -> PyResult<Option<Handle<Image>>> {
     match handle {
         Some(h) => {
             let extracted = extract_handle_from_any(h)?;

--- a/crates/pybevy_reload/src/cleanup.rs
+++ b/crates/pybevy_reload/src/cleanup.rs
@@ -6,6 +6,7 @@ use bevy::{
     prelude::Resource,
     time::{Time, Virtual},
 };
+use pybevy_core::asset_cleanup::clear_all_programmatic_assets;
 
 use crate::{BaseEntitySet, runtime::ReloadRuntime};
 
@@ -71,7 +72,7 @@ pub fn clear_world_state<R: ReloadRuntime>(world: &mut World, runtime: &mut R, v
         eprintln!("   → Clearing programmatic assets (preserving file-loaded)");
     }
 
-    pybevy_core::asset_cleanup::clear_all_programmatic_assets(world, verbose);
+    clear_all_programmatic_assets(world, verbose);
 
     // Clear custom runtime resources (preserves built-in and HotReloadControl)
     if verbose {

--- a/crates/pybevy_storage/src/pyasset.rs
+++ b/crates/pybevy_storage/src/pyasset.rs
@@ -29,6 +29,8 @@
 //! - **`BorrowedReadOnly`**: Created from `Res[Assets[T]].get()`, stores `*const T`
 //! - **`BorrowedMut`**: Created from `ResMut[Assets[T]].get_mut()`, stores `*mut T`
 
+use std::ptr;
+
 use bevy::asset::{Asset, UntypedHandle};
 
 use crate::{ValidityFlagWithMode, storage_error::StorageError};
@@ -252,7 +254,7 @@ impl<T: Asset> AssetStorage<T> {
     fn as_ptr(&self) -> *const T {
         match &self.inner {
             AssetStorageInner::Owned(Some(asset)) => &**asset as *const T,
-            AssetStorageInner::Owned(None) => std::ptr::null(),
+            AssetStorageInner::Owned(None) => ptr::null(),
             AssetStorageInner::BorrowedReadOnly { ptr, .. } => *ptr,
             AssetStorageInner::BorrowedMut { ptr, .. } => *ptr as *const T,
         }
@@ -267,10 +269,10 @@ impl<T: Asset> AssetStorage<T> {
     fn as_mut_ptr(&mut self) -> *mut T {
         match &mut self.inner {
             AssetStorageInner::Owned(Some(asset)) => &mut **asset as *mut T,
-            AssetStorageInner::Owned(None) => std::ptr::null_mut(),
+            AssetStorageInner::Owned(None) => ptr::null_mut(),
             // Read-only borrowed cannot be mutated - return null
             // check_write() will catch this before we get here
-            AssetStorageInner::BorrowedReadOnly { .. } => std::ptr::null_mut(),
+            AssetStorageInner::BorrowedReadOnly { .. } => ptr::null_mut(),
             AssetStorageInner::BorrowedMut { ptr, .. } => *ptr,
         }
     }

--- a/crates/pybevy_text/src/font_atlas_sets.rs
+++ b/crates/pybevy_text/src/font_atlas_sets.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    asset::AssetId,
+    asset::{AssetId, Handle},
     text::{Font, FontAtlasSet},
 };
 use pybevy_core::{ResourceStorage, extract_handle_from_any};
@@ -21,7 +21,7 @@ impl PyFontAtlasSet {
         id: &Bound<'_, PyAny>,
     ) -> PyResult<Vec<(PyFontAtlasKey, Vec<PyFontAtlas>)>> {
         let handle = extract_handle_from_any(id)?;
-        let bevy_handle: bevy::asset::Handle<Font> = (&handle).try_into()?;
+        let bevy_handle: Handle<Font> = (&handle).try_into()?;
         let asset_id: AssetId<Font> = bevy_handle.id();
         let set = self.as_ref()?;
         let results: Vec<(PyFontAtlasKey, Vec<PyFontAtlas>)> = set

--- a/crates/pybevy_text/src/text_font.rs
+++ b/crates/pybevy_text/src/text_font.rs
@@ -1,4 +1,7 @@
-use bevy::text::{Font, FontSmoothing, FontWeight, TextFont};
+use bevy::{
+    asset::Handle,
+    text::{Font, FontSmoothing, FontWeight, TextFont},
+};
 use pybevy_core::{PyComponent, PyHandle, extract_handle_from_any, pycomponent::ComponentStorage};
 use pybevy_macros::pycomponent;
 use pyo3::prelude::*;
@@ -49,7 +52,7 @@ impl PyTextFont {
         weight: PyFontWeight,
         font_features: PyFontFeatures,
     ) -> PyResult<(Self, PyComponent)> {
-        let font_handle: bevy::asset::Handle<Font> = match font {
+        let font_handle: Handle<Font> = match font {
             Some(handle_obj) => {
                 let handle = extract_handle_from_any(handle_obj)?;
                 (&handle).try_into()?

--- a/crates/pybevy_transform/src/transform.rs
+++ b/crates/pybevy_transform/src/transform.rs
@@ -1,4 +1,7 @@
-use bevy::{math::Dir3, transform::components::Transform};
+use bevy::{
+    math::{Dir3, Mat4},
+    transform::components::Transform,
+};
 use pybevy_core::{ComponentStorage, PyComponent};
 use pybevy_macros::pycomponent;
 use pybevy_math::{
@@ -62,7 +65,7 @@ impl PyTransform {
 
     #[staticmethod]
     pub fn from_matrix(py: Python, world_from_local: &PyMat4) -> PyResult<Py<Self>> {
-        let bevy_mat: bevy::math::Mat4 = world_from_local.into();
+        let bevy_mat: Mat4 = world_from_local.into();
         let transform = Transform::from_matrix(bevy_mat);
         Py::new(py, (transform.into(), PyComponent))
     }
@@ -74,8 +77,8 @@ impl PyTransform {
     }
 
     #[staticmethod]
-    #[allow(non_snake_case)]
-    pub fn IDENTITY(py: Python) -> PyResult<Py<Self>> {
+    #[pyo3(name = "IDENTITY")]
+    pub fn identity(py: Python) -> PyResult<Py<Self>> {
         Py::new(py, (Transform::IDENTITY.into(), PyComponent))
     }
 

--- a/crates/pybevy_ui/src/border_radius.rs
+++ b/crates/pybevy_ui/src/border_radius.rs
@@ -1,4 +1,4 @@
-use bevy::ui::BorderRadius;
+use bevy::ui::{BorderRadius, Val};
 use pyo3::prelude::*;
 
 use crate::val::PyVal;
@@ -30,16 +30,16 @@ impl From<&PyBorderRadius> for BorderRadius {
 #[pymethods]
 impl PyBorderRadius {
     #[classattr]
-    #[allow(non_snake_case)]
-    pub fn ZERO() -> Self {
+    #[pyo3(name = "ZERO")]
+    pub fn zero() -> Self {
         Self {
             inner: BorderRadius::ZERO,
         }
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
-    pub fn MAX() -> Self {
+    #[pyo3(name = "MAX")]
+    pub fn max() -> Self {
         Self {
             inner: BorderRadius::MAX,
         }
@@ -54,7 +54,7 @@ impl PyBorderRadius {
         bottom_left: Option<PyVal>,
         bottom_right: Option<PyVal>,
     ) -> Self {
-        let base: bevy::ui::Val = radius.into();
+        let base: Val = radius.into();
         Self {
             inner: BorderRadius {
                 top_left: top_left.map(Into::into).unwrap_or(base),

--- a/src/app/app_exit.rs
+++ b/src/app/app_exit.rs
@@ -39,8 +39,8 @@ impl PyAppExit {
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
-    pub fn SUCCESS() -> PyResult<Py<Self>> {
+    #[pyo3(name = "SUCCESS")]
+    pub fn success() -> PyResult<Py<Self>> {
         Python::attach(|py| Py::new(py, (Self(AppExit::Success), PyMessage)))
     }
 

--- a/src/app/hot_reload/cleanup.rs
+++ b/src/app/hot_reload/cleanup.rs
@@ -1,4 +1,7 @@
-use bevy::ecs::{entity::Entity, world::World};
+use bevy::ecs::{
+    entity::Entity,
+    world::{EntityRef, World},
+};
 use pybevy_reload::is_verbose;
 use pyo3::prelude::*;
 
@@ -74,7 +77,7 @@ pub(crate) fn clear_custom_resources(world: &mut World, verbose: bool) {
 pub fn clear_entities_and_resources(world: &mut World) {
     // Despawn ALL entities (complete clean slate)
     let all_entities: Vec<Entity> = world
-        .query::<bevy::ecs::world::EntityRef>()
+        .query::<EntityRef>()
         .iter(world)
         .map(|e| e.id())
         .collect();

--- a/src/ecs/observer.rs
+++ b/src/ecs/observer.rs
@@ -1,3 +1,7 @@
+use bevy::ecs::{
+    entity::Entity,
+    world::{EntityRef, World},
+};
 use pyo3::{PyTypeInfo, exceptions::PyTypeError, prelude::*, types::PyType};
 
 use super::{
@@ -396,11 +400,7 @@ pub struct BundleFilter {
 impl BundleFilter {
     /// Check if an entity matches this bundle filter.
     /// Returns true if the entity has at least one of the components (OR logic).
-    pub(crate) fn matches(
-        &self,
-        world: &bevy::ecs::world::World,
-        entity: bevy::ecs::entity::Entity,
-    ) -> bool {
+    pub(crate) fn matches(&self, world: &World, entity: Entity) -> bool {
         // Get entity reference
         let entity_ref = match world.get_entity(entity) {
             Ok(e) => e,
@@ -415,11 +415,7 @@ impl BundleFilter {
 }
 
 /// Helper function to check if an entity has a specific component type
-fn entity_has_component(
-    world: &bevy::ecs::world::World,
-    entity: &bevy::ecs::world::EntityRef,
-    comp_type: &PyComponentType,
-) -> bool {
+fn entity_has_component(world: &World, entity: &EntityRef, comp_type: &PyComponentType) -> bool {
     match comp_type {
         PyComponentType::Custom(type_ptr) => {
             // For custom components, look up the ComponentId from the registry
@@ -440,8 +436,8 @@ fn entity_has_component(
 /// Public helper to check if an entity has a specific component type.
 /// This is used by commands.rs to check for component existence before insertion.
 pub(crate) fn entity_has_component_type(
-    world: &bevy::ecs::world::World,
-    entity: bevy::ecs::entity::Entity,
+    world: &World,
+    entity: Entity,
     comp_type: &PyComponentType,
 ) -> bool {
     match world.get_entity(entity) {


### PR DESCRIPTION
Also using macro-level renames instead of capital-case methods.