### PR TITLE
Refactor pybevy-control tool schema & flat namespace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2326,6 +2326,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4414,6 +4420,7 @@ dependencies = [
  "pybevy_macros",
  "pybevy_transform",
  "pyo3",
+ "schemars",
  "serde",
  "serde_json",
  "tokio",
@@ -4975,6 +4982,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5109,6 +5136,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.110",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5179,6 +5231,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/pybevy_control/Cargo.toml
+++ b/crates/pybevy_control/Cargo.toml
@@ -36,6 +36,7 @@ axum = { version = "0.8", features = ["json"] }
 tower-http = { version = "0.6", features = ["cors"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 base64 = "0.22"
+schemars = "1.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 image = { version = "0.25", default-features = false, features = ["png"] }

--- a/crates/pybevy_control/src/bridge.rs
+++ b/crates/pybevy_control/src/bridge.rs
@@ -1,16 +1,18 @@
 use std::sync::{Arc, Mutex};
 
 use bevy::{ecs::world::World, prelude::Resource};
-use serde::Deserialize;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, oneshot};
 
 use crate::handlers::{
     self,
     reload::{PendingReloadAndCapture, PendingReloadAndCaptures, ReloadAndCaptureState},
     schedule::{
-        ActiveSchedule, ActiveSchedules, SharedScheduleRegistryResource, SharedScheduleState,
+        ActiveSchedule, ActiveSchedules, ScheduleMode, ScheduleRequest,
+        SharedScheduleRegistryResource, SharedScheduleState,
     },
-    screenshot::{ActiveTimeline, PendingTimelines, setup_debug_camera},
+    screenshot::{ActiveTimeline, PendingTimelines, compute_schedule, setup_debug_camera},
     turnaround::{ActiveTurnaround, PendingTurnarounds, compute_scene_bounds, compute_viewpoints},
 };
 
@@ -23,208 +25,426 @@ const MAX_REQUESTS_PER_FRAME: usize = 32;
 pub struct InternalOverlayUi;
 
 /// Entity can be addressed by numeric ID or Name string
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(untagged)]
 pub enum EntityRef {
     Id(u64),
     Name(String),
 }
 
-/// Scene inspection operations (read-only)
-#[derive(Debug)]
-pub enum SceneOp {
+/// Reload mode: full (default) re-executes all scene code, partial only reloads changed systems.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ReloadMode {
+    /// Re-execute all scene code
+    #[default]
+    Full,
+    /// Only reload changed systems
+    Partial,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct QueryEntitiesParams {
+    /// Component names entities must have
+    #[serde(default)]
+    pub with: Vec<String>,
+    /// Component names entities must not have
+    #[serde(default)]
+    pub without: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct GetComponentParams {
+    /// Entity ID or Name
+    pub entity: EntityRef,
+    /// Component name (e.g. 'Transform', 'PointLight')
+    pub component: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SetComponentParams {
+    /// Entity ID or Name
+    pub entity: EntityRef,
+    /// Component name
+    pub component: String,
+    /// Fields to update
+    pub fields: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct RemoveComponentParams {
+    /// Entity ID or Name
+    pub entity: EntityRef,
+    /// Component to remove
+    pub component: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SetResourceParams {
+    /// Resource type name
+    pub resource_type: String,
+    /// Resource value as JSON
+    pub value: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SeekTimeParams {
+    /// Target elapsed time in seconds
+    pub seconds: f64,
+    /// Pause after seeking (default true)
+    #[serde(default = "default_true")]
+    pub pause: bool,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CaptureScreenshotParams {
+    /// Frames to wait before capture (default 2)
+    #[serde(default = "default_2")]
+    pub delay_frames: u32,
+    /// Max image width in pixels (default 768). Use 1280 for detail.
+    pub max_width: Option<u32>,
+    /// Camera position [x, y, z]. If set, spawns a temporary debug camera instead of using the scene camera.
+    pub position: Option<[f32; 3]>,
+    /// Point the camera looks at [x, y, z]. Defaults to [0, 0, 0] if position is set.
+    pub look_at: Option<[f32; 3]>,
+    /// Hide authored UI Node entities during capture (default true). Internal overlays (hot reload status) are always hidden regardless.
+    #[serde(default = "default_true")]
+    pub hide_ui: bool,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CaptureTimelineParams {
+    /// Frame span to capture over (~1s at 60fps)
+    #[serde(default = "default_60")]
+    pub total_frames: u32,
+    /// Number of captures (max 20)
+    #[serde(default = "default_6")]
+    pub capture_count: u32,
+    /// Max composite width in pixels
+    pub max_width: Option<u32>,
+    /// Grid columns
+    #[serde(default = "default_3")]
+    pub columns: u32,
+    /// Debug camera position [x, y, z]
+    pub position: Option<[f32; 3]>,
+    /// Point the camera looks at [x, y, z]. Defaults to [0, 0, 0] if position is set.
+    pub look_at: Option<[f32; 3]>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CaptureTurnaroundParams {
+    /// Center point to orbit around. Auto-detected from scene bounds if omitted.
+    pub look_at: Option<[f32; 3]>,
+    /// Camera distance from center. Auto-fitted to scene bounds if omitted.
+    pub distance: Option<f32>,
+    /// Camera elevation in degrees (default 25)
+    #[schemars(extend("default" = 25))]
+    pub elevation: Option<f32>,
+    /// Number of orbit positions (default 6)
+    #[schemars(extend("default" = 6))]
+    pub view_count: Option<u32>,
+    /// Include top-down view (default true)
+    #[schemars(extend("default" = true))]
+    pub include_top: Option<bool>,
+    /// Grid columns in contact sheet (default 3)
+    #[schemars(extend("default" = 3))]
+    pub columns: Option<u32>,
+    /// Max composite width (default 1200)
+    #[schemars(extend("default" = 1200))]
+    pub max_width: Option<u32>,
+    /// Hide UI during capture (default true)
+    #[schemars(extend("default" = true))]
+    pub hide_ui: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CaptureDepthParams {
+    /// Camera position [x, y, z]
+    pub position: Option<[f32; 3]>,
+    /// Camera look-at [x, y, z]
+    pub look_at: Option<[f32; 3]>,
+    /// Screen-space sample points [[x, y], ...]. Auto-generates grid if omitted.
+    pub sample_points: Option<Vec<[u32; 2]>>,
+    /// Auto-generate NxN sample grid (default 8 if no sample_points)
+    #[schemars(extend("default" = 8))]
+    pub grid_density: Option<u32>,
+    /// Include RGB screenshot (default true)
+    #[schemars(extend("default" = true))]
+    pub include_rgb: Option<bool>,
+    /// Frames to wait before capture (default 2)
+    #[schemars(extend("default" = 2))]
+    pub delay_frames: Option<u32>,
+    /// Hide UI during capture (default true)
+    #[schemars(extend("default" = true))]
+    pub hide_ui: Option<bool>,
+    /// Max screenshot width (default 768)
+    #[schemars(extend("default" = 768))]
+    pub max_width: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ReloadParams {
+    /// Reload mode
+    #[serde(default)]
+    pub mode: ReloadMode,
+    /// Pause time immediately (before reload runs). Scene starts frozen so you can capture at t=0.
+    #[serde(default)]
+    pub pause: bool,
+    /// Set time scale atomically with reload (e.g. 0.1 for slow-motion). Applied before any frames run.
+    pub time_scale: Option<f32>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ReloadAndCaptureParams {
+    /// Reload mode (default full)
+    #[serde(default)]
+    pub mode: ReloadMode,
+    /// Pause time before reload
+    #[serde(default)]
+    pub pause: bool,
+    /// Set time scale atomically with reload
+    pub time_scale: Option<f32>,
+    /// Frames to wait after reload before capture (default 30)
+    #[schemars(extend("default" = 30))]
+    pub delay_frames: Option<u32>,
+    /// Max screenshot width (default 768)
+    pub max_width: Option<u32>,
+    /// Debug camera position [x, y, z]
+    pub position: Option<[f32; 3]>,
+    /// Camera look-at point [x, y, z]
+    pub look_at: Option<[f32; 3]>,
+    /// Hide UI during capture (default true)
+    #[schemars(extend("default" = true))]
+    pub hide_ui: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct QuerySpatialParams {
+    /// First entity (ID or Name)
+    pub entity_a: EntityRef,
+    /// Second entity (ID or Name)
+    pub entity_b: EntityRef,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct QuerySpatialNeighborhoodParams {
+    /// Center entity
+    pub entity: EntityRef,
+    /// Search radius
+    pub radius: f32,
+    /// Max neighbors to return (default 50)
+    #[schemars(extend("default" = 50))]
+    pub max_results: Option<usize>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CheckOverlapsParams {
+    /// Entity to check
+    pub entity: EntityRef,
+    /// Include siblings under same parent (default false, since parented parts overlap by design)
+    #[serde(default)]
+    pub include_siblings: bool,
+    /// Max gap (units) between entity bottom and surface below to still count as grounded (default 0.1). Increase for scenes with small placement gaps.
+    #[schemars(extend("default" = 0.1))]
+    #[serde(default)]
+    pub max_float_gap: f32,
+    /// Ground plane Y coordinate for sunk-detection. When provided, entities whose world AABB min_y is below this value are flagged as sunken. Useful for detecting GLB models placed at origin that are half-buried below the ground plane.
+    pub ground_y: Option<f32>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CheckAllOverlapsParams {
+    /// Minimum overlap depth to report (default 0.001)
+    #[schemars(extend("default" = 0.001))]
+    pub min_penetration: Option<f32>,
+    /// Max overlapping pairs to return (default 100)
+    #[schemars(extend("default" = 100))]
+    pub max_results: Option<usize>,
+    /// Max gap to still count as grounded (default 0.1)
+    #[schemars(extend("default" = 0.1))]
+    #[serde(default)]
+    pub max_float_gap: f32,
+    /// Ground plane Y for sunk-detection
+    pub ground_y: Option<f32>,
+    /// Include siblings under same parent (default false)
+    #[serde(default)]
+    pub include_siblings: bool,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SetAssetParams {
+    /// Entity ID or Name
+    pub entity: EntityRef,
+    /// Handle component: MeshMaterial3d, Mesh3d, MeshMaterial2d, AudioPlayer
+    pub component: String,
+    /// Asset type: StandardMaterial, Mesh, ColorMaterial, AudioSource
+    pub asset_type: String,
+    /// Fields to update on the asset
+    pub fields: serde_json::Value,
+}
+
+/// All control operations that require World access.
+///
+/// To deserialize from an MCP tool call: inject the tool name as `"tool"` into
+/// the args object, then call `serde_json::from_value::<ControlOperation>(args)`.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(tag = "tool", rename_all = "snake_case")]
+pub enum ControlOperation {
+    /// List all entities in the scene.
+    #[schemars(extend("x-hidden" = true))]
     ListEntities,
+    /// Get details for a single entity.
+    #[schemars(extend("x-hidden" = true))]
     GetEntity {
+        /// Entity ID or Name
         entity: EntityRef,
     },
+    /// List all resources in the world.
+    #[schemars(extend("x-hidden" = true))]
     ListResources,
+    /// List all registered systems.
+    #[schemars(extend("x-hidden" = true))]
     ListSystems,
-    QueryEntities {
-        with: Vec<String>,
-        without: Vec<String>,
-    },
+    /// Get component field names, types, defaults, and a JSON spawn example.
     GetComponentSchema {
+        /// Component name (e.g. 'Transform')
         name: String,
     },
-    GetComponent {
-        entity: EntityRef,
-        component: String,
-    },
-    SceneSummary,
+    /// Get live field values for a specific component on an entity.
+    GetComponent(GetComponentParams),
+    /// Query entities by With/Without component filters. Also supports Name lookup.
+    QueryEntities(QueryEntitiesParams),
+    /// Get a grouped entity inventory: counts by type (e.g. '30 Bubble, 6 Fish, 1 Camera3d'). Faster than query_entities for understanding scene composition.
+    GetSceneSummary,
+    /// Get the axis-aligned bounding box (AABB) of an entity, both local and world-space. Requires entity to have a mesh.
     GetBoundingBox {
+        /// Entity ID or Name
         entity: EntityRef,
     },
-    DebugRegistry,
-}
+    /// Show bridge registry state, entity count, and component detection status.
+    GetRegistry,
 
-/// Mutation operations (spawn, despawn, set, remove)
-#[derive(Debug)]
-pub enum MutateOp {
+    /// Capture a screenshot. Default 768px wide. UI elements are hidden by default. Use position/look_at to capture from an arbitrary viewpoint without affecting the scene camera.
+    #[schemars(extend("x-feature-gate" = "screenshot"))]
+    CaptureScreenshot(CaptureScreenshotParams),
+    /// Capture a screenshot with entity ID/Name gizmo labels overlaid.
+    #[schemars(extend("x-hidden" = true))]
+    CaptureWithGizmos(CaptureScreenshotParams),
+    /// Capture multiple frames over time into a contact sheet. Shows animation/motion in one image.
+    #[schemars(extend("x-feature-gate" = "screenshot"))]
+    CaptureTimeline(CaptureTimelineParams),
+    /// Capture multiple viewpoints orbiting around a target, composited into one contact sheet. Auto-fits distance to scene bounds if not specified.
+    #[schemars(extend("x-feature-gate" = "screenshot"))]
+    CaptureTurnaround(CaptureTurnaroundParams),
+    /// Capture RGB screenshot + ray-AABB depth samples. Casts rays from camera through sample points (or auto-grid) against entity bounding boxes. Returns structured depth data with hit entity, distance, and world position.
+    #[schemars(extend("x-feature-gate" = "screenshot"))]
+    CaptureDepth(CaptureDepthParams),
+
+    /// Hot-reload the scene (full or partial). Waits for reload to complete before responding - response includes any errors or warnings.
+    Reload(ReloadParams),
+    /// Primary iteration tool. Reload and capture in one round-trip. Hot-reloads the scene, waits for completion, checks for errors, then captures a screenshot.
+    #[schemars(extend("x-feature-gate" = "screenshot"))]
+    ReloadAndCapture(ReloadAndCaptureParams),
+    /// Get current reload generation, mode, and enabled state.
+    GetReloadStatus,
+    /// Get the last Python system error traceback.
+    GetLastError,
+
+    /// Spawn a new entity with components specified as JSON.
+    #[schemars(extend("x-feature-gate" = "manipulation"))]
     SpawnEntity {
+        /// Component name -> field values (e.g. {"Transform": {"translation": [0, 5, 0]}})
         components: serde_json::Value,
     },
+    /// Remove an entity by ID or Name.
+    #[schemars(extend("x-feature-gate" = "manipulation"))]
     DespawnEntity {
+        /// Entity ID or Name
         entity: EntityRef,
     },
-    SetComponent {
-        entity: EntityRef,
-        component: String,
-        fields: serde_json::Value,
-    },
-    RemoveComponent {
-        entity: EntityRef,
-        component: String,
-    },
-    InsertResource {
-        resource_type: String,
-        value: serde_json::Value,
-    },
+    /// Update specific fields on a component without replacing it.
+    #[schemars(extend("x-feature-gate" = "manipulation"))]
+    SetComponent(SetComponentParams),
+    /// Remove a component from an entity.
+    #[schemars(extend("x-feature-gate" = "manipulation"))]
+    RemoveComponent(RemoveComponentParams),
+    /// Insert or update a resource on a running scene (in scene code, use commands.insert_resource() instead).
+    #[schemars(extend("x-feature-gate" = "manipulation"))]
+    SetResource(SetResourceParams),
+    /// Remove a resource from the world.
+    #[schemars(extend("x-feature-gate" = "manipulation"))]
     RemoveResource {
+        /// Resource type name
         resource_type: String,
     },
-    BatchMutate {
+    /// Execute multiple mutation operations in a single round-trip. Each operation runs independently - failures don't abort the batch. Actions: set_component, spawn, despawn, remove_component.
+    #[schemars(extend("x-feature-gate" = "manipulation"))]
+    Batch {
+        /// Array of operations to execute. Each item: {"action": "set_component|spawn|despawn|remove_component", "entity": id_or_name, ...}
         operations: Vec<serde_json::Value>,
     },
-}
+    /// Update asset properties (material color, mesh settings) live without code reload.
+    #[schemars(extend("x-feature-gate" = "manipulation"))]
+    SetAsset(SetAssetParams),
 
-/// Time control operations
-#[derive(Debug)]
-pub enum TimeOp {
+    /// Pause game time. Scene freezes but rendering continues. Useful for inspecting a specific moment.
     PauseTime,
+    /// Resume game time after pause.
     ResumeTime,
-    SetTimeScale { scale: f32 },
+    /// Set game speed multiplier (0.1 = slow-mo, 2.0 = 2x speed). Does not affect pause state.
+    SetTimeScale {
+        /// Speed multiplier (default 1.0)
+        scale: f32,
+    },
+    /// Get current time state: paused, speed, elapsed seconds.
     GetTimeStatus,
-    SeekTime { seconds: f64, pause: bool },
-}
+    /// Jump virtual time to a specific moment. Seeking backwards resets virtual time (preserves speed). Pauses by default so you can capture at that exact time.
+    SeekTime(SeekTimeParams),
 
-/// Visual capture operations (deferred response)
-#[derive(Debug)]
-pub enum VisualOp {
-    CaptureScreenshot {
-        delay_frames: u32,
-        max_width: Option<u32>,
-        position: Option<[f32; 3]>,
-        look_at: Option<[f32; 3]>,
-        hide_ui: bool,
-    },
-    CaptureWithGizmos {
-        delay_frames: u32,
-        max_width: Option<u32>,
-        position: Option<[f32; 3]>,
-        look_at: Option<[f32; 3]>,
-        hide_ui: bool,
-    },
-    CaptureTimeline {
-        total_frames: u32,
-        capture_count: u32,
-        max_width: Option<u32>,
-        columns: u32,
-        position: Option<[f32; 3]>,
-        look_at: Option<[f32; 3]>,
-    },
-    CaptureTurnaround {
-        look_at: Option<[f32; 3]>,
-        distance: Option<f32>,
-        elevation: Option<f32>,
-        view_count: Option<u32>,
-        include_top: Option<bool>,
-        columns: Option<u32>,
-        max_width: Option<u32>,
-        hide_ui: Option<bool>,
-    },
-    CaptureDepth {
-        position: Option<[f32; 3]>,
-        look_at: Option<[f32; 3]>,
-        sample_points: Option<Vec<[u32; 2]>>,
-        grid_density: Option<u32>,
-        include_rgb: Option<bool>,
-        delay_frames: Option<u32>,
-        hide_ui: Option<bool>,
-        max_width: Option<u32>,
-    },
-}
+    /// Spatial query between two entities: distance, direction, AABB overlap. For finding all entities within a radius, use query_spatial_neighborhood instead.
+    QuerySpatial(QuerySpatialParams),
+    /// Find all entities within radius of a center entity.
+    QuerySpatialNeighborhood(QuerySpatialNeighborhoodParams),
+    /// Detect AABB overlaps for a single entity against all others.
+    CheckOverlaps(CheckOverlapsParams),
+    /// Detect all AABB overlaps scene-wide.
+    CheckAllOverlaps(CheckAllOverlapsParams),
 
-/// Reload operations (deferred response)
-#[derive(Debug)]
-pub enum ReloadOp {
-    TriggerReload {
-        mode: String,
-        pause: bool,
-        time_scale: Option<f32>,
-    },
-    ReloadAndCapture {
-        mode: String,
-        pause: bool,
-        time_scale: Option<f32>,
-        delay_frames: Option<u32>,
-        max_width: Option<u32>,
-        position: Option<[f32; 3]>,
-        look_at: Option<[f32; 3]>,
-        hide_ui: Option<bool>,
-    },
-    GetReloadStatus,
-    GetLastError,
-}
-
-/// Spatial query operations
-#[derive(Debug)]
-pub enum SpatialOp {
-    QuerySpatial {
-        entity_a: EntityRef,
-        entity_b: EntityRef,
-    },
-    QuerySpatialNeighborhood {
-        entity: EntityRef,
-        radius: f32,
-        max_results: Option<usize>,
-    },
-    CheckOverlaps {
-        entity: EntityRef,
-        include_siblings: bool,
-        max_float_gap: f32,
-        ground_y: Option<f32>,
-    },
-    CheckAllOverlaps {
-        min_penetration: Option<f32>,
-        max_results: Option<usize>,
-        max_float_gap: f32,
-        ground_y: Option<f32>,
-        include_siblings: bool,
-    },
-}
-
-/// Other operations (execute, performance, assets, configs, schedule)
-#[derive(Debug)]
-pub enum OtherOp {
-    ExecutePython {
+    /// Run arbitrary Python code with World context. Returns stdout/stderr capture and change summary.
+    #[schemars(extend("x-feature-gate" = "execute_python"))]
+    RunCode {
+        /// Python code to execute
         code: String,
     },
+    /// Get full diagnostics: FPS, CPU/GPU/RAM/VRAM usage, entity/asset counts, system profiling times.
     GetPerformance,
-    MutateAsset {
-        entity: EntityRef,
-        component: String,
-        asset_type: String,
-        fields: serde_json::Value,
-    },
+    /// Submit batched, timed tool calls that execute inside the engine frame loop with frame-precise timing. Same-'at' actions fire in the same frame (atomic). Supports: time control, mutations, queries, screenshots. NOT supported: get_logs, search_api, run_scene (bridge-local tools).
+    ScheduleActions(ScheduleRequest),
+    /// Get internal config value.
+    #[schemars(extend("x-hidden" = true))]
     GetConfig {
+        /// Config key
         key: String,
     },
+    /// List all config values.
+    #[schemars(extend("x-hidden" = true))]
     ListConfigs,
-    SubmitSchedule {
-        request: crate::handlers::schedule::ScheduleRequest,
-    },
 }
 
-/// All control operations that require World access
-#[derive(Debug)]
-pub enum ControlOperation {
-    Scene(SceneOp),
-    Mutate(MutateOp),
-    Time(TimeOp),
-    Visual(VisualOp),
-    Reload(ReloadOp),
-    Spatial(SpatialOp),
-    Other(OtherOp),
+fn default_2() -> u32 {
+    2
+}
+fn default_3() -> u32 {
+    3
+}
+fn default_6() -> u32 {
+    6
+}
+fn default_60() -> u32 {
+    60
+}
+fn default_true() -> bool {
+    true
 }
 
 /// Error codes for control operations (JSON-RPC style)
@@ -242,7 +462,6 @@ impl ErrorCode {
         self as i32
     }
 }
-
 /// Error type for control operations
 #[derive(Debug)]
 pub struct ControlError {
@@ -329,7 +548,7 @@ pub struct PendingReloadResponses {
 pub struct PendingReloadResponse {
     pub response_tx: oneshot::Sender<Result<serde_json::Value, ControlError>>,
     pub frames_remaining: u32,
-    pub mode: String,
+    pub mode: ReloadMode,
     pub error_timestamp_before: f64,
 }
 
@@ -416,77 +635,39 @@ pub fn create_channel() -> (ControlSender, ControlReceiver) {
     (ControlSender { tx }, ControlReceiver { rx })
 }
 
-/// Handle deferred CaptureScreenshot or CaptureWithGizmos requests.
-fn handle_deferred_screenshot(request: ControlRequest, deferred: &mut Vec<PendingScreenshot>) {
-    match request.operation {
-        ControlOperation::Visual(VisualOp::CaptureScreenshot {
-            delay_frames,
-            max_width,
-            position,
-            look_at,
-            hide_ui,
-        }) => {
-            let debug_camera = position.map(|pos| DebugCameraRequest {
-                position: pos,
-                look_at: look_at.unwrap_or([0.0, 0.0, 0.0]),
-            });
-            deferred.push(PendingScreenshot {
-                response_tx: request.response_tx,
-                frames_remaining: delay_frames,
-                with_gizmos: false,
-                max_width,
-                debug_camera,
-                hide_ui,
-                extra_response: None,
-            });
-        }
-        ControlOperation::Visual(VisualOp::CaptureWithGizmos {
-            delay_frames,
-            max_width,
-            position,
-            look_at,
-            hide_ui,
-        }) => {
-            let debug_camera = position.map(|pos| DebugCameraRequest {
-                position: pos,
-                look_at: look_at.unwrap_or([0.0, 0.0, 0.0]),
-            });
-            deferred.push(PendingScreenshot {
-                response_tx: request.response_tx,
-                frames_remaining: delay_frames,
-                with_gizmos: true,
-                max_width,
-                debug_camera,
-                hide_ui,
-                extra_response: None,
-            });
-        }
-        _ => unreachable!(),
-    }
+pub fn push_pending_screenshot(
+    params: CaptureScreenshotParams,
+    with_gizmos: bool,
+    response_tx: oneshot::Sender<Result<serde_json::Value, ControlError>>,
+    deferred: &mut Vec<PendingScreenshot>,
+) {
+    let debug_camera = params.position.map(|pos| DebugCameraRequest {
+        position: pos,
+        look_at: params.look_at.unwrap_or([0.0, 0.0, 0.0]),
+    });
+    deferred.push(PendingScreenshot {
+        response_tx,
+        frames_remaining: params.delay_frames,
+        with_gizmos,
+        max_width: params.max_width,
+        debug_camera,
+        hide_ui: params.hide_ui,
+        extra_response: None,
+    });
 }
 
-/// Handle deferred CaptureTimeline requests.
-fn handle_deferred_timeline(request: ControlRequest, world: &mut World) {
-    let ControlOperation::Visual(VisualOp::CaptureTimeline {
-        total_frames,
-        capture_count,
-        max_width,
-        columns,
-        position,
-        look_at,
-    }) = request.operation
-    else {
-        unreachable!()
-    };
+pub fn push_pending_timeline(
+    params: CaptureTimelineParams,
+    response_tx: oneshot::Sender<Result<serde_json::Value, ControlError>>,
+    world: &mut World,
+) {
+    let mut schedule = compute_schedule(params.total_frames, params.capture_count);
 
-    let mut schedule = crate::handlers::screenshot::compute_schedule(total_frames, capture_count);
-
-    let debug_cleanup = position.map(|pos| {
+    let debug_cleanup = params.position.map(|pos| {
         let debug_req = DebugCameraRequest {
             position: pos,
-            look_at: look_at.unwrap_or([0.0, 0.0, 0.0]),
+            look_at: params.look_at.unwrap_or([0.0, 0.0, 0.0]),
         };
-        // Add extra frames for debug camera to render
         if let Some(first) = schedule.front_mut() {
             *first += 2;
         }
@@ -499,67 +680,55 @@ fn handle_deferred_timeline(request: ControlRequest, world: &mut World) {
     pending.active.insert(
         id,
         ActiveTimeline {
-            response_tx: Some(request.response_tx),
-            max_width,
-            columns,
+            response_tx: Some(response_tx),
+            max_width: params.max_width,
+            columns: params.columns,
             debug_cleanup,
             schedule,
-            total_captures: capture_count,
+            total_captures: params.capture_count,
             next_capture_index: 0,
             collected: Vec::new(),
         },
     );
 }
 
-/// Handle deferred TriggerReload requests.
-fn handle_deferred_reload(request: ControlRequest, world: &mut World) {
-    let ControlOperation::Reload(ReloadOp::TriggerReload {
-        mode,
-        pause,
-        time_scale,
-    }) = request.operation
-    else {
-        unreachable!()
-    };
+pub fn push_pending_reload(
+    params: ReloadParams,
+    response_tx: oneshot::Sender<Result<serde_json::Value, ControlError>>,
+    world: &mut World,
+) {
+    let _ = handlers::reload::trigger_reload(
+        world,
+        params.mode.clone(),
+        params.pause,
+        params.time_scale,
+    );
 
-    // Execute the reload synchronously, then defer the response
-    let mode_str = mode;
-    let _ = handlers::reload::trigger_reload(world, mode_str.clone(), pause, time_scale);
-
-    // Record current error timestamp to detect new errors after reload
     let error_ts = world
         .get_resource::<pybevy_core::LastSystemError>()
         .map(|e| e.timestamp_secs)
         .unwrap_or(0.0);
 
-    let mut pending_reloads = world.get_resource_or_insert_with(PendingReloadResponses::default);
-    pending_reloads.pending.push(PendingReloadResponse {
-        response_tx: request.response_tx,
+    let mut pending = world.get_resource_or_insert_with(PendingReloadResponses::default);
+    pending.pending.push(PendingReloadResponse {
+        response_tx,
         frames_remaining: 5,
-        mode: mode_str,
+        mode: params.mode,
         error_timestamp_before: error_ts,
     });
 }
 
-/// Handle deferred ReloadAndCapture requests.
-fn handle_deferred_reload_and_capture(request: ControlRequest, world: &mut World) {
-    let ControlOperation::Reload(ReloadOp::ReloadAndCapture {
-        mode,
-        pause,
-        time_scale,
-        delay_frames,
-        max_width,
-        position,
-        look_at,
-        hide_ui,
-    }) = request.operation
-    else {
-        unreachable!()
-    };
-
-    // Trigger the reload
-    let mode_str = mode;
-    let _ = handlers::reload::trigger_reload(world, mode_str.clone(), pause, time_scale);
+pub fn push_pending_reload_and_capture(
+    params: ReloadAndCaptureParams,
+    response_tx: oneshot::Sender<Result<serde_json::Value, ControlError>>,
+    world: &mut World,
+) {
+    let _ = handlers::reload::trigger_reload(
+        world,
+        params.mode.clone(),
+        params.pause,
+        params.time_scale,
+    );
 
     let error_ts = world
         .get_resource::<pybevy_core::LastSystemError>()
@@ -568,47 +737,34 @@ fn handle_deferred_reload_and_capture(request: ControlRequest, world: &mut World
 
     let mut pending = world.get_resource_or_insert_with(PendingReloadAndCaptures::default);
     pending.pending.push(PendingReloadAndCapture {
-        response_tx: request.response_tx,
-        mode: mode_str,
+        response_tx,
+        mode: params.mode,
         error_timestamp_before: error_ts,
         reload_frames_remaining: 5,
-        screenshot_delay_frames: delay_frames.unwrap_or(30),
-        max_width,
-        position,
-        look_at,
-        hide_ui: hide_ui.unwrap_or(true),
+        screenshot_delay_frames: params.delay_frames.unwrap_or(30),
+        max_width: params.max_width,
+        position: params.position,
+        look_at: params.look_at,
+        hide_ui: params.hide_ui.unwrap_or(true),
         state: ReloadAndCaptureState::WaitingForReload,
         reload_response: None,
     });
 }
 
-/// Handle deferred CaptureTurnaround requests.
-fn handle_deferred_turnaround(request: ControlRequest, world: &mut World) {
-    let ControlOperation::Visual(VisualOp::CaptureTurnaround {
-        look_at,
-        distance,
-        elevation,
-        view_count,
-        include_top,
-        columns,
-        max_width,
-        hide_ui,
-    }) = request.operation
-    else {
-        unreachable!()
-    };
+pub fn push_pending_turnaround(
+    params: CaptureTurnaroundParams,
+    response_tx: oneshot::Sender<Result<serde_json::Value, ControlError>>,
+    world: &mut World,
+) {
+    let vc = params.view_count.unwrap_or(6);
+    let elev = params.elevation.unwrap_or(25.0);
+    let top = params.include_top.unwrap_or(true);
 
-    let vc = view_count.unwrap_or(6);
-    let elev = elevation.unwrap_or(25.0);
-    let top = include_top.unwrap_or(true);
-
-    // Auto-fit distance and look_at from scene bounds
-    let (auto_look_at, auto_distance) = if distance.is_none() || look_at.is_none() {
+    let (auto_look_at, auto_distance) = if params.distance.is_none() || params.look_at.is_none() {
         if let Some((scene_min, scene_max)) = compute_scene_bounds(world) {
             let center = (scene_min + scene_max) * 0.5;
             let extent = scene_max - scene_min;
             let diagonal = (extent.x * extent.x + extent.y * extent.y + extent.z * extent.z).sqrt();
-            // Distance so diagonal subtends ~60° FOV
             let dist = diagonal / (30.0_f32.to_radians().tan() * 2.0);
             ([center.x, center.y, center.z], dist.max(2.0))
         } else {
@@ -618,21 +774,20 @@ fn handle_deferred_turnaround(request: ControlRequest, world: &mut World) {
         ([0.0, 0.0, 0.0], 10.0)
     };
 
-    let final_look_at = look_at.unwrap_or(auto_look_at);
-    let final_distance = distance.unwrap_or(auto_distance);
-
+    let final_look_at = params.look_at.unwrap_or(auto_look_at);
+    let final_distance = params.distance.unwrap_or(auto_distance);
     let viewpoints = compute_viewpoints(final_look_at, final_distance, elev, vc, top);
 
     let mut pending = world.get_resource_or_insert_with(PendingTurnarounds::default);
     pending.active.push(ActiveTurnaround {
-        response_tx: Some(request.response_tx),
+        response_tx: Some(response_tx),
         viewpoints,
         current_index: 0,
         captures: Vec::new(),
-        columns: columns.unwrap_or(3),
-        max_width: Some(max_width.unwrap_or(1200)),
+        columns: params.columns.unwrap_or(3),
+        max_width: Some(params.max_width.unwrap_or(1200)),
         frames_remaining: 0,
-        hide_ui: hide_ui.unwrap_or(true),
+        hide_ui: params.hide_ui.unwrap_or(true),
         ui_restore: None,
         debug_cleanup: None,
         look_at: final_look_at,
@@ -640,55 +795,40 @@ fn handle_deferred_turnaround(request: ControlRequest, world: &mut World) {
     });
 }
 
-/// Handle deferred CaptureDepth requests.
-fn handle_deferred_depth(
-    request: ControlRequest,
+pub fn push_pending_depth(
+    params: CaptureDepthParams,
+    response_tx: oneshot::Sender<Result<serde_json::Value, ControlError>>,
     deferred: &mut Vec<PendingScreenshot>,
     world: &mut World,
 ) {
-    let ControlOperation::Visual(VisualOp::CaptureDepth {
-        position,
-        look_at,
-        sample_points,
-        grid_density,
-        include_rgb,
-        delay_frames,
-        hide_ui,
-        max_width,
-    }) = request.operation
-    else {
-        unreachable!()
-    };
-
-    // Compute depth samples synchronously
     let depth_result = crate::handlers::depth::compute_depth_samples(
         world,
-        &position,
-        &look_at,
-        &sample_points,
-        &grid_density,
+        &params.position,
+        &params.look_at,
+        &params.sample_points,
+        &params.grid_density,
     );
 
-    let want_rgb = include_rgb.unwrap_or(true);
-    let df = delay_frames.unwrap_or(2);
-    let mw = Some(max_width.unwrap_or(768));
-    let hu = hide_ui.unwrap_or(true);
-    let dc = position.as_ref().map(|pos| DebugCameraRequest {
+    let want_rgb = params.include_rgb.unwrap_or(true);
+    let df = params.delay_frames.unwrap_or(2);
+    let mw = Some(params.max_width.unwrap_or(768));
+    let hu = params.hide_ui.unwrap_or(true);
+    let dc = params.position.as_ref().map(|pos| DebugCameraRequest {
         position: *pos,
-        look_at: look_at.unwrap_or([0.0, 0.0, 0.0]),
+        look_at: params.look_at.unwrap_or([0.0, 0.0, 0.0]),
     });
 
     if want_rgb {
         let depth = match depth_result {
             Ok(d) => d,
             Err(e) => {
-                let _ = request.response_tx.send(Err(e));
+                let _ = response_tx.send(Err(e));
                 return;
             }
         };
 
         deferred.push(PendingScreenshot {
-            response_tx: request.response_tx,
+            response_tx,
             frames_remaining: df,
             with_gizmos: false,
             max_width: mw,
@@ -703,17 +843,16 @@ fn handle_deferred_depth(
                 "depth_samples": depth,
             })
         });
-        let _ = request.response_tx.send(result);
+        let _ = response_tx.send(result);
     }
 }
 
-/// Handle SubmitSchedule requests (no GIL needed).
-fn handle_submit_schedule(request: ControlRequest, world: &mut World) {
-    let sched_req = match request.operation {
-        ControlOperation::Other(OtherOp::SubmitSchedule { request: r }) => r,
-        _ => unreachable!(),
-    };
-
+/// Handle ScheduleActions requests (no GIL needed).
+fn handle_submit_schedule(
+    sched_req: ScheduleRequest,
+    response_tx: oneshot::Sender<Result<serde_json::Value, ControlError>>,
+    world: &mut World,
+) {
     let mut active = world.get_resource_or_insert_with(ActiveSchedules::default);
     let schedule_id = format!("schedule-{}", active.next_id);
     active.next_id += 1;
@@ -723,7 +862,7 @@ fn handle_submit_schedule(request: ControlRequest, world: &mut World) {
         .map(|t| t.elapsed_secs_f64())
         .unwrap_or(0.0);
 
-    if sched_req.mode == "async" {
+    if sched_req.mode == ScheduleMode::Async {
         let shared = std::sync::Arc::new(std::sync::Mutex::new(SharedScheduleState::new(
             &schedule_id,
             sched_req.actions.len(),
@@ -733,7 +872,7 @@ fn handle_submit_schedule(request: ControlRequest, world: &mut World) {
             registry_res.0.insert(schedule_id.clone(), shared.clone());
         }
 
-        let _ = request.response_tx.send(Ok(serde_json::json!({
+        let _ = response_tx.send(Ok(serde_json::json!({
             "schedule_id": schedule_id,
             "status": "running",
         })));
@@ -751,7 +890,7 @@ fn handle_submit_schedule(request: ControlRequest, world: &mut World) {
             schedule_id,
             sched_req,
             t0,
-            request.response_tx,
+            response_tx,
         ));
     }
 }
@@ -782,40 +921,56 @@ pub fn control_poll_system(world: &mut World) {
             Ok(request) => {
                 processed += 1;
 
-                // Handle SubmitSchedule (no GIL needed — just stores in World resource)
-                if matches!(
-                    &request.operation,
-                    ControlOperation::Other(OtherOp::SubmitSchedule { .. })
-                ) {
-                    handle_submit_schedule(request, world);
+                // Handle ScheduleActions (no GIL needed - just stores in World resource)
+                if let ControlOperation::ScheduleActions(sched) = request.operation {
+                    handle_submit_schedule(sched, request.response_tx, world);
                     continue;
                 }
 
                 // Classify: deferred ops go directly to their queues,
                 // sync ops are collected for batched GIL processing
-                match &request.operation {
-                    ControlOperation::Visual(VisualOp::CaptureScreenshot { .. })
-                    | ControlOperation::Visual(VisualOp::CaptureWithGizmos { .. }) => {
-                        handle_deferred_screenshot(request, &mut deferred_screenshots);
+                match request.operation {
+                    ControlOperation::CaptureScreenshot(p) => {
+                        push_pending_screenshot(
+                            p,
+                            false,
+                            request.response_tx,
+                            &mut deferred_screenshots,
+                        );
                     }
-                    ControlOperation::Visual(VisualOp::CaptureTimeline { .. }) => {
-                        handle_deferred_timeline(request, world);
+                    ControlOperation::CaptureWithGizmos(p) => {
+                        push_pending_screenshot(
+                            p,
+                            true,
+                            request.response_tx,
+                            &mut deferred_screenshots,
+                        );
                     }
-                    ControlOperation::Reload(ReloadOp::TriggerReload { .. }) => {
-                        handle_deferred_reload(request, world);
+                    ControlOperation::CaptureTimeline(p) => {
+                        push_pending_timeline(p, request.response_tx, world);
                     }
-                    ControlOperation::Reload(ReloadOp::ReloadAndCapture { .. }) => {
-                        handle_deferred_reload_and_capture(request, world);
+                    ControlOperation::Reload(p) => {
+                        push_pending_reload(p, request.response_tx, world);
                     }
-                    ControlOperation::Visual(VisualOp::CaptureTurnaround { .. }) => {
-                        handle_deferred_turnaround(request, world);
+                    ControlOperation::ReloadAndCapture(p) => {
+                        push_pending_reload_and_capture(p, request.response_tx, world);
                     }
-                    ControlOperation::Visual(VisualOp::CaptureDepth { .. }) => {
-                        handle_deferred_depth(request, &mut deferred_screenshots, world);
+                    ControlOperation::CaptureTurnaround(p) => {
+                        push_pending_turnaround(p, request.response_tx, world);
                     }
-                    // Sync operation — collect for batched GIL processing
-                    _ => {
-                        sync_requests.push(request);
+                    ControlOperation::CaptureDepth(p) => {
+                        push_pending_depth(
+                            p,
+                            request.response_tx,
+                            &mut deferred_screenshots,
+                            world,
+                        );
+                    }
+                    other => {
+                        sync_requests.push(ControlRequest {
+                            operation: other,
+                            response_tx: request.response_tx,
+                        });
                     }
                 }
             }
@@ -959,16 +1114,13 @@ mod tests {
         sender
             .tx
             .send(ControlRequest {
-                operation: ControlOperation::Scene(SceneOp::ListEntities),
+                operation: ControlOperation::ListEntities,
                 response_tx: tx,
             })
             .unwrap();
 
         let req = receiver.rx.try_recv().unwrap();
-        assert!(matches!(
-            req.operation,
-            ControlOperation::Scene(SceneOp::ListEntities)
-        ));
+        assert!(matches!(req.operation, ControlOperation::ListEntities));
     }
 
     #[test]
@@ -1080,7 +1232,7 @@ mod tests {
                     sender
                         .tx
                         .send(ControlRequest {
-                            operation: ControlOperation::Scene(SceneOp::GetComponent {
+                            operation: ControlOperation::GetComponent(GetComponentParams {
                                 entity: EntityRef::Id(entity.to_bits()),
                                 component: "Transform".into(),
                             }),
@@ -1111,5 +1263,25 @@ mod tests {
                 }
             });
         });
+    }
+
+    #[test]
+    fn control_operation_schema_generates() {
+        let schema = schemars::schema_for!(ControlOperation);
+        let json = serde_json::to_string_pretty(&schema).unwrap();
+        // Basic sanity: schema should contain tool names as snake_case
+        assert!(json.contains("query_entities"), "missing query_entities");
+        assert!(
+            json.contains("capture_screenshot"),
+            "missing capture_screenshot"
+        );
+        assert!(json.contains("pause_time"), "missing pause_time");
+        assert!(json.contains("spawn_entity"), "missing spawn_entity");
+        assert!(
+            json.contains("schedule_actions"),
+            "missing schedule_actions"
+        );
+        // Should contain descriptions from doc comments
+        assert!(json.contains("description"), "no descriptions in schema");
     }
 }

--- a/crates/pybevy_control/src/handlers/mod.rs
+++ b/crates/pybevy_control/src/handlers/mod.rs
@@ -12,10 +12,7 @@ pub mod turnaround;
 use bevy::ecs::world::World;
 
 use crate::{
-    bridge::{
-        ControlError, ControlOperation, MutateOp, OtherOp, ReloadOp, SceneOp, SpatialOp, TimeOp,
-        VisualOp,
-    },
+    bridge::{ControlError, ControlOperation},
     runtime::ControlRuntime,
 };
 
@@ -30,150 +27,59 @@ pub fn dispatch(
     runtime: &mut dyn ControlRuntime,
 ) -> Result<serde_json::Value, ControlError> {
     match operation {
-        ControlOperation::Scene(op) => dispatch_scene(world, op, runtime),
-        ControlOperation::Mutate(op) => dispatch_mutate(world, op, runtime),
-        ControlOperation::Time(op) => dispatch_time(world, op),
-        ControlOperation::Visual(op) => dispatch_visual(world, op),
-        ControlOperation::Reload(op) => dispatch_reload(world, op),
-        ControlOperation::Spatial(op) => dispatch_spatial(world, op),
-        ControlOperation::Other(op) => dispatch_other(world, op, runtime),
-    }
-}
-
-fn dispatch_scene(
-    world: &mut World,
-    op: SceneOp,
-    runtime: &mut dyn ControlRuntime,
-) -> Result<serde_json::Value, ControlError> {
-    match op {
-        SceneOp::ListEntities => runtime.list_entities(world),
-        SceneOp::GetEntity { entity } => runtime.get_entity(world, entity),
-        SceneOp::ListResources => runtime.list_resources(world),
-        SceneOp::ListSystems => runtime.list_systems(world),
-        SceneOp::QueryEntities { with, without } => runtime.query_entities(world, with, without),
-        SceneOp::GetComponentSchema { name } => runtime.get_component_schema(world, name),
-        SceneOp::GetComponent { entity, component } => {
-            runtime.get_component(world, entity, component)
+        ControlOperation::ListEntities => runtime.list_entities(world),
+        ControlOperation::GetEntity { entity } => runtime.get_entity(world, entity),
+        ControlOperation::ListResources => runtime.list_resources(world),
+        ControlOperation::ListSystems => runtime.list_systems(world),
+        ControlOperation::QueryEntities(p) => runtime.query_entities(world, p),
+        ControlOperation::GetComponentSchema { name } => runtime.get_component_schema(world, name),
+        ControlOperation::GetComponent(p) => runtime.get_component(world, p),
+        ControlOperation::GetSceneSummary => runtime.scene_summary(world),
+        ControlOperation::GetBoundingBox { entity } => runtime.get_bounding_box(world, entity),
+        ControlOperation::GetRegistry => runtime.debug_registry(world),
+        ControlOperation::SpawnEntity { components } => runtime.spawn_entity(world, components),
+        ControlOperation::DespawnEntity { entity } => pyo3::mutate::despawn_entity(world, entity),
+        ControlOperation::SetComponent(p) => runtime.set_component(world, p),
+        ControlOperation::RemoveComponent(p) => runtime.remove_component(world, p),
+        ControlOperation::SetResource(p) => runtime.insert_resource(world, p),
+        ControlOperation::RemoveResource { resource_type } => {
+            runtime.remove_resource(world, resource_type)
         }
-        SceneOp::SceneSummary => runtime.scene_summary(world),
-        SceneOp::GetBoundingBox { entity } => runtime.get_bounding_box(world, entity),
-        SceneOp::DebugRegistry => runtime.debug_registry(world),
-    }
-}
-
-fn dispatch_mutate(
-    world: &mut World,
-    op: MutateOp,
-    runtime: &mut dyn ControlRuntime,
-) -> Result<serde_json::Value, ControlError> {
-    match op {
-        MutateOp::SpawnEntity { components } => runtime.spawn_entity(world, components),
-        MutateOp::DespawnEntity { entity } => pyo3::mutate::despawn_entity(world, entity),
-        MutateOp::SetComponent {
-            entity,
-            component,
-            fields,
-        } => runtime.set_component(world, entity, component, fields),
-        MutateOp::RemoveComponent { entity, component } => {
-            runtime.remove_component(world, entity, component)
-        }
-        MutateOp::InsertResource {
-            resource_type,
-            value,
-        } => runtime.insert_resource(world, resource_type, value),
-        MutateOp::RemoveResource { resource_type } => runtime.remove_resource(world, resource_type),
-        MutateOp::BatchMutate { operations } => runtime.batch_mutate(world, operations),
-    }
-}
-
-fn dispatch_time(world: &mut World, op: TimeOp) -> Result<serde_json::Value, ControlError> {
-    match op {
-        TimeOp::PauseTime => time_control::pause_time(world),
-        TimeOp::ResumeTime => time_control::resume_time(world),
-        TimeOp::SetTimeScale { scale } => time_control::set_time_scale(world, scale),
-        TimeOp::GetTimeStatus => time_control::get_time_status(world),
-        TimeOp::SeekTime { seconds, pause } => time_control::seek_time(world, seconds, pause),
-    }
-}
-
-fn dispatch_visual(_world: &mut World, op: VisualOp) -> Result<serde_json::Value, ControlError> {
-    // Visual ops should have been intercepted by control_poll_system for deferred handling
-    match op {
-        VisualOp::CaptureScreenshot { .. }
-        | VisualOp::CaptureWithGizmos { .. }
-        | VisualOp::CaptureTimeline { .. } => Err(ControlError::internal(
+        ControlOperation::Batch { operations } => runtime.batch_mutate(world, operations),
+        ControlOperation::PauseTime => time_control::pause_time(world),
+        ControlOperation::ResumeTime => time_control::resume_time(world),
+        ControlOperation::SetTimeScale { scale } => time_control::set_time_scale(world, scale),
+        ControlOperation::GetTimeStatus => time_control::get_time_status(world),
+        ControlOperation::SeekTime(p) => time_control::seek_time(world, p),
+        ControlOperation::CaptureScreenshot(..)
+        | ControlOperation::CaptureWithGizmos(..)
+        | ControlOperation::CaptureTimeline(..) => Err(ControlError::internal(
             "Screenshot requests should be deferred",
         )),
-        VisualOp::CaptureTurnaround { .. } => Err(ControlError::internal(
+        ControlOperation::CaptureTurnaround(..) => Err(ControlError::internal(
             "CaptureTurnaround requests should be deferred",
         )),
-        VisualOp::CaptureDepth { .. } => Err(ControlError::internal(
+        ControlOperation::CaptureDepth(..) => Err(ControlError::internal(
             "CaptureDepth requests should be deferred",
         )),
-    }
-}
-
-fn dispatch_reload(world: &mut World, op: ReloadOp) -> Result<serde_json::Value, ControlError> {
-    match op {
-        ReloadOp::GetReloadStatus => reload::get_reload_status(world),
-        ReloadOp::GetLastError => reload::get_last_error(world),
-        ReloadOp::TriggerReload { .. } => {
+        ControlOperation::Reload(..) => {
             Err(ControlError::internal("Reload requests should be deferred"))
         }
-        ReloadOp::ReloadAndCapture { .. } => Err(ControlError::internal(
+        ControlOperation::ReloadAndCapture(..) => Err(ControlError::internal(
             "ReloadAndCapture requests should be deferred",
         )),
-    }
-}
-
-fn dispatch_spatial(world: &mut World, op: SpatialOp) -> Result<serde_json::Value, ControlError> {
-    match op {
-        SpatialOp::QuerySpatial { entity_a, entity_b } => {
-            spatial::query_spatial(world, entity_a, entity_b)
+        ControlOperation::GetReloadStatus => reload::get_reload_status(world),
+        ControlOperation::GetLastError => reload::get_last_error(world),
+        ControlOperation::QuerySpatial(p) => spatial::query_spatial(world, p),
+        ControlOperation::QuerySpatialNeighborhood(p) => {
+            spatial::query_spatial_neighborhood(world, p)
         }
-        SpatialOp::QuerySpatialNeighborhood {
-            entity,
-            radius,
-            max_results,
-        } => spatial::query_spatial_neighborhood(world, entity, radius, max_results),
-        SpatialOp::CheckOverlaps {
-            entity,
-            include_siblings,
-            max_float_gap,
-            ground_y,
-        } => spatial::check_overlaps(world, entity, include_siblings, max_float_gap, ground_y),
-        SpatialOp::CheckAllOverlaps {
-            min_penetration,
-            max_results,
-            max_float_gap,
-            ground_y,
-            include_siblings,
-        } => spatial::check_all_overlaps(
-            world,
-            min_penetration,
-            max_results,
-            max_float_gap,
-            ground_y,
-            include_siblings,
-        ),
-    }
-}
-
-fn dispatch_other(
-    world: &mut World,
-    op: OtherOp,
-    runtime: &mut dyn ControlRuntime,
-) -> Result<serde_json::Value, ControlError> {
-    match op {
-        OtherOp::ExecutePython { code } => runtime.execute_python(world, code),
-        OtherOp::GetPerformance => diagnostics::get_performance(world),
-        OtherOp::MutateAsset {
-            entity,
-            component,
-            asset_type,
-            fields,
-        } => runtime.mutate_asset(world, entity, component, asset_type, fields),
-        OtherOp::GetConfig { key } => {
+        ControlOperation::CheckOverlaps(p) => spatial::check_overlaps(world, p),
+        ControlOperation::CheckAllOverlaps(p) => spatial::check_all_overlaps(world, p),
+        ControlOperation::RunCode { code } => runtime.execute_python(world, code),
+        ControlOperation::GetPerformance => diagnostics::get_performance(world),
+        ControlOperation::SetAsset(p) => runtime.mutate_asset(world, p),
+        ControlOperation::GetConfig { key } => {
             let configs = world.get_resource::<pybevy_core::PluginConfigs>();
             match configs.and_then(|c| c.get(&key).cloned()) {
                 Some(value) => Ok(value),
@@ -182,15 +88,15 @@ fn dispatch_other(
                 ))),
             }
         }
-        OtherOp::ListConfigs => {
+        ControlOperation::ListConfigs => {
             let configs = world
                 .get_resource::<pybevy_core::PluginConfigs>()
                 .map(|c| c.all().clone())
                 .unwrap_or_default();
             Ok(serde_json::json!(configs))
         }
-        OtherOp::SubmitSchedule { .. } => Err(ControlError::internal(
-            "SubmitSchedule should be intercepted by control_poll_system",
+        ControlOperation::ScheduleActions(..) => Err(ControlError::internal(
+            "ScheduleActions should be intercepted by control_poll_system",
         )),
     }
 }
@@ -208,7 +114,10 @@ mod tests {
 
     use super::*;
     use crate::{
-        bridge::{EntityRef, ErrorCode},
+        bridge::{
+            CaptureDepthParams, CaptureScreenshotParams, CaptureTurnaroundParams,
+            CheckAllOverlapsParams, EntityRef, ErrorCode,
+        },
         runtime_pyo3::Pyo3ControlRuntime,
     };
 
@@ -219,36 +128,21 @@ mod tests {
     #[test]
     fn dispatch_list_entities_empty_world() {
         let mut world = World::new();
-        let result = dispatch(
-            &mut world,
-            ControlOperation::Scene(SceneOp::ListEntities),
-            &mut runtime(),
-        )
-        .unwrap();
+        let result = dispatch(&mut world, ControlOperation::ListEntities, &mut runtime()).unwrap();
         assert_eq!(result["entity_count"], 0);
     }
 
     #[test]
     fn dispatch_list_systems() {
         let mut world = World::new();
-        let result = dispatch(
-            &mut world,
-            ControlOperation::Scene(SceneOp::ListSystems),
-            &mut runtime(),
-        )
-        .unwrap();
+        let result = dispatch(&mut world, ControlOperation::ListSystems, &mut runtime()).unwrap();
         assert!(result["stages"].is_object());
     }
 
     #[test]
     fn dispatch_list_resources() {
         let mut world = World::new();
-        let result = dispatch(
-            &mut world,
-            ControlOperation::Scene(SceneOp::ListResources),
-            &mut runtime(),
-        )
-        .unwrap();
+        let result = dispatch(&mut world, ControlOperation::ListResources, &mut runtime()).unwrap();
         assert!(result["resource_count"].is_number());
     }
 
@@ -257,7 +151,7 @@ mod tests {
         let mut world = World::new();
         let result = dispatch(
             &mut world,
-            ControlOperation::Scene(SceneOp::SceneSummary),
+            ControlOperation::GetSceneSummary,
             &mut runtime(),
         )
         .unwrap();
@@ -267,24 +161,15 @@ mod tests {
     #[test]
     fn dispatch_debug_registry() {
         let mut world = World::new();
-        let result = dispatch(
-            &mut world,
-            ControlOperation::Scene(SceneOp::DebugRegistry),
-            &mut runtime(),
-        )
-        .unwrap();
+        let result = dispatch(&mut world, ControlOperation::GetRegistry, &mut runtime()).unwrap();
         assert!(result["component_bridge_count"].is_number());
     }
 
     #[test]
     fn dispatch_get_performance() {
         let mut world = World::new();
-        let result = dispatch(
-            &mut world,
-            ControlOperation::Other(OtherOp::GetPerformance),
-            &mut runtime(),
-        )
-        .unwrap();
+        let result =
+            dispatch(&mut world, ControlOperation::GetPerformance, &mut runtime()).unwrap();
         assert!(result["entity_count"].is_number());
     }
 
@@ -293,7 +178,7 @@ mod tests {
         let mut world = World::new();
         let result = dispatch(
             &mut world,
-            ControlOperation::Mutate(MutateOp::BatchMutate { operations: vec![] }),
+            ControlOperation::Batch { operations: vec![] },
             &mut runtime(),
         )
         .unwrap();
@@ -305,7 +190,7 @@ mod tests {
         let mut world = World::new();
         let result = dispatch(
             &mut world,
-            ControlOperation::Visual(VisualOp::CaptureScreenshot {
+            ControlOperation::CaptureScreenshot(CaptureScreenshotParams {
                 max_width: None,
                 delay_frames: 0,
                 position: None,
@@ -323,7 +208,7 @@ mod tests {
         let mut world = World::new();
         let result = dispatch(
             &mut world,
-            ControlOperation::Visual(VisualOp::CaptureTurnaround {
+            ControlOperation::CaptureTurnaround(CaptureTurnaroundParams {
                 look_at: None,
                 distance: None,
                 elevation: None,
@@ -344,7 +229,7 @@ mod tests {
         let mut world = World::new();
         let result = dispatch(
             &mut world,
-            ControlOperation::Visual(VisualOp::CaptureDepth {
+            ControlOperation::CaptureDepth(CaptureDepthParams {
                 position: None,
                 look_at: None,
                 sample_points: None,
@@ -365,9 +250,9 @@ mod tests {
         let mut world = World::new();
         let result = dispatch(
             &mut world,
-            ControlOperation::Other(OtherOp::GetConfig {
+            ControlOperation::GetConfig {
                 key: "nonexistent".into(),
-            }),
+            },
             &mut runtime(),
         );
         assert!(result.is_err());
@@ -377,12 +262,7 @@ mod tests {
     #[test]
     fn dispatch_list_configs_empty() {
         let mut world = World::new();
-        let result = dispatch(
-            &mut world,
-            ControlOperation::Other(OtherOp::ListConfigs),
-            &mut runtime(),
-        )
-        .unwrap();
+        let result = dispatch(&mut world, ControlOperation::ListConfigs, &mut runtime()).unwrap();
         assert!(result.is_object());
     }
 
@@ -394,9 +274,9 @@ mod tests {
         world.insert_resource(configs);
         let result = dispatch(
             &mut world,
-            ControlOperation::Other(OtherOp::GetConfig {
+            ControlOperation::GetConfig {
                 key: "test_key".into(),
-            }),
+            },
             &mut runtime(),
         )
         .unwrap();
@@ -410,12 +290,7 @@ mod tests {
         configs.insert("key1", serde_json::json!("val1"));
         configs.insert("key2", serde_json::json!("val2"));
         world.insert_resource(configs);
-        let result = dispatch(
-            &mut world,
-            ControlOperation::Other(OtherOp::ListConfigs),
-            &mut runtime(),
-        )
-        .unwrap();
+        let result = dispatch(&mut world, ControlOperation::ListConfigs, &mut runtime()).unwrap();
         assert_eq!(result["key1"], "val1");
         assert_eq!(result["key2"], "val2");
     }
@@ -426,9 +301,9 @@ mod tests {
         let entity = world.spawn(Name::new("Target")).id();
         let result = dispatch(
             &mut world,
-            ControlOperation::Mutate(MutateOp::DespawnEntity {
+            ControlOperation::DespawnEntity {
                 entity: EntityRef::Id(entity.to_bits()),
-            }),
+            },
             &mut runtime(),
         )
         .unwrap();
@@ -441,9 +316,9 @@ mod tests {
         let initial_count = world.entities().len();
         let result = dispatch(
             &mut world,
-            ControlOperation::Mutate(MutateOp::SpawnEntity {
+            ControlOperation::SpawnEntity {
                 components: serde_json::json!({"NonExistentComponent": {"field": 1}}),
-            }),
+            },
             &mut runtime(),
         );
         // Unknown components -> invalid_params error, no stray entity
@@ -457,9 +332,9 @@ mod tests {
         let mut world = World::new();
         let result = dispatch(
             &mut world,
-            ControlOperation::Mutate(MutateOp::SpawnEntity {
+            ControlOperation::SpawnEntity {
                 components: serde_json::json!({}),
-            }),
+            },
             &mut runtime(),
         )
         .unwrap();
@@ -473,12 +348,12 @@ mod tests {
         let entity = world.spawn(Name::new("Target")).id();
         let result = dispatch(
             &mut world,
-            ControlOperation::Mutate(MutateOp::BatchMutate {
+            ControlOperation::Batch {
                 operations: vec![serde_json::json!({
                     "action": "despawn",
                     "entity_id": entity.to_bits()
                 })],
-            }),
+            },
             &mut runtime(),
         )
         .unwrap();
@@ -493,12 +368,12 @@ mod tests {
         let mut world = World::new();
         let result = dispatch(
             &mut world,
-            ControlOperation::Mutate(MutateOp::BatchMutate {
+            ControlOperation::Batch {
                 operations: vec![serde_json::json!({
                     "action": "spawn",
                     "components": {"FakeComponent": {}}
                 })],
-            }),
+            },
             &mut runtime(),
         )
         .unwrap();
@@ -513,7 +388,7 @@ mod tests {
         let mut world = World::new();
         let result = dispatch(
             &mut world,
-            ControlOperation::Spatial(SpatialOp::CheckAllOverlaps {
+            ControlOperation::CheckAllOverlaps(CheckAllOverlapsParams {
                 min_penetration: None,
                 max_results: None,
                 max_float_gap: 0.1,
@@ -531,12 +406,7 @@ mod tests {
     fn dispatch_list_entities_includes_label() {
         let mut world = World::new();
         world.spawn(Name::new("TestEntity"));
-        let result = dispatch(
-            &mut world,
-            ControlOperation::Scene(SceneOp::ListEntities),
-            &mut runtime(),
-        )
-        .unwrap();
+        let result = dispatch(&mut world, ControlOperation::ListEntities, &mut runtime()).unwrap();
         let entities = result["entities"].as_array().unwrap();
         assert!(!entities.is_empty());
         // Every entity should have a "label" field
@@ -557,9 +427,9 @@ mod tests {
         // (Transform may be registered globally by other tests calling setup().)
         let result = dispatch(
             app.world_mut(),
-            ControlOperation::Scene(SceneOp::GetComponentSchema {
+            ControlOperation::GetComponentSchema {
                 name: "NonExistentComponentXYZ".into(),
-            }),
+            },
             &mut runtime(),
         );
         // Not in the bridge registry, so this returns not_found.
@@ -579,7 +449,7 @@ mod tests {
 
         let result = dispatch(
             &mut world,
-            ControlOperation::Spatial(SpatialOp::CheckAllOverlaps {
+            ControlOperation::CheckAllOverlaps(CheckAllOverlapsParams {
                 min_penetration: None,
                 max_results: None,
                 max_float_gap: 0.1,

--- a/crates/pybevy_control/src/handlers/reload.rs
+++ b/crates/pybevy_control/src/handlers/reload.rs
@@ -6,7 +6,9 @@ use bevy::{
 use pybevy_core::{PendingReloadRequest, ReloadRequestMode, ReloadResult};
 use tokio::sync::oneshot;
 
-use crate::bridge::{ControlError, DebugCameraRequest, PendingReloadResponses, PendingScreenshots};
+use crate::bridge::{
+    ControlError, DebugCameraRequest, PendingReloadResponses, PendingScreenshots, ReloadMode,
+};
 
 /// State machine for reload-and-capture.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -18,7 +20,7 @@ pub enum ReloadAndCaptureState {
 /// A pending reload-and-capture request.
 pub struct PendingReloadAndCapture {
     pub response_tx: oneshot::Sender<Result<serde_json::Value, ControlError>>,
-    pub mode: String,
+    pub mode: ReloadMode,
     pub error_timestamp_before: f64,
     pub reload_frames_remaining: u32,
     pub screenshot_delay_frames: u32,
@@ -39,13 +41,13 @@ pub struct PendingReloadAndCaptures {
 /// Trigger a hot reload (full or partial), optionally setting time control atomically
 pub fn trigger_reload(
     world: &mut World,
-    mode: String,
+    mode: ReloadMode,
     pause: bool,
     time_scale: Option<f32>,
 ) -> Result<serde_json::Value, ControlError> {
-    let reload_mode = match mode.as_str() {
-        "partial" => ReloadRequestMode::Partial,
-        _ => ReloadRequestMode::Full,
+    let reload_mode = match mode {
+        ReloadMode::Partial => ReloadRequestMode::Partial,
+        ReloadMode::Full => ReloadRequestMode::Full,
     };
 
     // Apply time control BEFORE queuing reload — no frames run at wrong speed
@@ -544,7 +546,7 @@ mod tests {
     #[test]
     fn trigger_reload_full_mode() {
         let mut world = world_with_reload_deps();
-        let result = trigger_reload(&mut world, "full".into(), false, None).unwrap();
+        let result = trigger_reload(&mut world, ReloadMode::Full, false, None).unwrap();
         assert_eq!(result["status"], "reload_requested");
         assert_eq!(result["mode"], "full");
         assert_eq!(result["paused"], false);
@@ -556,7 +558,7 @@ mod tests {
     #[test]
     fn trigger_reload_partial_mode_has_note() {
         let mut world = world_with_reload_deps();
-        let result = trigger_reload(&mut world, "partial".into(), false, None).unwrap();
+        let result = trigger_reload(&mut world, ReloadMode::Partial, false, None).unwrap();
         assert_eq!(result["mode"], "partial");
         let note = result["note"].as_str().unwrap();
         assert!(note.contains("auto-escalate"));
@@ -568,7 +570,7 @@ mod tests {
     #[test]
     fn trigger_reload_with_pause() {
         let mut world = world_with_reload_deps();
-        let result = trigger_reload(&mut world, "full".into(), true, None).unwrap();
+        let result = trigger_reload(&mut world, ReloadMode::Full, true, None).unwrap();
         assert_eq!(result["paused"], true);
         let time = world.resource::<Time<Virtual>>();
         assert!(time.is_paused());
@@ -577,7 +579,7 @@ mod tests {
     #[test]
     fn trigger_reload_with_time_scale() {
         let mut world = world_with_reload_deps();
-        let result = trigger_reload(&mut world, "full".into(), false, Some(0.5)).unwrap();
+        let result = trigger_reload(&mut world, ReloadMode::Full, false, Some(0.5)).unwrap();
         assert_eq!(result["relative_speed"], 0.5);
         let time = world.resource::<Time<Virtual>>();
         assert!((time.relative_speed() - 0.5).abs() < 1e-6);
@@ -586,7 +588,7 @@ mod tests {
     #[test]
     fn trigger_reload_with_pause_and_scale() {
         let mut world = world_with_reload_deps();
-        let result = trigger_reload(&mut world, "full".into(), true, Some(2.0)).unwrap();
+        let result = trigger_reload(&mut world, ReloadMode::Full, true, Some(2.0)).unwrap();
         assert_eq!(result["paused"], true);
         assert_eq!(result["relative_speed"], 2.0);
     }
@@ -599,7 +601,7 @@ mod tests {
             traceback: Some("old trace".into()),
             timestamp_secs: 1.0,
         });
-        trigger_reload(&mut world, "full".into(), false, None).unwrap();
+        trigger_reload(&mut world, ReloadMode::Full, false, None).unwrap();
         let err = world
             .get_resource::<pybevy_core::LastSystemError>()
             .unwrap();
@@ -608,13 +610,10 @@ mod tests {
     }
 
     #[test]
-    fn trigger_reload_unknown_mode_defaults_to_full() {
-        let mut world = world_with_reload_deps();
-        let result = trigger_reload(&mut world, "unknown_mode".into(), false, None).unwrap();
-        assert_eq!(result["mode"], "unknown_mode");
-        // Internal mode should be Full (the default branch)
-        let req = world.get_resource::<PendingReloadRequest>().unwrap();
-        assert_eq!(req.mode, Some(ReloadRequestMode::Full));
+    fn reload_mode_deserialize_rejects_unknown() {
+        let result: Result<ReloadMode, _> =
+            serde_json::from_value(serde_json::json!("unknown_mode"));
+        assert!(result.is_err());
     }
 
     #[test]
@@ -643,7 +642,7 @@ mod tests {
             pending: vec![PendingReloadResponse {
                 response_tx: tx,
                 frames_remaining: 3,
-                mode: "full".into(),
+                mode: ReloadMode::Full,
                 error_timestamp_before: 0.0,
             }],
         });
@@ -662,7 +661,7 @@ mod tests {
             pending: vec![PendingReloadResponse {
                 response_tx: tx,
                 frames_remaining: 0,
-                mode: "full".into(),
+                mode: ReloadMode::Full,
                 error_timestamp_before: 0.0,
             }],
         });
@@ -691,7 +690,7 @@ mod tests {
             pending: vec![PendingReloadResponse {
                 response_tx: tx,
                 frames_remaining: 0,
-                mode: "full".into(),
+                mode: ReloadMode::Full,
                 error_timestamp_before: 1.0, // error at 5.0 > 1.0
             }],
         });
@@ -716,7 +715,7 @@ mod tests {
             pending: vec![PendingReloadResponse {
                 response_tx: tx,
                 frames_remaining: 0,
-                mode: "full".into(),
+                mode: ReloadMode::Full,
                 error_timestamp_before: 1.0, // error at 0.5 < 1.0
             }],
         });

--- a/crates/pybevy_control/src/handlers/schedule.rs
+++ b/crates/pybevy_control/src/handlers/schedule.rs
@@ -12,46 +12,55 @@ use bevy::{
     prelude::{GlobalTransform, Resource, Transform, Without},
     time::{Time, Virtual},
 };
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;
 
 use crate::{
     bridge::{
-        ControlError, ControlOperation, DebugCameraRequest, EntityRef, MutateOp, OtherOp,
-        PendingReloadResponses, PendingScreenshot, PendingScreenshots, ReloadOp, SceneOp,
-        SpatialOp, TimeOp, VisualOp,
+        ControlError, ControlOperation, PendingScreenshots, push_pending_depth,
+        push_pending_reload, push_pending_reload_and_capture, push_pending_screenshot,
+        push_pending_timeline, push_pending_turnaround,
     },
-    handlers::{
-        self,
-        reload::{PendingReloadAndCapture, PendingReloadAndCaptures, ReloadAndCaptureState},
-        screenshot::{ActiveTimeline, PendingTimelines, setup_debug_camera},
-        turnaround::{
-            ActiveTurnaround, PendingTurnarounds, compute_scene_bounds, compute_viewpoints,
-        },
-    },
+    handlers,
 };
 
-#[derive(Debug, Deserialize)]
+/// sync (default): block until all actions complete. async: return schedule_id immediately.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ScheduleMode {
+    /// Block until all actions complete
+    #[default]
+    Sync,
+    /// Return schedule_id immediately
+    Async,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct ScheduleRequest {
+    /// Ordered list of tool calls to execute
     pub actions: Vec<ScheduleAction>,
-    #[serde(default = "default_mode")]
-    pub mode: String,
+    #[serde(default)]
+    pub mode: ScheduleMode,
+    /// Abort remaining actions on first error (default false)
     #[serde(default)]
     pub stop_on_error: bool,
 }
 
-fn default_mode() -> String {
-    "sync".to_string()
-}
-
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct ScheduleAction {
+    /// Tool name to call
     pub tool: String,
+    /// Tool arguments (default {})
     #[serde(default)]
     pub args: serde_json::Value,
+    /// Time offset in seconds from schedule start (default 0). Must be monotonically non-decreasing.
     pub at: Option<f64>,
+    /// Frame offset from schedule start (alternative to 'at'). Cannot mix with 'at'.
     pub at_frame: Option<u64>,
+    /// Label for this action (used by skip_if_error)
     pub label: Option<String>,
+    /// Skip this action if the action with the given label errored
     pub skip_if_error: Option<String>,
 }
 
@@ -240,13 +249,6 @@ pub fn validate_schedule(request: &ScheduleRequest) -> Result<(), String> {
     if request.actions.len() > 256 {
         return Err("actions must have at most 256 entries".to_string());
     }
-    if request.mode != "sync" && request.mode != "async" {
-        return Err(format!(
-            "mode must be 'sync' or 'async', got '{}'",
-            request.mode
-        ));
-    }
-
     let mut last_at: Option<f64> = None;
     let mut last_frame: Option<u64> = None;
     let mut uses_at = false;
@@ -313,357 +315,34 @@ pub fn validate_schedule(request: &ScheduleRequest) -> Result<(), String> {
     Ok(())
 }
 pub fn tool_to_operation(tool: &str, args: &serde_json::Value) -> Result<ControlOperation, String> {
-    let obj = args.as_object();
-    let get_str = |key: &str| -> String {
-        obj.and_then(|o| o.get(key))
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string()
+    let mut obj = if args.is_null() {
+        serde_json::json!({})
+    } else {
+        args.clone()
     };
-    let get_f64 =
-        |key: &str| -> Option<f64> { obj.and_then(|o| o.get(key)).and_then(|v| v.as_f64()) };
-    let get_f32 = |key: &str| -> Option<f32> { get_f64(key).map(|v| v as f32) };
-    let get_u32 = |key: &str| -> Option<u32> {
-        obj.and_then(|o| o.get(key))
-            .and_then(|v| v.as_u64())
-            .map(|v| v as u32)
-    };
-    let get_bool = |key: &str, default: bool| -> bool {
-        obj.and_then(|o| o.get(key))
-            .and_then(|v| v.as_bool())
-            .unwrap_or(default)
-    };
-    let get_entity_ref = || -> EntityRef {
-        if let Some(id) = obj
-            .and_then(|o| o.get("entity_id"))
-            .and_then(|v| v.as_u64())
-        {
-            EntityRef::Id(id)
-        } else {
-            EntityRef::Name(get_str("name"))
+    let map = obj
+        .as_object_mut()
+        .ok_or_else(|| "args must be an object".to_string())?;
+
+    // Route combined tools to their hidden sub-variants
+    let effective_tool = match tool {
+        "capture_screenshot" if map.get("gizmos").and_then(|v| v.as_bool()).unwrap_or(false) => {
+            map.remove("gizmos");
+            "capture_with_gizmos"
         }
-    };
-    let get_vec3 = |key: &str| -> Option<[f32; 3]> {
-        obj.and_then(|o| o.get(key)).and_then(|v| {
-            let arr = v.as_array()?;
-            if arr.len() != 3 {
-                return None;
-            }
-            Some([
-                arr[0].as_f64()? as f32,
-                arr[1].as_f64()? as f32,
-                arr[2].as_f64()? as f32,
-            ])
-        })
+        "query_spatial" if map.contains_key("radius") => "query_spatial_neighborhood",
+        "check_overlaps" if !map.contains_key("entity") => "check_all_overlaps",
+        other => other,
     };
 
-    match tool {
-        // Time control
-        "pause_time" => Ok(ControlOperation::Time(TimeOp::PauseTime)),
-        "resume_time" => Ok(ControlOperation::Time(TimeOp::ResumeTime)),
-        "set_time_scale" => {
-            let scale = get_f32("scale").unwrap_or(1.0);
-            Ok(ControlOperation::Time(TimeOp::SetTimeScale { scale }))
-        }
-        "get_time_status" => Ok(ControlOperation::Time(TimeOp::GetTimeStatus)),
-        "seek_time" => {
-            let seconds =
-                get_f64("seconds").ok_or_else(|| "seek_time requires 'seconds'".to_string())?;
-            let pause = get_bool("pause", true);
-            Ok(ControlOperation::Time(TimeOp::SeekTime { seconds, pause }))
-        }
+    map.insert(
+        "tool".to_string(),
+        serde_json::Value::String(effective_tool.to_string()),
+    );
 
-        // Scene queries
-        "query_entities" => {
-            let with = obj
-                .and_then(|o| o.get("with"))
-                .and_then(|v| v.as_array())
-                .map(|a| {
-                    a.iter()
-                        .filter_map(|v| v.as_str().map(String::from))
-                        .collect()
-                })
-                .unwrap_or_default();
-            let without = obj
-                .and_then(|o| o.get("without"))
-                .and_then(|v| v.as_array())
-                .map(|a| {
-                    a.iter()
-                        .filter_map(|v| v.as_str().map(String::from))
-                        .collect()
-                })
-                .unwrap_or_default();
-            Ok(ControlOperation::Scene(SceneOp::QueryEntities {
-                with,
-                without,
-            }))
-        }
-        "get_component" => {
-            let component = get_str("component");
-            if component.is_empty() {
-                return Err("get_component requires 'component'".to_string());
-            }
-            Ok(ControlOperation::Scene(SceneOp::GetComponent {
-                entity: get_entity_ref(),
-                component,
-            }))
-        }
-        "get_component_schema" => {
-            let name = get_str("name");
-            if name.is_empty() {
-                return Err("get_component_schema requires 'name'".to_string());
-            }
-            Ok(ControlOperation::Scene(SceneOp::GetComponentSchema {
-                name,
-            }))
-        }
-        "get_scene_summary" => Ok(ControlOperation::Scene(SceneOp::SceneSummary)),
-        "get_performance" => Ok(ControlOperation::Other(OtherOp::GetPerformance)),
-        "get_registry" => Ok(ControlOperation::Scene(SceneOp::DebugRegistry)),
-        "get_reload_status" => Ok(ControlOperation::Reload(ReloadOp::GetReloadStatus)),
-        "get_last_error" => Ok(ControlOperation::Reload(ReloadOp::GetLastError)),
-        "get_bounding_box" => Ok(ControlOperation::Scene(SceneOp::GetBoundingBox {
-            entity: get_entity_ref(),
-        })),
-
-        // Mutations
-        "spawn_entity" => {
-            let components = obj
-                .and_then(|o| o.get("components"))
-                .cloned()
-                .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
-            Ok(ControlOperation::Mutate(MutateOp::SpawnEntity {
-                components,
-            }))
-        }
-        "despawn_entity" => Ok(ControlOperation::Mutate(MutateOp::DespawnEntity {
-            entity: get_entity_ref(),
-        })),
-        "set_component" => {
-            let component = get_str("component");
-            let fields = obj
-                .and_then(|o| o.get("fields"))
-                .cloned()
-                .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
-            Ok(ControlOperation::Mutate(MutateOp::SetComponent {
-                entity: get_entity_ref(),
-                component,
-                fields,
-            }))
-        }
-        "remove_component" => {
-            let component = get_str("component");
-            Ok(ControlOperation::Mutate(MutateOp::RemoveComponent {
-                entity: get_entity_ref(),
-                component,
-            }))
-        }
-        "set_resource" => {
-            let resource_type = get_str("resource_type");
-            let value = obj
-                .and_then(|o| o.get("value"))
-                .cloned()
-                .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
-            Ok(ControlOperation::Mutate(MutateOp::InsertResource {
-                resource_type,
-                value,
-            }))
-        }
-        "remove_resource" => {
-            let resource_type = get_str("resource_type");
-            Ok(ControlOperation::Mutate(MutateOp::RemoveResource {
-                resource_type,
-            }))
-        }
-        "run_code" => {
-            let code = get_str("code");
-            Ok(ControlOperation::Other(OtherOp::ExecutePython { code }))
-        }
-        "batch" => {
-            let operations = obj
-                .and_then(|o| o.get("operations"))
-                .and_then(|v| v.as_array())
-                .cloned()
-                .unwrap_or_default();
-            Ok(ControlOperation::Mutate(MutateOp::BatchMutate {
-                operations,
-            }))
-        }
-
-        // Asset mutation
-        "set_asset" => {
-            let component = get_str("component");
-            let asset_type = get_str("asset_type");
-            let fields = obj
-                .and_then(|o| o.get("fields"))
-                .cloned()
-                .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
-            Ok(ControlOperation::Other(OtherOp::MutateAsset {
-                entity: get_entity_ref(),
-                component,
-                asset_type,
-                fields,
-            }))
-        }
-
-        // Spatial queries
-        "query_spatial" => {
-            if obj.is_some_and(|o| o.contains_key("radius")) {
-                let radius = get_f32("radius").unwrap_or(10.0);
-                let max_results = obj
-                    .and_then(|o| o.get("max_results"))
-                    .and_then(|v| v.as_u64())
-                    .map(|v| v as usize);
-                Ok(ControlOperation::Spatial(
-                    SpatialOp::QuerySpatialNeighborhood {
-                        entity: get_entity_ref(),
-                        radius,
-                        max_results,
-                    },
-                ))
-            } else {
-                let entity_a = if let Some(id) = obj
-                    .and_then(|o| o.get("entity_id_a"))
-                    .and_then(|v| v.as_u64())
-                {
-                    EntityRef::Id(id)
-                } else {
-                    EntityRef::Name(get_str("name_a"))
-                };
-                let entity_b = if let Some(id) = obj
-                    .and_then(|o| o.get("entity_id_b"))
-                    .and_then(|v| v.as_u64())
-                {
-                    EntityRef::Id(id)
-                } else {
-                    EntityRef::Name(get_str("name_b"))
-                };
-                Ok(ControlOperation::Spatial(SpatialOp::QuerySpatial {
-                    entity_a,
-                    entity_b,
-                }))
-            }
-        }
-        "check_overlaps" => {
-            let has_entity =
-                obj.is_some_and(|o| o.contains_key("entity_id") || o.contains_key("name"));
-            let max_float_gap = get_f32("max_float_gap").unwrap_or(0.1);
-            let ground_y = get_f32("ground_y");
-            if has_entity {
-                let include_siblings = get_bool("include_siblings", false);
-                Ok(ControlOperation::Spatial(SpatialOp::CheckOverlaps {
-                    entity: get_entity_ref(),
-                    include_siblings,
-                    max_float_gap,
-                    ground_y,
-                }))
-            } else {
-                let min_penetration = get_f32("min_penetration");
-                let max_results = obj
-                    .and_then(|o| o.get("max_results"))
-                    .and_then(|v| v.as_u64())
-                    .map(|v| v as usize);
-                let include_siblings = get_bool("include_siblings", false);
-                Ok(ControlOperation::Spatial(SpatialOp::CheckAllOverlaps {
-                    min_penetration,
-                    max_results,
-                    max_float_gap,
-                    ground_y,
-                    include_siblings,
-                }))
-            }
-        }
-
-        // Deferred tools (screenshots, reload, etc.)
-        "capture_screenshot" => {
-            let delay_frames = get_u32("delay_frames").unwrap_or(2);
-            let max_width = get_u32("max_width");
-            let position = get_vec3("position");
-            let look_at = get_vec3("look_at");
-            let hide_ui = get_bool("hide_ui", true);
-            if get_bool("gizmos", false) {
-                Ok(ControlOperation::Visual(VisualOp::CaptureWithGizmos {
-                    delay_frames,
-                    max_width,
-                    position,
-                    look_at,
-                    hide_ui,
-                }))
-            } else {
-                Ok(ControlOperation::Visual(VisualOp::CaptureScreenshot {
-                    delay_frames,
-                    max_width,
-                    position,
-                    look_at,
-                    hide_ui,
-                }))
-            }
-        }
-        "capture_timeline" => Ok(ControlOperation::Visual(VisualOp::CaptureTimeline {
-            total_frames: get_u32("total_frames").unwrap_or(60),
-            capture_count: get_u32("capture_count").unwrap_or(6),
-            max_width: get_u32("max_width"),
-            columns: get_u32("columns").unwrap_or(3),
-            position: get_vec3("position"),
-            look_at: get_vec3("look_at"),
-        })),
-        "reload" => Ok(ControlOperation::Reload(ReloadOp::TriggerReload {
-            mode: get_str("mode"),
-            pause: get_bool("pause", false),
-            time_scale: get_f32("time_scale"),
-        })),
-        "reload_and_capture" => Ok(ControlOperation::Reload(ReloadOp::ReloadAndCapture {
-            mode: {
-                let m = get_str("mode");
-                if m.is_empty() { "full".to_string() } else { m }
-            },
-            pause: get_bool("pause", false),
-            time_scale: get_f32("time_scale"),
-            delay_frames: get_u32("delay_frames"),
-            max_width: get_u32("max_width"),
-            position: get_vec3("position"),
-            look_at: get_vec3("look_at"),
-            hide_ui: Some(get_bool("hide_ui", true)),
-        })),
-        "capture_turnaround" => Ok(ControlOperation::Visual(VisualOp::CaptureTurnaround {
-            look_at: get_vec3("look_at"),
-            distance: get_f32("distance"),
-            elevation: get_f32("elevation"),
-            view_count: get_u32("view_count"),
-            include_top: obj
-                .and_then(|o| o.get("include_top"))
-                .and_then(|v| v.as_bool()),
-            columns: get_u32("columns"),
-            max_width: get_u32("max_width"),
-            hide_ui: obj.and_then(|o| o.get("hide_ui")).and_then(|v| v.as_bool()),
-        })),
-        "capture_depth" => Ok(ControlOperation::Visual(VisualOp::CaptureDepth {
-            position: get_vec3("position"),
-            look_at: get_vec3("look_at"),
-            sample_points: obj.and_then(|o| o.get("sample_points")).and_then(|v| {
-                v.as_array().map(|arr| {
-                    arr.iter()
-                        .filter_map(|pt| {
-                            let a = pt.as_array()?;
-                            if a.len() != 2 {
-                                return None;
-                            }
-                            Some([a[0].as_u64()? as u32, a[1].as_u64()? as u32])
-                        })
-                        .collect()
-                })
-            }),
-            grid_density: get_u32("grid_density"),
-            include_rgb: obj
-                .and_then(|o| o.get("include_rgb"))
-                .and_then(|v| v.as_bool()),
-            delay_frames: get_u32("delay_frames"),
-            hide_ui: obj.and_then(|o| o.get("hide_ui")).and_then(|v| v.as_bool()),
-            max_width: get_u32("max_width"),
-        })),
-
-        _ => Err(format!("unknown tool: '{}'", tool)),
-    }
+    let call: ControlOperation =
+        serde_json::from_value(obj).map_err(|e| format!("invalid tool call '{tool}': {e}"))?;
+    Ok(call)
 }
 fn resolve_at(action: &ScheduleAction) -> f64 {
     action.at.unwrap_or(0.0)
@@ -1148,354 +827,31 @@ fn setup_deferred_action(
     tool: &str,
     args: &serde_json::Value,
 ) -> Result<oneshot::Receiver<Result<serde_json::Value, ControlError>>, String> {
-    let (forward_tx, forward_rx) = oneshot::channel();
+    let op = tool_to_operation(tool, args)?;
+    let (tx, rx) = oneshot::channel();
+    let mut screenshots = Vec::new();
 
-    match tool {
-        "capture_screenshot" => {
-            let op = tool_to_operation(tool, args).map_err(|e| e.to_string())?;
-            let (delay_frames, max_width, position, look_at, hide_ui, with_gizmos) = match &op {
-                ControlOperation::Visual(VisualOp::CaptureScreenshot {
-                    delay_frames,
-                    max_width,
-                    position,
-                    look_at,
-                    hide_ui,
-                }) => (
-                    *delay_frames,
-                    *max_width,
-                    *position,
-                    *look_at,
-                    *hide_ui,
-                    false,
-                ),
-                ControlOperation::Visual(VisualOp::CaptureWithGizmos {
-                    delay_frames,
-                    max_width,
-                    position,
-                    look_at,
-                    hide_ui,
-                }) => (
-                    *delay_frames,
-                    *max_width,
-                    *position,
-                    *look_at,
-                    *hide_ui,
-                    true,
-                ),
-                _ => unreachable!(),
-            };
-
-            let debug_camera = position.map(|pos| DebugCameraRequest {
-                position: pos,
-                look_at: look_at.unwrap_or([0.0, 0.0, 0.0]),
-            });
-
-            let mut pending = world.get_resource_or_insert_with(PendingScreenshots::default);
-            pending.pending.push(PendingScreenshot {
-                response_tx: forward_tx,
-                frames_remaining: delay_frames,
-                with_gizmos,
-                max_width,
-                debug_camera,
-                hide_ui,
-                extra_response: None,
-            });
-            Ok(forward_rx)
+    match op {
+        ControlOperation::CaptureScreenshot(p) => {
+            push_pending_screenshot(p, false, tx, &mut screenshots)
         }
-
-        "reload" => {
-            let op = tool_to_operation(tool, args).map_err(|e| e.to_string())?;
-            let (mode, pause, time_scale) = match &op {
-                ControlOperation::Reload(ReloadOp::TriggerReload {
-                    mode,
-                    pause,
-                    time_scale,
-                }) => (mode.clone(), *pause, *time_scale),
-                _ => unreachable!(),
-            };
-
-            let _ = handlers::reload::trigger_reload(world, mode.clone(), pause, time_scale);
-
-            let error_ts = world
-                .get_resource::<pybevy_core::LastSystemError>()
-                .map(|e| e.timestamp_secs)
-                .unwrap_or(0.0);
-
-            let mut pending = world.get_resource_or_insert_with(PendingReloadResponses::default);
-            pending.pending.push(crate::bridge::PendingReloadResponse {
-                response_tx: forward_tx,
-                frames_remaining: 5,
-                mode,
-                error_timestamp_before: error_ts,
-            });
-            Ok(forward_rx)
+        ControlOperation::CaptureWithGizmos(p) => {
+            push_pending_screenshot(p, true, tx, &mut screenshots)
         }
-
-        "reload_and_capture" => {
-            let op = tool_to_operation(tool, args).map_err(|e| e.to_string())?;
-            let (mode, pause, time_scale, delay_frames, max_width, position, look_at, hide_ui) =
-                match &op {
-                    ControlOperation::Reload(ReloadOp::ReloadAndCapture {
-                        mode,
-                        pause,
-                        time_scale,
-                        delay_frames,
-                        max_width,
-                        position,
-                        look_at,
-                        hide_ui,
-                    }) => (
-                        mode.clone(),
-                        *pause,
-                        *time_scale,
-                        *delay_frames,
-                        *max_width,
-                        *position,
-                        *look_at,
-                        *hide_ui,
-                    ),
-                    _ => unreachable!(),
-                };
-
-            let _ = handlers::reload::trigger_reload(world, mode.clone(), pause, time_scale);
-
-            let error_ts = world
-                .get_resource::<pybevy_core::LastSystemError>()
-                .map(|e| e.timestamp_secs)
-                .unwrap_or(0.0);
-
-            let mut pending = world.get_resource_or_insert_with(PendingReloadAndCaptures::default);
-            pending.pending.push(PendingReloadAndCapture {
-                response_tx: forward_tx,
-                mode,
-                error_timestamp_before: error_ts,
-                reload_frames_remaining: 5,
-                screenshot_delay_frames: delay_frames.unwrap_or(30),
-                max_width,
-                position,
-                look_at,
-                hide_ui: hide_ui.unwrap_or(true),
-                state: ReloadAndCaptureState::WaitingForReload,
-                reload_response: None,
-            });
-            Ok(forward_rx)
-        }
-
-        "capture_timeline" => {
-            let op = tool_to_operation(tool, args).map_err(|e| e.to_string())?;
-            let (total_frames, capture_count, max_width, columns, position, look_at) = match &op {
-                ControlOperation::Visual(VisualOp::CaptureTimeline {
-                    total_frames,
-                    capture_count,
-                    max_width,
-                    columns,
-                    position,
-                    look_at,
-                }) => (
-                    *total_frames,
-                    *capture_count,
-                    *max_width,
-                    *columns,
-                    *position,
-                    *look_at,
-                ),
-                _ => unreachable!(),
-            };
-
-            let mut schedule_frames =
-                crate::handlers::screenshot::compute_schedule(total_frames, capture_count);
-
-            let debug_cleanup = position.map(|pos| {
-                let debug_req = DebugCameraRequest {
-                    position: pos,
-                    look_at: look_at.unwrap_or([0.0, 0.0, 0.0]),
-                };
-                if let Some(first) = schedule_frames.front_mut() {
-                    *first += 2;
-                }
-                setup_debug_camera(world, &debug_req)
-            });
-
-            let mut pending = world.get_resource_or_insert_with(PendingTimelines::default);
-            let id = pending.next_id;
-            pending.next_id += 1;
-            pending.active.insert(
-                id,
-                ActiveTimeline {
-                    response_tx: Some(forward_tx),
-                    max_width,
-                    columns,
-                    debug_cleanup,
-                    schedule: schedule_frames,
-                    total_captures: capture_count,
-                    next_capture_index: 0,
-                    collected: Vec::new(),
-                },
-            );
-            Ok(forward_rx)
-        }
-
-        "capture_turnaround" => {
-            let op = tool_to_operation(tool, args).map_err(|e| e.to_string())?;
-            let (
-                look_at_opt,
-                distance,
-                elevation,
-                view_count,
-                include_top,
-                columns,
-                max_width,
-                hide_ui,
-            ) = match &op {
-                ControlOperation::Visual(VisualOp::CaptureTurnaround {
-                    look_at,
-                    distance,
-                    elevation,
-                    view_count,
-                    include_top,
-                    columns,
-                    max_width,
-                    hide_ui,
-                }) => (
-                    *look_at,
-                    *distance,
-                    *elevation,
-                    *view_count,
-                    *include_top,
-                    *columns,
-                    *max_width,
-                    *hide_ui,
-                ),
-                _ => unreachable!(),
-            };
-
-            let vc = view_count.unwrap_or(6);
-            let elev = elevation.unwrap_or(25.0);
-            let top = include_top.unwrap_or(true);
-
-            let (auto_look_at, auto_distance) = if distance.is_none() || look_at_opt.is_none() {
-                if let Some((scene_min, scene_max)) = compute_scene_bounds(world) {
-                    let center = (scene_min + scene_max) * 0.5;
-                    let extent = scene_max - scene_min;
-                    let diagonal =
-                        (extent.x * extent.x + extent.y * extent.y + extent.z * extent.z).sqrt();
-                    let dist = diagonal / (30.0_f32.to_radians().tan() * 2.0);
-                    ([center.x, center.y, center.z], dist.max(2.0))
-                } else {
-                    ([0.0, 0.0, 0.0], 10.0)
-                }
-            } else {
-                ([0.0, 0.0, 0.0], 10.0)
-            };
-
-            let final_look_at = look_at_opt.unwrap_or(auto_look_at);
-            let final_distance = distance.unwrap_or(auto_distance);
-
-            let viewpoints = compute_viewpoints(final_look_at, final_distance, elev, vc, top);
-
-            let mut pending = world.get_resource_or_insert_with(PendingTurnarounds::default);
-            pending.active.push(ActiveTurnaround {
-                response_tx: Some(forward_tx),
-                viewpoints,
-                current_index: 0,
-                captures: Vec::new(),
-                columns: columns.unwrap_or(3),
-                max_width: Some(max_width.unwrap_or(1200)),
-                frames_remaining: 0,
-                hide_ui: hide_ui.unwrap_or(true),
-                ui_restore: None,
-                debug_cleanup: None,
-                look_at: final_look_at,
-                pending_screenshot_entity: None,
-            });
-            Ok(forward_rx)
-        }
-
-        "capture_depth" => {
-            let op = tool_to_operation(tool, args).map_err(|e| e.to_string())?;
-            let (
-                position,
-                look_at,
-                sample_points,
-                grid_density,
-                include_rgb,
-                delay_frames,
-                hide_ui,
-                max_width,
-            ) = match &op {
-                ControlOperation::Visual(VisualOp::CaptureDepth {
-                    position,
-                    look_at,
-                    sample_points,
-                    grid_density,
-                    include_rgb,
-                    delay_frames,
-                    hide_ui,
-                    max_width,
-                }) => (
-                    *position,
-                    *look_at,
-                    sample_points.clone(),
-                    *grid_density,
-                    *include_rgb,
-                    *delay_frames,
-                    *hide_ui,
-                    *max_width,
-                ),
-                _ => unreachable!(),
-            };
-
-            // Compute depth samples synchronously
-            let depth_result = crate::handlers::depth::compute_depth_samples(
-                world,
-                &position,
-                &look_at,
-                &sample_points,
-                &grid_density,
-            );
-
-            let want_rgb = include_rgb.unwrap_or(true);
-            let df = delay_frames.unwrap_or(2);
-            let mw = Some(max_width.unwrap_or(768));
-            let hu = hide_ui.unwrap_or(true);
-            let dc = position.as_ref().map(|pos| DebugCameraRequest {
-                position: *pos,
-                look_at: look_at.unwrap_or([0.0, 0.0, 0.0]),
-            });
-
-            if want_rgb {
-                let depth = match depth_result {
-                    Ok(d) => d,
-                    Err(e) => {
-                        let _ = forward_tx.send(Err(e));
-                        return Err(format!("Depth computation failed"));
-                    }
-                };
-
-                let mut pending = world.get_resource_or_insert_with(PendingScreenshots::default);
-                pending.pending.push(PendingScreenshot {
-                    response_tx: forward_tx,
-                    frames_remaining: df,
-                    with_gizmos: false,
-                    max_width: mw,
-                    debug_camera: dc,
-                    hide_ui: hu,
-                    extra_response: Some(serde_json::json!({ "depth_samples": depth })),
-                });
-            } else {
-                let result = depth_result.map(|depth| {
-                    serde_json::json!({
-                        "screenshot": null,
-                        "depth_samples": depth,
-                    })
-                });
-                let _ = forward_tx.send(result);
-            }
-            Ok(forward_rx)
-        }
-
-        _ => Err(format!("Cannot defer tool '{}'", tool)),
+        ControlOperation::CaptureTimeline(p) => push_pending_timeline(p, tx, world),
+        ControlOperation::Reload(p) => push_pending_reload(p, tx, world),
+        ControlOperation::ReloadAndCapture(p) => push_pending_reload_and_capture(p, tx, world),
+        ControlOperation::CaptureTurnaround(p) => push_pending_turnaround(p, tx, world),
+        ControlOperation::CaptureDepth(p) => push_pending_depth(p, tx, &mut screenshots, world),
+        _ => return Err(format!("tool '{tool}' is not deferrable")),
     }
+
+    if !screenshots.is_empty() {
+        let mut pending = world.get_resource_or_insert_with(PendingScreenshots::default);
+        pending.pending.extend(screenshots);
+    }
+
+    Ok(rx)
 }
 fn abort_remaining(schedule: &mut ActiveSchedule, from_index: usize) {
     for idx in from_index..schedule.actions.len() {
@@ -1557,13 +913,19 @@ mod tests {
     use bevy::math::Vec3;
 
     use super::*;
-    use crate::handlers::pyo3::mutate::has_embedded_errors;
+    use crate::{
+        bridge::{
+            CaptureScreenshotParams, EntityRef, GetComponentParams, ReloadMode, ReloadParams,
+            SeekTimeParams, SetComponentParams,
+        },
+        handlers::pyo3::mutate::has_embedded_errors,
+    };
 
     #[test]
     fn test_validate_empty_actions() {
         let req = ScheduleRequest {
             actions: vec![],
-            mode: "sync".to_string(),
+            mode: ScheduleMode::Sync,
             stop_on_error: false,
         };
         assert!(validate_schedule(&req).is_err());
@@ -1583,7 +945,7 @@ mod tests {
             .collect();
         let req = ScheduleRequest {
             actions,
-            mode: "sync".to_string(),
+            mode: ScheduleMode::Sync,
             stop_on_error: false,
         };
         assert!(validate_schedule(&req).is_err());
@@ -1600,7 +962,7 @@ mod tests {
                 label: None,
                 skip_if_error: None,
             }],
-            mode: "sync".to_string(),
+            mode: ScheduleMode::Sync,
             stop_on_error: false,
         };
         let err = validate_schedule(&req).unwrap_err();
@@ -1628,7 +990,7 @@ mod tests {
                     skip_if_error: None,
                 },
             ],
-            mode: "sync".to_string(),
+            mode: ScheduleMode::Sync,
             stop_on_error: false,
         };
         let err = validate_schedule(&req).unwrap_err();
@@ -1656,7 +1018,7 @@ mod tests {
                     skip_if_error: None,
                 },
             ],
-            mode: "sync".to_string(),
+            mode: ScheduleMode::Sync,
             stop_on_error: false,
         };
         let err = validate_schedule(&req).unwrap_err();
@@ -1674,7 +1036,7 @@ mod tests {
                 label: None,
                 skip_if_error: None,
             }],
-            mode: "sync".to_string(),
+            mode: ScheduleMode::Sync,
             stop_on_error: false,
         };
         let err = validate_schedule(&req).unwrap_err();
@@ -1692,7 +1054,7 @@ mod tests {
                 label: None,
                 skip_if_error: None,
             }],
-            mode: "sync".to_string(),
+            mode: ScheduleMode::Sync,
             stop_on_error: false,
         };
         let err = validate_schedule(&req).unwrap_err();
@@ -1710,7 +1072,7 @@ mod tests {
                 label: None,
                 skip_if_error: None,
             }],
-            mode: "sync".to_string(),
+            mode: ScheduleMode::Sync,
             stop_on_error: false,
         };
         let err = validate_schedule(&req).unwrap_err();
@@ -1718,21 +1080,10 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_invalid_mode() {
-        let req = ScheduleRequest {
-            actions: vec![ScheduleAction {
-                tool: "pause_time".to_string(),
-                args: serde_json::Value::Null,
-                at: Some(0.0),
-                at_frame: None,
-                label: None,
-                skip_if_error: None,
-            }],
-            mode: "invalid".to_string(),
-            stop_on_error: false,
-        };
-        let err = validate_schedule(&req).unwrap_err();
-        assert!(err.contains("mode"));
+    fn test_deserialize_invalid_mode() {
+        let json = r#"{"actions": [{"tool": "pause_time"}], "mode": "invalid"}"#;
+        let result: Result<ScheduleRequest, _> = serde_json::from_str(json);
+        assert!(result.is_err());
     }
 
     #[test]
@@ -1756,7 +1107,7 @@ mod tests {
                     skip_if_error: None,
                 },
             ],
-            mode: "sync".to_string(),
+            mode: ScheduleMode::Sync,
             stop_on_error: false,
         };
         assert!(validate_schedule(&req).is_ok());
@@ -1783,7 +1134,7 @@ mod tests {
                     skip_if_error: None,
                 },
             ],
-            mode: "sync".to_string(),
+            mode: ScheduleMode::Sync,
             stop_on_error: false,
         };
         assert!(validate_schedule(&req).is_ok());
@@ -1810,7 +1161,7 @@ mod tests {
                     skip_if_error: None,
                 },
             ],
-            mode: "sync".to_string(),
+            mode: ScheduleMode::Sync,
             stop_on_error: false,
         };
         assert!(validate_schedule(&req).is_ok());
@@ -1819,20 +1170,20 @@ mod tests {
     #[test]
     fn test_tool_to_operation_pause() {
         let op = tool_to_operation("pause_time", &serde_json::Value::Null).unwrap();
-        assert!(matches!(op, ControlOperation::Time(TimeOp::PauseTime)));
+        assert!(matches!(op, ControlOperation::PauseTime));
     }
 
     #[test]
     fn test_tool_to_operation_resume() {
         let op = tool_to_operation("resume_time", &serde_json::Value::Null).unwrap();
-        assert!(matches!(op, ControlOperation::Time(TimeOp::ResumeTime)));
+        assert!(matches!(op, ControlOperation::ResumeTime));
     }
 
     #[test]
     fn test_tool_to_operation_seek() {
         let op = tool_to_operation("seek_time", &serde_json::json!({"seconds": 5.0})).unwrap();
         assert!(
-            matches!(op, ControlOperation::Time(TimeOp::SeekTime { seconds, pause }) if (seconds - 5.0).abs() < 0.001 && pause)
+            matches!(op, ControlOperation::SeekTime(SeekTimeParams { seconds, pause }) if (seconds - 5.0).abs() < 0.001 && pause)
         );
     }
 
@@ -1840,7 +1191,7 @@ mod tests {
     fn test_tool_to_operation_set_time_scale() {
         let op = tool_to_operation("set_time_scale", &serde_json::json!({"scale": 2.0})).unwrap();
         assert!(
-            matches!(op, ControlOperation::Time(TimeOp::SetTimeScale { scale }) if (scale - 2.0).abs() < 0.001)
+            matches!(op, ControlOperation::SetTimeScale { scale } if (scale - 2.0).abs() < 0.001)
         );
     }
 
@@ -1848,11 +1199,11 @@ mod tests {
     fn test_tool_to_operation_set_component() {
         let op = tool_to_operation(
             "set_component",
-            &serde_json::json!({"name": "MyEntity", "component": "Transform", "fields": {"translation": [0, 1, 0]}}),
+            &serde_json::json!({"entity": "MyEntity", "component": "Transform", "fields": {"translation": [0, 1, 0]}}),
         )
         .unwrap();
         assert!(
-            matches!(op, ControlOperation::Mutate(MutateOp::SetComponent { entity: EntityRef::Name(n), component, .. }) if n == "MyEntity" && component == "Transform")
+            matches!(op, ControlOperation::SetComponent(SetComponentParams { entity: EntityRef::Name(n), component, .. }) if n == "MyEntity" && component == "Transform")
         );
     }
 
@@ -1862,7 +1213,7 @@ mod tests {
             .unwrap();
         assert!(matches!(
             op,
-            ControlOperation::Visual(VisualOp::CaptureScreenshot {
+            ControlOperation::CaptureScreenshot(CaptureScreenshotParams {
                 max_width: Some(768),
                 ..
             })
@@ -1944,44 +1295,32 @@ mod tests {
     fn test_tool_to_operation_query_spatial_pairwise() {
         let op = tool_to_operation(
             "query_spatial",
-            &serde_json::json!({"name_a": "A", "name_b": "B"}),
+            &serde_json::json!({"entity_a": "A", "entity_b": "B"}),
         )
         .unwrap();
-        assert!(matches!(
-            op,
-            ControlOperation::Spatial(SpatialOp::QuerySpatial { .. })
-        ));
+        assert!(matches!(op, ControlOperation::QuerySpatial(..)));
     }
 
     #[test]
     fn test_tool_to_operation_query_spatial_neighborhood() {
         let op = tool_to_operation(
             "query_spatial",
-            &serde_json::json!({"name": "A", "radius": 5.0}),
+            &serde_json::json!({"entity": "A", "radius": 5.0}),
         )
         .unwrap();
-        assert!(matches!(
-            op,
-            ControlOperation::Spatial(SpatialOp::QuerySpatialNeighborhood { .. })
-        ));
+        assert!(matches!(op, ControlOperation::QuerySpatialNeighborhood(..)));
     }
 
     #[test]
     fn test_tool_to_operation_check_overlaps_single() {
-        let op = tool_to_operation("check_overlaps", &serde_json::json!({"name": "A"})).unwrap();
-        assert!(matches!(
-            op,
-            ControlOperation::Spatial(SpatialOp::CheckOverlaps { .. })
-        ));
+        let op = tool_to_operation("check_overlaps", &serde_json::json!({"entity": "A"})).unwrap();
+        assert!(matches!(op, ControlOperation::CheckOverlaps(..)));
     }
 
     #[test]
     fn test_tool_to_operation_check_overlaps_all() {
         let op = tool_to_operation("check_overlaps", &serde_json::json!({})).unwrap();
-        assert!(matches!(
-            op,
-            ControlOperation::Spatial(SpatialOp::CheckAllOverlaps { .. })
-        ));
+        assert!(matches!(op, ControlOperation::CheckAllOverlaps(..)));
     }
 
     #[test]
@@ -2205,59 +1544,44 @@ mod tests {
     #[test]
     fn test_tool_to_operation_get_time_status() {
         let op = tool_to_operation("get_time_status", &serde_json::Value::Null).unwrap();
-        assert!(matches!(op, ControlOperation::Time(TimeOp::GetTimeStatus)));
+        assert!(matches!(op, ControlOperation::GetTimeStatus));
     }
 
     #[test]
     fn test_tool_to_operation_get_performance() {
         let op = tool_to_operation("get_performance", &serde_json::Value::Null).unwrap();
-        assert!(matches!(
-            op,
-            ControlOperation::Other(OtherOp::GetPerformance)
-        ));
+        assert!(matches!(op, ControlOperation::GetPerformance));
     }
 
     #[test]
     fn test_tool_to_operation_get_scene_summary() {
         let op = tool_to_operation("get_scene_summary", &serde_json::Value::Null).unwrap();
-        assert!(matches!(op, ControlOperation::Scene(SceneOp::SceneSummary)));
+        assert!(matches!(op, ControlOperation::GetSceneSummary));
     }
 
     #[test]
     fn test_tool_to_operation_get_registry() {
         let op = tool_to_operation("get_registry", &serde_json::Value::Null).unwrap();
-        assert!(matches!(
-            op,
-            ControlOperation::Scene(SceneOp::DebugRegistry)
-        ));
+        assert!(matches!(op, ControlOperation::GetRegistry));
     }
 
     #[test]
     fn test_tool_to_operation_get_reload_status() {
         let op = tool_to_operation("get_reload_status", &serde_json::Value::Null).unwrap();
-        assert!(matches!(
-            op,
-            ControlOperation::Reload(ReloadOp::GetReloadStatus)
-        ));
+        assert!(matches!(op, ControlOperation::GetReloadStatus));
     }
 
     #[test]
     fn test_tool_to_operation_get_last_error() {
         let op = tool_to_operation("get_last_error", &serde_json::Value::Null).unwrap();
-        assert!(matches!(
-            op,
-            ControlOperation::Reload(ReloadOp::GetLastError)
-        ));
+        assert!(matches!(op, ControlOperation::GetLastError));
     }
 
     #[test]
     fn test_tool_to_operation_get_bounding_box() {
         let op =
-            tool_to_operation("get_bounding_box", &serde_json::json!({"name": "Box"})).unwrap();
-        assert!(matches!(
-            op,
-            ControlOperation::Scene(SceneOp::GetBoundingBox { .. })
-        ));
+            tool_to_operation("get_bounding_box", &serde_json::json!({"entity": "Box"})).unwrap();
+        assert!(matches!(op, ControlOperation::GetBoundingBox { .. }));
     }
 
     #[test]
@@ -2267,33 +1591,24 @@ mod tests {
             &serde_json::json!({"components": {"Transform": {}}}),
         )
         .unwrap();
-        assert!(matches!(
-            op,
-            ControlOperation::Mutate(MutateOp::SpawnEntity { .. })
-        ));
+        assert!(matches!(op, ControlOperation::SpawnEntity { .. }));
     }
 
     #[test]
     fn test_tool_to_operation_despawn_entity() {
-        let op =
-            tool_to_operation("despawn_entity", &serde_json::json!({"name": "MyEntity"})).unwrap();
-        assert!(matches!(
-            op,
-            ControlOperation::Mutate(MutateOp::DespawnEntity { .. })
-        ));
+        let op = tool_to_operation("despawn_entity", &serde_json::json!({"entity": "MyEntity"}))
+            .unwrap();
+        assert!(matches!(op, ControlOperation::DespawnEntity { .. }));
     }
 
     #[test]
     fn test_tool_to_operation_remove_component() {
         let op = tool_to_operation(
             "remove_component",
-            &serde_json::json!({"name": "E", "component": "Marker"}),
+            &serde_json::json!({"entity": "E", "component": "Marker"}),
         )
         .unwrap();
-        assert!(matches!(
-            op,
-            ControlOperation::Mutate(MutateOp::RemoveComponent { .. })
-        ));
+        assert!(matches!(op, ControlOperation::RemoveComponent(..)));
     }
 
     #[test]
@@ -2303,10 +1618,7 @@ mod tests {
             &serde_json::json!({"resource_type": "GameSettings", "value": {}}),
         )
         .unwrap();
-        assert!(matches!(
-            op,
-            ControlOperation::Mutate(MutateOp::InsertResource { .. })
-        ));
+        assert!(matches!(op, ControlOperation::SetResource(..)));
     }
 
     #[test]
@@ -2316,19 +1628,13 @@ mod tests {
             &serde_json::json!({"resource_type": "GameSettings"}),
         )
         .unwrap();
-        assert!(matches!(
-            op,
-            ControlOperation::Mutate(MutateOp::RemoveResource { .. })
-        ));
+        assert!(matches!(op, ControlOperation::RemoveResource { .. }));
     }
 
     #[test]
     fn test_tool_to_operation_run_code() {
         let op = tool_to_operation("run_code", &serde_json::json!({"code": "print(1)"})).unwrap();
-        assert!(matches!(
-            op,
-            ControlOperation::Other(OtherOp::ExecutePython { .. })
-        ));
+        assert!(matches!(op, ControlOperation::RunCode { .. }));
     }
 
     #[test]
@@ -2338,22 +1644,16 @@ mod tests {
             &serde_json::json!({"operations": [{"type": "spawn"}]}),
         )
         .unwrap();
-        assert!(matches!(
-            op,
-            ControlOperation::Mutate(MutateOp::BatchMutate { .. })
-        ));
+        assert!(matches!(op, ControlOperation::Batch { .. }));
     }
 
     #[test]
     fn test_tool_to_operation_set_asset() {
         let op = tool_to_operation(
             "set_asset",
-            &serde_json::json!({"name": "E", "component": "MeshMaterial3d", "asset_type": "StandardMaterial", "fields": {}}),
+            &serde_json::json!({"entity": "E", "component": "MeshMaterial3d", "asset_type": "StandardMaterial", "fields": {}}),
         ).unwrap();
-        assert!(matches!(
-            op,
-            ControlOperation::Other(OtherOp::MutateAsset { .. })
-        ));
+        assert!(matches!(op, ControlOperation::SetAsset(..)));
     }
 
     #[test]
@@ -2363,10 +1663,7 @@ mod tests {
             &serde_json::json!({"total_frames": 120, "capture_count": 6}),
         )
         .unwrap();
-        assert!(matches!(
-            op,
-            ControlOperation::Visual(VisualOp::CaptureTimeline { .. })
-        ));
+        assert!(matches!(op, ControlOperation::CaptureTimeline(..)));
     }
 
     #[test]
@@ -2376,10 +1673,7 @@ mod tests {
             &serde_json::json!({"view_count": 8, "distance": 15.0}),
         )
         .unwrap();
-        assert!(matches!(
-            op,
-            ControlOperation::Visual(VisualOp::CaptureTurnaround { .. })
-        ));
+        assert!(matches!(op, ControlOperation::CaptureTurnaround(..)));
     }
 
     #[test]
@@ -2389,18 +1683,19 @@ mod tests {
             &serde_json::json!({"grid_density": 4, "include_rgb": false}),
         )
         .unwrap();
-        assert!(matches!(
-            op,
-            ControlOperation::Visual(VisualOp::CaptureDepth { .. })
-        ));
+        assert!(matches!(op, ControlOperation::CaptureDepth(..)));
     }
 
     #[test]
     fn test_tool_to_operation_reload() {
         let op = tool_to_operation("reload", &serde_json::json!({"mode": "partial"})).unwrap();
-        assert!(
-            matches!(op, ControlOperation::Reload(ReloadOp::TriggerReload { mode, .. }) if mode == "partial")
-        );
+        assert!(matches!(
+            op,
+            ControlOperation::Reload(ReloadParams {
+                mode: ReloadMode::Partial,
+                ..
+            })
+        ));
     }
 
     #[test]
@@ -2410,10 +1705,7 @@ mod tests {
             &serde_json::json!({"mode": "full", "delay_frames": 10}),
         )
         .unwrap();
-        assert!(matches!(
-            op,
-            ControlOperation::Reload(ReloadOp::ReloadAndCapture { .. })
-        ));
+        assert!(matches!(op, ControlOperation::ReloadAndCapture(..)));
     }
 
     #[test]
@@ -2423,10 +1715,7 @@ mod tests {
             &serde_json::json!({"name": "Transform"}),
         )
         .unwrap();
-        assert!(matches!(
-            op,
-            ControlOperation::Scene(SceneOp::GetComponentSchema { .. })
-        ));
+        assert!(matches!(op, ControlOperation::GetComponentSchema { .. }));
     }
 
     #[test]
@@ -2437,7 +1726,7 @@ mod tests {
 
     #[test]
     fn test_tool_to_operation_get_component_missing_component() {
-        let result = tool_to_operation("get_component", &serde_json::json!({"name": "E"}));
+        let result = tool_to_operation("get_component", &serde_json::json!({"entity": "E"}));
         assert!(result.is_err());
     }
 
@@ -2454,22 +1743,19 @@ mod tests {
             &serde_json::json!({"gizmos": true, "max_width": 1024}),
         )
         .unwrap();
-        assert!(matches!(
-            op,
-            ControlOperation::Visual(VisualOp::CaptureWithGizmos { .. })
-        ));
+        assert!(matches!(op, ControlOperation::CaptureWithGizmos(..)));
     }
 
     #[test]
     fn test_tool_to_operation_entity_ref_by_id() {
         let op = tool_to_operation(
             "get_component",
-            &serde_json::json!({"entity_id": 42, "component": "Transform"}),
+            &serde_json::json!({"entity": 42, "component": "Transform"}),
         )
         .unwrap();
         assert!(matches!(
             op,
-            ControlOperation::Scene(SceneOp::GetComponent {
+            ControlOperation::GetComponent(GetComponentParams {
                 entity: EntityRef::Id(42),
                 ..
             })
@@ -2483,10 +1769,7 @@ mod tests {
             &serde_json::json!({"with": ["Transform", "Velocity"], "without": ["Marker"]}),
         )
         .unwrap();
-        assert!(matches!(
-            op,
-            ControlOperation::Scene(SceneOp::QueryEntities { .. })
-        ));
+        assert!(matches!(op, ControlOperation::QueryEntities(..)));
     }
 
     #[test]
@@ -2689,7 +1972,7 @@ mod tests {
     fn test_schedule_request_deserialization_defaults() {
         let json = r#"{"actions": [{"tool": "pause_time"}]}"#;
         let req: ScheduleRequest = serde_json::from_str(json).unwrap();
-        assert_eq!(req.mode, "sync");
+        assert_eq!(req.mode, ScheduleMode::Sync);
         assert_eq!(req.stop_on_error, false);
         assert_eq!(req.actions.len(), 1);
     }
@@ -2739,7 +2022,7 @@ mod tests {
                 label: None,
                 skip_if_error: None,
             }],
-            mode: "sync".to_string(),
+            mode: ScheduleMode::Sync,
             stop_on_error: true,
         };
         let schedule = ActiveSchedule::new_sync("s-test".to_string(), req, 10.0, tx);
@@ -2762,7 +2045,7 @@ mod tests {
                 label: None,
                 skip_if_error: None,
             }],
-            mode: "async".to_string(),
+            mode: ScheduleMode::Async,
             stop_on_error: false,
         };
         let schedule = ActiveSchedule::new_async("s-async".to_string(), req, 0.0, shared);
@@ -2793,7 +2076,7 @@ mod tests {
                     skip_if_error: None,
                 },
             ],
-            mode: "sync".to_string(),
+            mode: ScheduleMode::Sync,
             stop_on_error: false,
         };
         let err = validate_schedule(&req).unwrap_err();
@@ -2811,7 +2094,7 @@ mod tests {
                 label: None,
                 skip_if_error: None,
             }],
-            mode: "async".to_string(),
+            mode: ScheduleMode::Async,
             stop_on_error: false,
         };
         assert!(validate_schedule(&req).is_ok());

--- a/crates/pybevy_control/src/handlers/spatial.rs
+++ b/crates/pybevy_control/src/handlers/spatial.rs
@@ -5,7 +5,10 @@ use bevy::{
 };
 
 use super::pyo3::scene::resolve_entity;
-use crate::bridge::{ControlError, EntityRef};
+use crate::bridge::{
+    CheckAllOverlapsParams, CheckOverlapsParams, ControlError, QuerySpatialNeighborhoodParams,
+    QuerySpatialParams,
+};
 
 /// Round an f32 to 6 decimal places for cleaner JSON output.
 pub fn round6(v: f32) -> f32 {
@@ -254,9 +257,9 @@ pub fn entity_label(world: &World, entity: Entity) -> String {
 /// Pairwise spatial query: distance, direction, AABB overlap between two entities.
 pub fn query_spatial(
     world: &mut World,
-    entity_a: EntityRef,
-    entity_b: EntityRef,
+    params: QuerySpatialParams,
 ) -> Result<serde_json::Value, ControlError> {
+    let QuerySpatialParams { entity_a, entity_b } = params;
     let ea = resolve_entity(world, &entity_a)?;
     let eb = resolve_entity(world, &entity_b)?;
 
@@ -316,10 +319,13 @@ pub fn query_spatial(
 /// Neighborhood query: find entities within radius of a center entity.
 pub fn query_spatial_neighborhood(
     world: &mut World,
-    entity_ref: EntityRef,
-    radius: f32,
-    max_results: Option<usize>,
+    params: QuerySpatialNeighborhoodParams,
 ) -> Result<serde_json::Value, ControlError> {
+    let QuerySpatialNeighborhoodParams {
+        entity: entity_ref,
+        radius,
+        max_results,
+    } = params;
     let center_entity = resolve_entity(world, &entity_ref)?;
 
     // Verify the entity actually has a Transform (not just a stale GlobalTransform)
@@ -381,11 +387,14 @@ pub fn query_spatial_neighborhood(
 /// Check overlaps for a single entity against all others.
 pub fn check_overlaps(
     world: &mut World,
-    entity_ref: EntityRef,
-    include_siblings: bool,
-    max_float_gap: f32,
-    ground_y: Option<f32>,
+    params: CheckOverlapsParams,
 ) -> Result<serde_json::Value, ControlError> {
+    let CheckOverlapsParams {
+        entity: entity_ref,
+        include_siblings,
+        max_float_gap,
+        ground_y,
+    } = params;
     let target = resolve_entity(world, &entity_ref)?;
     let target_aabb = compute_world_aabb(world, target)?;
 
@@ -491,12 +500,15 @@ pub fn check_overlaps(
 /// Scene-wide overlap detection using sweep-and-prune on Y axis.
 pub fn check_all_overlaps(
     world: &mut World,
-    min_penetration: Option<f32>,
-    max_results: Option<usize>,
-    max_float_gap: f32,
-    ground_y: Option<f32>,
-    include_siblings: bool,
+    params: CheckAllOverlapsParams,
 ) -> Result<serde_json::Value, ControlError> {
+    let CheckAllOverlapsParams {
+        min_penetration,
+        max_results,
+        max_float_gap,
+        ground_y,
+        include_siblings,
+    } = params;
     let min_pen = min_penetration.unwrap_or(0.001);
     let max_res = max_results.unwrap_or(100);
 
@@ -614,7 +626,7 @@ mod tests {
     use bevy::{camera::primitives::Aabb, ecs::entity::Entity, math::Vec3A};
 
     use super::*;
-    use crate::bridge::ErrorCode;
+    use crate::bridge::{EntityRef, ErrorCode};
 
     fn make_aabb(entity_bits: u64, min: [f32; 3], max: [f32; 3]) -> WorldAabb {
         WorldAabb {
@@ -792,8 +804,10 @@ mod tests {
 
         let result = super::query_spatial(
             &mut world,
-            EntityRef::Id(ea.to_bits()),
-            EntityRef::Id(eb.to_bits()),
+            QuerySpatialParams {
+                entity_a: EntityRef::Id(ea.to_bits()),
+                entity_b: EntityRef::Id(eb.to_bits()),
+            },
         )
         .unwrap();
 
@@ -824,9 +838,15 @@ mod tests {
             GlobalTransform::from(Transform::from_xyz(100.0, 0.0, 0.0)),
         ));
 
-        let result =
-            query_spatial_neighborhood(&mut world, EntityRef::Id(center.to_bits()), 5.0, None)
-                .unwrap();
+        let result = query_spatial_neighborhood(
+            &mut world,
+            QuerySpatialNeighborhoodParams {
+                entity: EntityRef::Id(center.to_bits()),
+                radius: 5.0,
+                max_results: None,
+            },
+        )
+        .unwrap();
 
         assert_eq!(result["count"], 1);
         let neighbors = result["neighbors"].as_array().unwrap();
@@ -854,9 +874,15 @@ mod tests {
             GlobalTransform::from(Transform::from_xyz(1.0, 0.0, 0.0)),
         ));
 
-        let result =
-            query_spatial_neighborhood(&mut world, EntityRef::Id(center.to_bits()), 10.0, None)
-                .unwrap();
+        let result = query_spatial_neighborhood(
+            &mut world,
+            QuerySpatialNeighborhoodParams {
+                entity: EntityRef::Id(center.to_bits()),
+                radius: 10.0,
+                max_results: None,
+            },
+        )
+        .unwrap();
 
         let neighbors = result["neighbors"].as_array().unwrap();
         assert_eq!(neighbors.len(), 2);
@@ -954,8 +980,16 @@ mod tests {
             GlobalTransform::from(Transform::from_xyz(10.0, 0.0, 0.0)),
         ));
 
-        let result =
-            check_overlaps(&mut world, EntityRef::Id(ea.to_bits()), true, 0.1, None).unwrap();
+        let result = check_overlaps(
+            &mut world,
+            CheckOverlapsParams {
+                entity: EntityRef::Id(ea.to_bits()),
+                include_siblings: true,
+                max_float_gap: 0.1,
+                ground_y: None,
+            },
+        )
+        .unwrap();
 
         assert_eq!(result["overlap_count"], 0);
     }
@@ -974,8 +1008,16 @@ mod tests {
             GlobalTransform::from(Transform::from_xyz(1.0, 0.0, 0.0)),
         ));
 
-        let result =
-            check_overlaps(&mut world, EntityRef::Id(ea.to_bits()), true, 0.1, None).unwrap();
+        let result = check_overlaps(
+            &mut world,
+            CheckOverlapsParams {
+                entity: EntityRef::Id(ea.to_bits()),
+                include_siblings: true,
+                max_float_gap: 0.1,
+                ground_y: None,
+            },
+        )
+        .unwrap();
 
         assert!(result["overlap_count"].as_u64().unwrap() > 0);
         let overlaps = result["overlaps"].as_array().unwrap();
@@ -1030,13 +1072,15 @@ mod tests {
         world.entity_mut(branch1).add_children(&[mesh_a]);
         world.entity_mut(branch2).add_children(&[mesh_b]);
 
-        // include_siblings=true → should report the overlap
+        // include_siblings=true -> should report the overlap
         let result_with = check_overlaps(
             &mut world,
-            EntityRef::Name("overlap_a_mesh".into()),
-            true,
-            0.1,
-            None,
+            CheckOverlapsParams {
+                entity: EntityRef::Name("overlap_a_mesh".into()),
+                include_siblings: true,
+                max_float_gap: 0.1,
+                ground_y: None,
+            },
         )
         .unwrap();
         assert!(
@@ -1044,13 +1088,15 @@ mod tests {
             "Expected overlap with include_siblings=true"
         );
 
-        // include_siblings=false → should filter (same root ancestor)
+        // include_siblings=false -> should filter (same root ancestor)
         let result_without = check_overlaps(
             &mut world,
-            EntityRef::Name("overlap_a_mesh".into()),
-            false,
-            0.1,
-            None,
+            CheckOverlapsParams {
+                entity: EntityRef::Name("overlap_a_mesh".into()),
+                include_siblings: false,
+                max_float_gap: 0.1,
+                ground_y: None,
+            },
         )
         .unwrap();
         assert_eq!(
@@ -1072,10 +1118,12 @@ mod tests {
 
         let result = check_overlaps(
             &mut world,
-            EntityRef::Id(floating.to_bits()),
-            true,
-            0.1,
-            None,
+            CheckOverlapsParams {
+                entity: EntityRef::Id(floating.to_bits()),
+                include_siblings: true,
+                max_float_gap: 0.1,
+                ground_y: None,
+            },
         )
         .unwrap();
 
@@ -1099,8 +1147,16 @@ mod tests {
             ))
             .id();
 
-        let result =
-            check_overlaps(&mut world, EntityRef::Id(entity.to_bits()), true, 0.1, None).unwrap();
+        let result = check_overlaps(
+            &mut world,
+            CheckOverlapsParams {
+                entity: EntityRef::Id(entity.to_bits()),
+                include_siblings: true,
+                max_float_gap: 0.1,
+                ground_y: None,
+            },
+        )
+        .unwrap();
 
         assert_eq!(result["grounded"], true);
     }
@@ -1109,7 +1165,17 @@ mod tests {
     fn check_all_overlaps_empty_world() {
         let mut world = World::new();
 
-        let result = super::check_all_overlaps(&mut world, None, None, 0.1, None, false).unwrap();
+        let result = super::check_all_overlaps(
+            &mut world,
+            CheckAllOverlapsParams {
+                min_penetration: None,
+                max_results: None,
+                max_float_gap: 0.1,
+                ground_y: None,
+                include_siblings: false,
+            },
+        )
+        .unwrap();
 
         assert_eq!(result["total_entities_with_aabb"], 0);
         assert_eq!(result["overlap_count"], 0);
@@ -1127,7 +1193,17 @@ mod tests {
             GlobalTransform::from(Transform::from_xyz(10.0, 0.0, 0.0)),
         ));
 
-        let result = super::check_all_overlaps(&mut world, None, None, 0.1, None, false).unwrap();
+        let result = super::check_all_overlaps(
+            &mut world,
+            CheckAllOverlapsParams {
+                min_penetration: None,
+                max_results: None,
+                max_float_gap: 0.1,
+                ground_y: None,
+                include_siblings: false,
+            },
+        )
+        .unwrap();
 
         assert_eq!(result["overlap_count"], 0);
     }
@@ -1144,7 +1220,17 @@ mod tests {
             GlobalTransform::from(Transform::from_xyz(1.0, 0.0, 0.0)),
         ));
 
-        let result = super::check_all_overlaps(&mut world, None, None, 0.1, None, false).unwrap();
+        let result = super::check_all_overlaps(
+            &mut world,
+            CheckAllOverlapsParams {
+                min_penetration: None,
+                max_results: None,
+                max_float_gap: 0.1,
+                ground_y: None,
+                include_siblings: false,
+            },
+        )
+        .unwrap();
 
         assert!(result["overlap_count"].as_u64().unwrap() > 0);
     }
@@ -1158,7 +1244,17 @@ mod tests {
             GlobalTransform::from(Transform::from_xyz(0.0, 50.0, 0.0)),
         ));
 
-        let result = super::check_all_overlaps(&mut world, None, None, 0.1, None, false).unwrap();
+        let result = super::check_all_overlaps(
+            &mut world,
+            CheckAllOverlapsParams {
+                min_penetration: None,
+                max_results: None,
+                max_float_gap: 0.1,
+                ground_y: None,
+                include_siblings: false,
+            },
+        )
+        .unwrap();
 
         assert!(result["floating_count"].as_u64().unwrap() > 0);
     }
@@ -1174,8 +1270,17 @@ mod tests {
             ));
         }
 
-        let result =
-            super::check_all_overlaps(&mut world, None, Some(1), 0.1, None, false).unwrap();
+        let result = super::check_all_overlaps(
+            &mut world,
+            CheckAllOverlapsParams {
+                min_penetration: None,
+                max_results: Some(1),
+                max_float_gap: 0.1,
+                ground_y: None,
+                include_siblings: false,
+            },
+        )
+        .unwrap();
 
         let overlaps = result["overlaps"].as_array().unwrap();
         assert!(overlaps.len() <= 1);
@@ -1212,9 +1317,15 @@ mod tests {
             ));
         }
 
-        let result =
-            query_spatial_neighborhood(&mut world, EntityRef::Id(center.to_bits()), 10.0, Some(2))
-                .unwrap();
+        let result = query_spatial_neighborhood(
+            &mut world,
+            QuerySpatialNeighborhoodParams {
+                entity: EntityRef::Id(center.to_bits()),
+                radius: 10.0,
+                max_results: Some(2),
+            },
+        )
+        .unwrap();
 
         assert_eq!(result["count"], 2);
         assert_eq!(result["truncated"], true);
@@ -1231,8 +1342,14 @@ mod tests {
             ))
             .id();
 
-        let result =
-            query_spatial_neighborhood(&mut world, EntityRef::Id(entity.to_bits()), 5.0, None);
+        let result = query_spatial_neighborhood(
+            &mut world,
+            QuerySpatialNeighborhoodParams {
+                entity: EntityRef::Id(entity.to_bits()),
+                radius: 5.0,
+                max_results: None,
+            },
+        );
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(
@@ -1253,9 +1370,15 @@ mod tests {
             ))
             .id();
 
-        let result =
-            query_spatial_neighborhood(&mut world, EntityRef::Id(center.to_bits()), 5.0, None)
-                .unwrap();
+        let result = query_spatial_neighborhood(
+            &mut world,
+            QuerySpatialNeighborhoodParams {
+                entity: EntityRef::Id(center.to_bits()),
+                radius: 5.0,
+                max_results: None,
+            },
+        )
+        .unwrap();
 
         assert_eq!(result["count"], 0);
     }
@@ -1393,10 +1516,12 @@ mod tests {
 
         let result = check_overlaps(
             &mut world,
-            EntityRef::Id(entity.to_bits()),
-            true,
-            0.1,
-            Some(0.0),
+            CheckOverlapsParams {
+                entity: EntityRef::Id(entity.to_bits()),
+                include_siblings: true,
+                max_float_gap: 0.1,
+                ground_y: Some(0.0),
+            },
         )
         .unwrap();
 
@@ -1415,8 +1540,16 @@ mod tests {
             ))
             .id();
 
-        let result =
-            check_overlaps(&mut world, EntityRef::Id(entity.to_bits()), true, 0.1, None).unwrap();
+        let result = check_overlaps(
+            &mut world,
+            CheckOverlapsParams {
+                entity: EntityRef::Id(entity.to_bits()),
+                include_siblings: true,
+                max_float_gap: 0.1,
+                ground_y: None,
+            },
+        )
+        .unwrap();
 
         assert!(result.get("sunken").is_none());
     }
@@ -1430,8 +1563,17 @@ mod tests {
             GlobalTransform::default(),
         ));
 
-        let result =
-            super::check_all_overlaps(&mut world, None, None, 0.1, Some(0.0), false).unwrap();
+        let result = super::check_all_overlaps(
+            &mut world,
+            CheckAllOverlapsParams {
+                min_penetration: None,
+                max_results: None,
+                max_float_gap: 0.1,
+                ground_y: Some(0.0),
+                include_siblings: false,
+            },
+        )
+        .unwrap();
 
         assert_eq!(result["sunken_count"], 1);
         let sunken = result["sunken_entities"].as_array().unwrap();
@@ -1447,8 +1589,17 @@ mod tests {
             GlobalTransform::default(),
         ));
 
-        let result =
-            super::check_all_overlaps(&mut world, None, None, 0.1, Some(0.0), false).unwrap();
+        let result = super::check_all_overlaps(
+            &mut world,
+            CheckAllOverlapsParams {
+                min_penetration: None,
+                max_results: None,
+                max_float_gap: 0.1,
+                ground_y: Some(0.0),
+                include_siblings: false,
+            },
+        )
+        .unwrap();
 
         assert_eq!(result["sunken_count"], 0);
     }
@@ -1461,7 +1612,17 @@ mod tests {
             GlobalTransform::default(),
         ));
 
-        let result = super::check_all_overlaps(&mut world, None, None, 0.1, None, false).unwrap();
+        let result = super::check_all_overlaps(
+            &mut world,
+            CheckAllOverlapsParams {
+                min_penetration: None,
+                max_results: None,
+                max_float_gap: 0.1,
+                ground_y: None,
+                include_siblings: false,
+            },
+        )
+        .unwrap();
 
         assert!(result.get("sunken_count").is_none());
         assert!(result.get("sunken_entities").is_none());
@@ -1514,16 +1675,34 @@ mod tests {
         world.entity_mut(bone2).add_children(&[mesh2]);
 
         // With include_siblings=true, overlaps should be reported
-        let result_with =
-            super::check_all_overlaps(&mut world, None, None, 0.1, None, true).unwrap();
+        let result_with = super::check_all_overlaps(
+            &mut world,
+            CheckAllOverlapsParams {
+                min_penetration: None,
+                max_results: None,
+                max_float_gap: 0.1,
+                ground_y: None,
+                include_siblings: true,
+            },
+        )
+        .unwrap();
         assert!(
             result_with["overlap_count"].as_u64().unwrap() > 0,
             "Expected overlaps with include_siblings=true"
         );
 
         // With include_siblings=false, sibling overlaps should be filtered
-        let result_without =
-            super::check_all_overlaps(&mut world, None, None, 0.1, None, false).unwrap();
+        let result_without = super::check_all_overlaps(
+            &mut world,
+            CheckAllOverlapsParams {
+                min_penetration: None,
+                max_results: None,
+                max_float_gap: 0.1,
+                ground_y: None,
+                include_siblings: false,
+            },
+        )
+        .unwrap();
         assert_eq!(
             result_without["overlap_count"].as_u64().unwrap(),
             0,
@@ -1580,8 +1759,18 @@ mod tests {
         world.entity_mut(root_a).add_children(&[child_a]);
         world.entity_mut(root_b).add_children(&[child_b]);
 
-        // Different roots → overlap should still be reported even with include_siblings=false
-        let result = super::check_all_overlaps(&mut world, None, None, 0.1, None, false).unwrap();
+        // Different roots - overlap should still be reported even with include_siblings=false
+        let result = super::check_all_overlaps(
+            &mut world,
+            CheckAllOverlapsParams {
+                min_penetration: None,
+                max_results: None,
+                max_float_gap: 0.1,
+                ground_y: None,
+                include_siblings: false,
+            },
+        )
+        .unwrap();
         assert!(
             result["overlap_count"].as_u64().unwrap() > 0,
             "Overlaps between different root hierarchies should not be filtered"

--- a/crates/pybevy_control/src/handlers/time_control.rs
+++ b/crates/pybevy_control/src/handlers/time_control.rs
@@ -6,7 +6,7 @@ use bevy::{
     time::{Time, Virtual},
 };
 
-use crate::bridge::ControlError;
+use crate::bridge::{ControlError, SeekTimeParams};
 
 /// Propagate transforms through the full hierarchy after time manipulation.
 /// Updates GlobalTransform for root entities first, then recursively for children.
@@ -90,9 +90,9 @@ pub fn get_time_status(world: &mut World) -> Result<serde_json::Value, ControlEr
 
 pub fn seek_time(
     world: &mut World,
-    seconds: f64,
-    pause: bool,
+    params: SeekTimeParams,
 ) -> Result<serde_json::Value, ControlError> {
+    let SeekTimeParams { seconds, pause } = params;
     if seconds < 0.0 {
         return Err(ControlError::invalid_params("seconds must be >= 0"));
     }
@@ -176,7 +176,14 @@ mod tests {
     #[test]
     fn test_seek_time_forward() {
         let mut world = world_with_virtual_time();
-        let result = seek_time(&mut world, 5.0, false).unwrap();
+        let result = seek_time(
+            &mut world,
+            SeekTimeParams {
+                seconds: 5.0,
+                pause: false,
+            },
+        )
+        .unwrap();
         let elapsed = result["elapsed_secs"].as_f64().unwrap();
         assert!((elapsed - 5.0).abs() < 0.01);
         assert_eq!(result["paused"], false);
@@ -186,9 +193,23 @@ mod tests {
     fn test_seek_time_backward() {
         let mut world = world_with_virtual_time();
         // Seek forward first
-        seek_time(&mut world, 10.0, false).unwrap();
+        seek_time(
+            &mut world,
+            SeekTimeParams {
+                seconds: 10.0,
+                pause: false,
+            },
+        )
+        .unwrap();
         // Then seek backward
-        let result = seek_time(&mut world, 3.0, false).unwrap();
+        let result = seek_time(
+            &mut world,
+            SeekTimeParams {
+                seconds: 3.0,
+                pause: false,
+            },
+        )
+        .unwrap();
         let elapsed = result["elapsed_secs"].as_f64().unwrap();
         assert!((elapsed - 3.0).abs() < 0.01);
     }
@@ -196,7 +217,13 @@ mod tests {
     #[test]
     fn test_seek_time_negative_error() {
         let mut world = world_with_virtual_time();
-        let result = seek_time(&mut world, -1.0, false);
+        let result = seek_time(
+            &mut world,
+            SeekTimeParams {
+                seconds: -1.0,
+                pause: false,
+            },
+        );
         assert!(result.is_err());
         assert_eq!(result.unwrap_err().code, ErrorCode::InvalidParams);
     }
@@ -204,7 +231,14 @@ mod tests {
     #[test]
     fn test_seek_time_with_pause() {
         let mut world = world_with_virtual_time();
-        let result = seek_time(&mut world, 5.0, true).unwrap();
+        let result = seek_time(
+            &mut world,
+            SeekTimeParams {
+                seconds: 5.0,
+                pause: true,
+            },
+        )
+        .unwrap();
         assert_eq!(result["paused"], true);
     }
 
@@ -218,7 +252,14 @@ mod tests {
         ));
 
         // Seek should not panic and should sync transforms
-        let result = seek_time(&mut world, 2.0, false).unwrap();
+        let result = seek_time(
+            &mut world,
+            SeekTimeParams {
+                seconds: 2.0,
+                pause: false,
+            },
+        )
+        .unwrap();
         assert!(result["note"].as_str().is_some());
     }
 }

--- a/crates/pybevy_control/src/lib.rs
+++ b/crates/pybevy_control/src/lib.rs
@@ -7,14 +7,28 @@ pub mod runtime;
 pub mod runtime_pyo3;
 pub mod server;
 pub mod sse;
+pub mod tools;
 
 pub use handlers::pyo3::execute::register_world_wrapper_hook;
 pub use plugin::PyControlPlugin;
-use pyo3::prelude::*;
+use pyo3::{exceptions::PyRuntimeError, prelude::*};
+
+/// Return MCP tool definitions generated from ControlOperation's JSON schema.
+#[pyfunction]
+fn rust_tool_definitions(py: Python<'_>) -> PyResult<Py<PyAny>> {
+    let tools = tools::list_tools();
+    let json_str = serde_json::to_string(&tools)
+        .map_err(|e| PyRuntimeError::new_err(format!("Failed to serialize tools: {e}")))?;
+    // Parse JSON string into Python objects
+    let json_mod = py.import("json")?;
+    let result = json_mod.call_method1("loads", (json_str,))?;
+    Ok(result.into())
+}
 
 pub fn add_module(parent: &Bound<'_, PyModule>) -> PyResult<()> {
     let m = PyModule::new(parent.py(), "mcp")?;
     m.add_class::<PyControlPlugin>()?;
     m.add_class::<api_index::PyApiIndex>()?;
+    m.add_function(wrap_pyfunction!(rust_tool_definitions, &m)?)?;
     parent.add_submodule(&m)
 }

--- a/crates/pybevy_control/src/runtime.rs
+++ b/crates/pybevy_control/src/runtime.rs
@@ -1,7 +1,10 @@
 use bevy::ecs::world::World;
 use serde_json::Value;
 
-use crate::bridge::{ControlError, ControlRequest, EntityRef};
+use crate::bridge::{
+    ControlError, ControlRequest, EntityRef, GetComponentParams, QueryEntitiesParams,
+    RemoveComponentParams, SetAssetParams, SetComponentParams, SetResourceParams,
+};
 
 /// Trait for runtime-specific operations in the control server.
 ///
@@ -24,8 +27,7 @@ pub trait ControlRuntime: 'static {
     fn query_entities(
         &mut self,
         world: &mut World,
-        with: Vec<String>,
-        without: Vec<String>,
+        params: QueryEntitiesParams,
     ) -> Result<Value, ControlError>;
 
     fn get_component_schema(
@@ -37,8 +39,7 @@ pub trait ControlRuntime: 'static {
     fn get_component(
         &mut self,
         world: &mut World,
-        entity: EntityRef,
-        component: String,
+        params: GetComponentParams,
     ) -> Result<Value, ControlError>;
 
     fn scene_summary(&mut self, world: &mut World) -> Result<Value, ControlError>;
@@ -57,23 +58,19 @@ pub trait ControlRuntime: 'static {
     fn set_component(
         &mut self,
         world: &mut World,
-        entity: EntityRef,
-        component: String,
-        fields: Value,
+        params: SetComponentParams,
     ) -> Result<Value, ControlError>;
 
     fn remove_component(
         &mut self,
         world: &mut World,
-        entity: EntityRef,
-        component: String,
+        params: RemoveComponentParams,
     ) -> Result<Value, ControlError>;
 
     fn insert_resource(
         &mut self,
         world: &mut World,
-        resource_type: String,
-        value: Value,
+        params: SetResourceParams,
     ) -> Result<Value, ControlError>;
 
     fn remove_resource(
@@ -91,9 +88,6 @@ pub trait ControlRuntime: 'static {
     fn mutate_asset(
         &mut self,
         world: &mut World,
-        entity: EntityRef,
-        component: String,
-        asset_type: String,
-        fields: Value,
+        params: SetAssetParams,
     ) -> Result<Value, ControlError>;
 }

--- a/crates/pybevy_control/src/runtime_pyo3.rs
+++ b/crates/pybevy_control/src/runtime_pyo3.rs
@@ -3,7 +3,10 @@ use pyo3::Python;
 use serde_json::Value;
 
 use crate::{
-    bridge::{ControlError, ControlRequest, EntityRef},
+    bridge::{
+        ControlError, ControlRequest, EntityRef, GetComponentParams, QueryEntitiesParams,
+        RemoveComponentParams, SetAssetParams, SetComponentParams, SetResourceParams,
+    },
     handlers,
     runtime::ControlRuntime,
 };
@@ -60,10 +63,9 @@ impl ControlRuntime for Pyo3ControlRuntime {
     fn query_entities(
         &mut self,
         world: &mut World,
-        with: Vec<String>,
-        without: Vec<String>,
+        params: QueryEntitiesParams,
     ) -> Result<Value, ControlError> {
-        handlers::pyo3::scene::query_entities(world, with, without)
+        handlers::pyo3::scene::query_entities(world, params.with, params.without)
     }
 
     fn get_component_schema(
@@ -77,10 +79,9 @@ impl ControlRuntime for Pyo3ControlRuntime {
     fn get_component(
         &mut self,
         world: &mut World,
-        entity: EntityRef,
-        component: String,
+        params: GetComponentParams,
     ) -> Result<Value, ControlError> {
-        handlers::pyo3::scene::get_component(world, entity, component)
+        handlers::pyo3::scene::get_component(world, params.entity, params.component)
     }
 
     fn scene_summary(&mut self, world: &mut World) -> Result<Value, ControlError> {
@@ -110,29 +111,25 @@ impl ControlRuntime for Pyo3ControlRuntime {
     fn set_component(
         &mut self,
         world: &mut World,
-        entity: EntityRef,
-        component: String,
-        fields: Value,
+        params: SetComponentParams,
     ) -> Result<Value, ControlError> {
-        handlers::pyo3::mutate::set_component(world, entity, component, fields)
+        handlers::pyo3::mutate::set_component(world, params.entity, params.component, params.fields)
     }
 
     fn remove_component(
         &mut self,
         world: &mut World,
-        entity: EntityRef,
-        component: String,
+        params: RemoveComponentParams,
     ) -> Result<Value, ControlError> {
-        handlers::pyo3::mutate::remove_component(world, entity, component)
+        handlers::pyo3::mutate::remove_component(world, params.entity, params.component)
     }
 
     fn insert_resource(
         &mut self,
         world: &mut World,
-        resource_type: String,
-        value: Value,
+        params: SetResourceParams,
     ) -> Result<Value, ControlError> {
-        handlers::pyo3::mutate::insert_resource(world, resource_type, value)
+        handlers::pyo3::mutate::insert_resource(world, params.resource_type, params.value)
     }
 
     fn remove_resource(
@@ -154,11 +151,14 @@ impl ControlRuntime for Pyo3ControlRuntime {
     fn mutate_asset(
         &mut self,
         world: &mut World,
-        entity: EntityRef,
-        component: String,
-        asset_type: String,
-        fields: Value,
+        params: SetAssetParams,
     ) -> Result<Value, ControlError> {
-        handlers::pyo3::asset::mutate_asset(world, entity, component, asset_type, fields)
+        handlers::pyo3::asset::mutate_asset(
+            world,
+            params.entity,
+            params.component,
+            params.asset_type,
+            params.fields,
+        )
     }
 }

--- a/crates/pybevy_control/src/server.rs
+++ b/crates/pybevy_control/src/server.rs
@@ -18,8 +18,16 @@ use tower_http::cors::CorsLayer;
 use crate::{
     api_index::ApiIndex,
     bridge::{
-        ControlOperation, ControlRequest, ControlSender, EntityRef, ErrorCode, MutateOp, OtherOp,
-        ReloadOp, SceneOp, SharedLatestError, SpatialOp, SseEventBroadcaster, TimeOp, VisualOp,
+        CaptureDepthParams, CaptureScreenshotParams, CaptureTimelineParams,
+        CaptureTurnaroundParams, CheckAllOverlapsParams, CheckOverlapsParams, ControlOperation,
+        ControlRequest, ControlSender, EntityRef, ErrorCode, GetComponentParams,
+        QueryEntitiesParams, QuerySpatialNeighborhoodParams, QuerySpatialParams,
+        ReloadAndCaptureParams, ReloadMode, ReloadParams, RemoveComponentParams, SeekTimeParams,
+        SetAssetParams, SetComponentParams, SetResourceParams, SharedLatestError,
+        SseEventBroadcaster,
+    },
+    handlers::schedule::{
+        ScheduleMode, ScheduleRequest, SharedScheduleRegistry, validate_schedule,
     },
 };
 
@@ -31,7 +39,7 @@ pub struct AppState {
     pub api_index: Arc<ApiIndex>,
     pub config: ServerConfig,
     pub latest_error: SharedLatestError,
-    pub schedule_registry: crate::handlers::schedule::SharedScheduleRegistry,
+    pub schedule_registry: SharedScheduleRegistry,
 }
 
 impl AppState {
@@ -41,7 +49,7 @@ impl AppState {
         api_index: Arc<ApiIndex>,
         config: ServerConfig,
         latest_error: SharedLatestError,
-        schedule_registry: crate::handlers::schedule::SharedScheduleRegistry,
+        schedule_registry: SharedScheduleRegistry,
     ) -> Self {
         Self {
             sender,
@@ -200,6 +208,7 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/v1/guides", get(guides_index))
         .route("/api/v1/guides/{name}", get(guides_get))
         .route("/api/v1/instructions", get(get_instructions))
+        .route("/api/v1/tools", get(list_tools))
         .layer(CorsLayer::permissive())
         .with_state(state)
 }
@@ -218,12 +227,7 @@ async fn handle_sse(
     Sse::new(stream).keep_alive(KeepAlive::default())
 }
 async fn list_entities(State(state): State<AppState>) -> impl IntoResponse {
-    match send_operation(
-        &state.sender,
-        ControlOperation::Scene(SceneOp::ListEntities),
-    )
-    .await
-    {
+    match send_operation(&state.sender, ControlOperation::ListEntities).await {
         Ok(v) => (StatusCode::OK, Json(v)),
         Err(e) => e,
     }
@@ -235,9 +239,9 @@ async fn get_entity(
 ) -> impl IntoResponse {
     match send_operation(
         &state.sender,
-        ControlOperation::Scene(SceneOp::GetEntity {
+        ControlOperation::GetEntity {
             entity: parse_entity_ref(&entity),
-        }),
+        },
     )
     .await
     {
@@ -260,9 +264,9 @@ async fn spawn_entity(
     }
     match send_operation(
         &state.sender,
-        ControlOperation::Mutate(MutateOp::SpawnEntity {
+        ControlOperation::SpawnEntity {
             components: body.components,
-        }),
+        },
     )
     .await
     {
@@ -280,9 +284,9 @@ async fn despawn_entity(
     }
     match send_operation(
         &state.sender,
-        ControlOperation::Mutate(MutateOp::DespawnEntity {
+        ControlOperation::DespawnEntity {
             entity: parse_entity_ref(&entity),
-        }),
+        },
     )
     .await
     {
@@ -297,7 +301,7 @@ async fn get_component(
 ) -> impl IntoResponse {
     match send_operation(
         &state.sender,
-        ControlOperation::Scene(SceneOp::GetComponent {
+        ControlOperation::GetComponent(GetComponentParams {
             entity: parse_entity_ref(&entity),
             component,
         }),
@@ -324,7 +328,7 @@ async fn set_component(
     }
     match send_operation(
         &state.sender,
-        ControlOperation::Mutate(MutateOp::SetComponent {
+        ControlOperation::SetComponent(SetComponentParams {
             entity: parse_entity_ref(&entity),
             component,
             fields: body.fields,
@@ -346,7 +350,7 @@ async fn remove_component(
     }
     match send_operation(
         &state.sender,
-        ControlOperation::Mutate(MutateOp::RemoveComponent {
+        ControlOperation::RemoveComponent(RemoveComponentParams {
             entity: parse_entity_ref(&entity),
             component,
         }),
@@ -364,9 +368,9 @@ async fn get_bounding_box(
 ) -> impl IntoResponse {
     match send_operation(
         &state.sender,
-        ControlOperation::Scene(SceneOp::GetBoundingBox {
+        ControlOperation::GetBoundingBox {
             entity: parse_entity_ref(&entity),
-        }),
+        },
     )
     .await
     {
@@ -388,7 +392,7 @@ async fn query_entities(
 ) -> impl IntoResponse {
     match send_operation(
         &state.sender,
-        ControlOperation::Scene(SceneOp::QueryEntities {
+        ControlOperation::QueryEntities(QueryEntitiesParams {
             with: body.with,
             without: body.without,
         }),
@@ -401,23 +405,13 @@ async fn query_entities(
 }
 
 async fn scene_summary(State(state): State<AppState>) -> impl IntoResponse {
-    match send_operation(
-        &state.sender,
-        ControlOperation::Scene(SceneOp::SceneSummary),
-    )
-    .await
-    {
+    match send_operation(&state.sender, ControlOperation::GetSceneSummary).await {
         Ok(v) => (StatusCode::OK, Json(v)),
         Err(e) => e,
     }
 }
 async fn list_resources(State(state): State<AppState>) -> impl IntoResponse {
-    match send_operation(
-        &state.sender,
-        ControlOperation::Scene(SceneOp::ListResources),
-    )
-    .await
-    {
+    match send_operation(&state.sender, ControlOperation::ListResources).await {
         Ok(v) => (StatusCode::OK, Json(v)),
         Err(e) => e,
     }
@@ -438,7 +432,7 @@ async fn insert_resource(
     }
     match send_operation(
         &state.sender,
-        ControlOperation::Mutate(MutateOp::InsertResource {
+        ControlOperation::SetResource(SetResourceParams {
             resource_type,
             value: body.value,
         }),
@@ -459,7 +453,7 @@ async fn remove_resource(
     }
     match send_operation(
         &state.sender,
-        ControlOperation::Mutate(MutateOp::RemoveResource { resource_type }),
+        ControlOperation::RemoveResource { resource_type },
     )
     .await
     {
@@ -468,7 +462,7 @@ async fn remove_resource(
     }
 }
 async fn list_systems(State(state): State<AppState>) -> impl IntoResponse {
-    match send_operation(&state.sender, ControlOperation::Scene(SceneOp::ListSystems)).await {
+    match send_operation(&state.sender, ControlOperation::ListSystems).await {
         Ok(v) => (StatusCode::OK, Json(v)),
         Err(e) => e,
     }
@@ -478,12 +472,7 @@ async fn get_component_schema(
     State(state): State<AppState>,
     Path(name): Path<String>,
 ) -> impl IntoResponse {
-    match send_operation(
-        &state.sender,
-        ControlOperation::Scene(SceneOp::GetComponentSchema { name }),
-    )
-    .await
-    {
+    match send_operation(&state.sender, ControlOperation::GetComponentSchema { name }).await {
         Ok(v) => (StatusCode::OK, Json(v)),
         Err(e) => e,
     }
@@ -512,7 +501,7 @@ async fn capture_screenshot(
     }
     match send_operation(
         &state.sender,
-        ControlOperation::Visual(VisualOp::CaptureScreenshot {
+        ControlOperation::CaptureScreenshot(CaptureScreenshotParams {
             delay_frames: body.delay_frames,
             max_width: body.max_width,
             position: body.position,
@@ -536,7 +525,7 @@ async fn capture_with_gizmos(
     }
     match send_operation(
         &state.sender,
-        ControlOperation::Visual(VisualOp::CaptureWithGizmos {
+        ControlOperation::CaptureWithGizmos(CaptureScreenshotParams {
             delay_frames: body.delay_frames,
             max_width: body.max_width,
             position: body.position,
@@ -583,7 +572,7 @@ async fn capture_timeline(
     }
     match send_operation(
         &state.sender,
-        ControlOperation::Visual(VisualOp::CaptureTimeline {
+        ControlOperation::CaptureTimeline(CaptureTimelineParams {
             total_frames: body.total_frames,
             capture_count: body.capture_count,
             max_width: body.max_width,
@@ -620,7 +609,7 @@ async fn capture_turnaround(
     }
     match send_operation(
         &state.sender,
-        ControlOperation::Visual(VisualOp::CaptureTurnaround {
+        ControlOperation::CaptureTurnaround(CaptureTurnaroundParams {
             look_at: body.look_at,
             distance: body.distance,
             elevation: body.elevation,
@@ -659,7 +648,7 @@ async fn capture_depth(
     }
     match send_operation(
         &state.sender,
-        ControlOperation::Visual(VisualOp::CaptureDepth {
+        ControlOperation::CaptureDepth(CaptureDepthParams {
             position: body.position,
             look_at: body.look_at,
             sample_points: body.sample_points,
@@ -678,15 +667,11 @@ async fn capture_depth(
 }
 #[derive(Deserialize)]
 struct ReloadBody {
-    #[serde(default = "default_reload_mode")]
-    mode: String,
+    #[serde(default)]
+    mode: ReloadMode,
     #[serde(default)]
     pause: bool,
     time_scale: Option<f32>,
-}
-
-fn default_reload_mode() -> String {
-    "full".to_string()
 }
 
 async fn trigger_reload(
@@ -695,7 +680,7 @@ async fn trigger_reload(
 ) -> impl IntoResponse {
     match send_operation(
         &state.sender,
-        ControlOperation::Reload(ReloadOp::TriggerReload {
+        ControlOperation::Reload(ReloadParams {
             mode: body.mode,
             pause: body.pause,
             time_scale: body.time_scale,
@@ -709,12 +694,7 @@ async fn trigger_reload(
 }
 
 async fn get_reload_status(State(state): State<AppState>) -> impl IntoResponse {
-    match send_operation(
-        &state.sender,
-        ControlOperation::Reload(ReloadOp::GetReloadStatus),
-    )
-    .await
-    {
+    match send_operation(&state.sender, ControlOperation::GetReloadStatus).await {
         Ok(v) => (StatusCode::OK, Json(v)),
         Err(e) => e,
     }
@@ -722,8 +702,8 @@ async fn get_reload_status(State(state): State<AppState>) -> impl IntoResponse {
 
 #[derive(Deserialize)]
 struct ReloadAndCaptureBody {
-    #[serde(default = "default_reload_mode")]
-    mode: String,
+    #[serde(default)]
+    mode: ReloadMode,
     #[serde(default)]
     pause: bool,
     time_scale: Option<f32>,
@@ -740,7 +720,7 @@ async fn reload_and_capture(
 ) -> impl IntoResponse {
     match send_operation(
         &state.sender,
-        ControlOperation::Reload(ReloadOp::ReloadAndCapture {
+        ControlOperation::ReloadAndCapture(ReloadAndCaptureParams {
             mode: body.mode,
             pause: body.pause,
             time_scale: body.time_scale,
@@ -769,32 +749,27 @@ async fn execute_python(
     if !state.config.execute_python_enabled {
         return error_response(StatusCode::FORBIDDEN, "Python execution disabled");
     }
-    match send_operation(
-        &state.sender,
-        ControlOperation::Other(OtherOp::ExecutePython { code: body.code }),
-    )
-    .await
-    {
+    match send_operation(&state.sender, ControlOperation::RunCode { code: body.code }).await {
         Ok(v) => (StatusCode::OK, Json(v)),
         Err(e) => e,
     }
 }
 async fn get_time_status(State(state): State<AppState>) -> impl IntoResponse {
-    match send_operation(&state.sender, ControlOperation::Time(TimeOp::GetTimeStatus)).await {
+    match send_operation(&state.sender, ControlOperation::GetTimeStatus).await {
         Ok(v) => (StatusCode::OK, Json(v)),
         Err(e) => e,
     }
 }
 
 async fn pause_time(State(state): State<AppState>) -> impl IntoResponse {
-    match send_operation(&state.sender, ControlOperation::Time(TimeOp::PauseTime)).await {
+    match send_operation(&state.sender, ControlOperation::PauseTime).await {
         Ok(v) => (StatusCode::OK, Json(v)),
         Err(e) => e,
     }
 }
 
 async fn resume_time(State(state): State<AppState>) -> impl IntoResponse {
-    match send_operation(&state.sender, ControlOperation::Time(TimeOp::ResumeTime)).await {
+    match send_operation(&state.sender, ControlOperation::ResumeTime).await {
         Ok(v) => (StatusCode::OK, Json(v)),
         Err(e) => e,
     }
@@ -811,7 +786,7 @@ async fn set_time_scale(
 ) -> impl IntoResponse {
     match send_operation(
         &state.sender,
-        ControlOperation::Time(TimeOp::SetTimeScale { scale: body.scale }),
+        ControlOperation::SetTimeScale { scale: body.scale },
     )
     .await
     {
@@ -833,7 +808,7 @@ async fn seek_time(
 ) -> impl IntoResponse {
     match send_operation(
         &state.sender,
-        ControlOperation::Time(TimeOp::SeekTime {
+        ControlOperation::SeekTime(SeekTimeParams {
             seconds: body.seconds,
             pause: body.pause,
         }),
@@ -865,7 +840,7 @@ async fn mutate_asset(
     };
     match send_operation(
         &state.sender,
-        ControlOperation::Other(OtherOp::MutateAsset {
+        ControlOperation::SetAsset(SetAssetParams {
             entity,
             component: body.component,
             asset_type: body.asset_type,
@@ -898,7 +873,7 @@ async fn query_spatial(
     };
     match send_operation(
         &state.sender,
-        ControlOperation::Spatial(SpatialOp::QuerySpatial { entity_a, entity_b }),
+        ControlOperation::QuerySpatial(QuerySpatialParams { entity_a, entity_b }),
     )
     .await
     {
@@ -924,7 +899,7 @@ async fn query_spatial_neighborhood(
     };
     match send_operation(
         &state.sender,
-        ControlOperation::Spatial(SpatialOp::QuerySpatialNeighborhood {
+        ControlOperation::QuerySpatialNeighborhood(QuerySpatialNeighborhoodParams {
             entity,
             radius: body.radius,
             max_results: body.max_results,
@@ -957,7 +932,7 @@ async fn check_overlaps(
     };
     match send_operation(
         &state.sender,
-        ControlOperation::Spatial(SpatialOp::CheckOverlaps {
+        ControlOperation::CheckOverlaps(CheckOverlapsParams {
             entity,
             include_siblings: body.include_siblings,
             max_float_gap: body.max_float_gap,
@@ -988,7 +963,7 @@ async fn check_all_overlaps(
 ) -> impl IntoResponse {
     match send_operation(
         &state.sender,
-        ControlOperation::Spatial(SpatialOp::CheckAllOverlaps {
+        ControlOperation::CheckAllOverlaps(CheckAllOverlapsParams {
             min_penetration: body.min_penetration,
             max_results: body.max_results,
             max_float_gap: body.max_float_gap,
@@ -1003,36 +978,21 @@ async fn check_all_overlaps(
     }
 }
 async fn get_performance(State(state): State<AppState>) -> impl IntoResponse {
-    match send_operation(
-        &state.sender,
-        ControlOperation::Other(OtherOp::GetPerformance),
-    )
-    .await
-    {
+    match send_operation(&state.sender, ControlOperation::GetPerformance).await {
         Ok(v) => (StatusCode::OK, Json(v)),
         Err(e) => e,
     }
 }
 
 async fn get_last_error(State(state): State<AppState>) -> impl IntoResponse {
-    match send_operation(
-        &state.sender,
-        ControlOperation::Reload(ReloadOp::GetLastError),
-    )
-    .await
-    {
+    match send_operation(&state.sender, ControlOperation::GetLastError).await {
         Ok(v) => (StatusCode::OK, Json(v)),
         Err(e) => e,
     }
 }
 
 async fn debug_registry(State(state): State<AppState>) -> impl IntoResponse {
-    match send_operation(
-        &state.sender,
-        ControlOperation::Scene(SceneOp::DebugRegistry),
-    )
-    .await
-    {
+    match send_operation(&state.sender, ControlOperation::GetRegistry).await {
         Ok(v) => (StatusCode::OK, Json(v)),
         Err(e) => e,
     }
@@ -1051,9 +1011,9 @@ async fn batch_mutate(
     }
     match send_operation(
         &state.sender,
-        ControlOperation::Mutate(MutateOp::BatchMutate {
+        ControlOperation::Batch {
             operations: body.operations,
-        }),
+        },
     )
     .await
     {
@@ -1064,22 +1024,17 @@ async fn batch_mutate(
 
 async fn submit_schedule(
     State(state): State<AppState>,
-    Json(body): Json<crate::handlers::schedule::ScheduleRequest>,
+    Json(body): Json<ScheduleRequest>,
 ) -> impl IntoResponse {
     // Validate before sending to engine
-    if let Err(e) = crate::handlers::schedule::validate_schedule(&body) {
+    if let Err(e) = validate_schedule(&body) {
         return error_response(StatusCode::BAD_REQUEST, &e);
     }
 
     // For sync mode, compute a dynamic timeout from max `at` value
-    let is_async = body.mode == "async";
+    let is_async = body.mode == ScheduleMode::Async;
 
-    match send_operation(
-        &state.sender,
-        ControlOperation::Other(OtherOp::SubmitSchedule { request: body }),
-    )
-    .await
-    {
+    match send_operation(&state.sender, ControlOperation::ScheduleActions(body)).await {
         Ok(v) => {
             if is_async {
                 (StatusCode::ACCEPTED, Json(v))
@@ -1124,19 +1079,14 @@ async fn cancel_schedule(
     }
 }
 async fn list_configs(State(state): State<AppState>) -> impl IntoResponse {
-    match send_operation(&state.sender, ControlOperation::Other(OtherOp::ListConfigs)).await {
+    match send_operation(&state.sender, ControlOperation::ListConfigs).await {
         Ok(v) => (StatusCode::OK, Json(v)),
         Err(e) => e,
     }
 }
 
 async fn get_config(State(state): State<AppState>, Path(key): Path<String>) -> impl IntoResponse {
-    match send_operation(
-        &state.sender,
-        ControlOperation::Other(OtherOp::GetConfig { key }),
-    )
-    .await
-    {
+    match send_operation(&state.sender, ControlOperation::GetConfig { key }).await {
         Ok(v) => (StatusCode::OK, Json(v)),
         Err(e) => e,
     }
@@ -1272,6 +1222,10 @@ async fn get_instructions(State(state): State<AppState>) -> impl IntoResponse {
     }
 }
 
+async fn list_tools() -> Json<Vec<serde_json::Value>> {
+    Json(crate::tools::list_tools())
+}
+
 pub fn start_server(host: String, port: u16, state: AppState) {
     std::thread::spawn(move || {
         let rt = tokio::runtime::Builder::new_multi_thread()
@@ -1382,11 +1336,6 @@ mod tests {
     }
 
     #[test]
-    fn default_reload_mode_value() {
-        assert_eq!(default_reload_mode(), "full");
-    }
-
-    #[test]
     fn screenshot_body_deserialize_defaults() {
         let json = r#"{"position": [1.0, 2.0, 3.0]}"#;
         let body: ScreenshotBody = serde_json::from_str(json).unwrap();
@@ -1490,7 +1439,7 @@ mod tests {
     fn reload_body_deserialize_defaults() {
         let json = "{}";
         let body: ReloadBody = serde_json::from_str(json).unwrap();
-        assert_eq!(body.mode, "full");
+        assert_eq!(body.mode, ReloadMode::Full);
         assert_eq!(body.pause, false);
         assert!(body.time_scale.is_none());
     }
@@ -1564,7 +1513,7 @@ mod tests {
     fn reload_and_capture_body_deserialize() {
         let json = r#"{"position": [0, 5, 10]}"#;
         let body: ReloadAndCaptureBody = serde_json::from_str(json).unwrap();
-        assert_eq!(body.mode, "full");
+        assert_eq!(body.mode, ReloadMode::Full);
         assert_eq!(body.pause, false);
         assert!(body.position.is_some());
     }

--- a/crates/pybevy_control/src/tools.rs
+++ b/crates/pybevy_control/src/tools.rs
@@ -1,0 +1,355 @@
+//! Generate MCP tool definitions from the ControlOperation JSON schema.
+//!
+//! Transforms schemars output into the MCP tools/list response format.
+
+use serde_json::{Map, Value, json};
+
+use crate::bridge::ControlOperation;
+
+/// Generate the full list of MCP tool definitions from ControlOperation's JSON schema.
+///
+/// Each tool has: `name`, `description`, `inputSchema`, and `feature_gate`.
+pub fn list_tools() -> Vec<Value> {
+    let root = schemars::schema_for!(ControlOperation);
+    let root_value = serde_json::to_value(&root).expect("schema serialization");
+
+    // Extract definitions for $ref resolution (schemars 1.x uses $defs, 0.8 uses definitions)
+    let definitions = root_value
+        .get("$defs")
+        .or_else(|| root_value.get("definitions"))
+        .and_then(|d| d.as_object())
+        .cloned()
+        .unwrap_or_default();
+
+    // The schema is a oneOf array at the top level
+    let variants = root_value
+        .get("oneOf")
+        .and_then(|o| o.as_array())
+        .expect("ControlOperation schema must have oneOf");
+
+    let mut tools = Vec::new();
+
+    for variant in variants {
+        let obj = match variant.as_object() {
+            Some(o) => o,
+            None => continue,
+        };
+
+        // Extract tool name from properties.tool.const (schemars 1.x)
+        // or properties.tool.enum[0] (schemars 0.8)
+        let tool_prop = obj.get("properties").and_then(|p| p.get("tool"));
+        let tool_name = tool_prop
+            .and_then(|t| {
+                t.get("const").and_then(|c| c.as_str()).or_else(|| {
+                    t.get("enum")
+                        .and_then(|e| e.as_array())
+                        .and_then(|a| a.first())
+                        .and_then(|v| v.as_str())
+                })
+            })
+            .unwrap_or("");
+
+        // Skip variants marked with #[schemars(extend("x-hidden" = true))]
+        let is_hidden = obj
+            .get("x-hidden")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        if tool_name.is_empty() || is_hidden {
+            continue;
+        }
+
+        let description = obj
+            .get("description")
+            .and_then(|d| d.as_str())
+            .unwrap_or("");
+
+        // Build inputSchema: take properties (minus "tool"), required (minus "tool").
+        // For newtype variants, schemars puts params in allOf/$ref instead of inline properties.
+        let mut properties = obj
+            .get("properties")
+            .and_then(|p| p.as_object())
+            .cloned()
+            .unwrap_or_default();
+        properties.remove("tool");
+
+        let mut required: Vec<String> = obj
+            .get("required")
+            .and_then(|r| r.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str())
+                    .filter(|s| *s != "tool")
+                    .map(|s| s.to_string())
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // Merge properties/required from $ref or allOf (newtype variant pattern).
+        // schemars generates newtype variants as { "$ref": "...", "properties": { "tool": ... } }
+        let refs_to_merge: Vec<Value> = if let Some(ref_path) = obj.get("$ref") {
+            vec![json!({"$ref": ref_path})]
+        } else if let Some(all_of) = obj.get("allOf").and_then(|a| a.as_array()) {
+            all_of.clone()
+        } else {
+            vec![]
+        };
+        for entry in &refs_to_merge {
+            let mut resolved = entry.clone();
+            resolve_refs(&mut resolved, &definitions);
+            if let Some(ref_props) = resolved.get("properties").and_then(|p| p.as_object()) {
+                for (k, v) in ref_props {
+                    properties.entry(k.clone()).or_insert_with(|| v.clone());
+                }
+            }
+            if let Some(ref_req) = resolved.get("required").and_then(|r| r.as_array()) {
+                for r in ref_req {
+                    if let Some(s) = r.as_str() {
+                        if !required.contains(&s.to_string()) {
+                            required.push(s.to_string());
+                        }
+                    }
+                }
+            }
+        }
+
+        // Resolve $ref in property values and clean up schemars noise
+        for (_key, prop_value) in properties.iter_mut() {
+            resolve_refs(prop_value, &definitions);
+            clean_schema_noise(prop_value);
+        }
+
+        required.sort();
+
+        let mut input_schema = json!({
+            "type": "object",
+            "properties": properties,
+        });
+
+        if !required.is_empty() {
+            input_schema["required"] = json!(required);
+        }
+
+        let gate = obj.get("x-feature-gate").and_then(|v| v.as_str());
+
+        tools.push(json!({
+            "name": tool_name,
+            "description": description,
+            "inputSchema": input_schema,
+            "feature_gate": gate,
+        }));
+    }
+
+    tools
+}
+
+/// Resolve `$ref` and `allOf` wrappers inline, replacing them with the referenced definition.
+fn resolve_refs(value: &mut Value, definitions: &Map<String, Value>) {
+    match value {
+        Value::Object(obj) => {
+            // Handle allOf with a single $ref entry (schemars pattern for described refs)
+            if let Some(all_of) = obj.get("allOf").and_then(|a| a.as_array()) {
+                if all_of.len() == 1 {
+                    if let Some(ref_path) = all_of[0].get("$ref").and_then(|r| r.as_str()) {
+                        let def_name = ref_path
+                            .trim_start_matches("#/$defs/")
+                            .trim_start_matches("#/definitions/");
+                        if let Some(def) = definitions.get(def_name) {
+                            // Preserve the description from the field, merge with definition
+                            let desc = obj.get("description").cloned();
+                            *value = def.clone();
+                            if let (Some(d), Some(obj)) = (desc, value.as_object_mut()) {
+                                obj.insert("description".to_string(), d);
+                            }
+                            return;
+                        }
+                    }
+                }
+            }
+            // Handle direct $ref
+            if let Some(ref_path) = obj.get("$ref").and_then(|r| r.as_str()) {
+                let def_name = ref_path
+                    .trim_start_matches("#/$defs/")
+                    .trim_start_matches("#/definitions/");
+                if let Some(def) = definitions.get(def_name) {
+                    *value = def.clone();
+                    return;
+                }
+            }
+            // Recurse into children
+            for (_, v) in obj.iter_mut() {
+                resolve_refs(v, definitions);
+            }
+        }
+        Value::Array(arr) => {
+            for v in arr.iter_mut() {
+                resolve_refs(v, definitions);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Strip schemars noise that wastes MCP context: `format`, `minimum` on integers,
+/// and simplify `["type", "null"]` arrays to just `"type"` (MCP always allows omission).
+fn clean_schema_noise(value: &mut Value) {
+    match value {
+        Value::Object(obj) => {
+            obj.remove("format");
+            // Remove minimum: 0 on unsigned integers (not useful for LLMs)
+            if obj.get("minimum") == Some(&json!(0)) {
+                obj.remove("minimum");
+            }
+            // Simplify ["integer", "null"] -> "integer", ["boolean", "null"] -> "boolean", etc.
+            if let Some(type_val) = obj.get("type").cloned() {
+                if let Some(arr) = type_val.as_array() {
+                    let non_null: Vec<&Value> =
+                        arr.iter().filter(|v| v.as_str() != Some("null")).collect();
+                    if non_null.len() == 1 {
+                        obj.insert("type".to_string(), non_null[0].clone());
+                    }
+                }
+            }
+            // Recurse into nested schemas (items, properties, etc.)
+            for (_, v) in obj.iter_mut() {
+                clean_schema_noise(v);
+            }
+        }
+        Value::Array(arr) => {
+            for v in arr.iter_mut() {
+                clean_schema_noise(v);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_tools_produces_expected_tools() {
+        let tools = list_tools();
+        let names: Vec<&str> = tools
+            .iter()
+            .filter_map(|t| t.get("name").and_then(|n| n.as_str()))
+            .collect();
+
+        // Check expected MCP tools are present
+        assert!(names.contains(&"query_entities"), "missing query_entities");
+        assert!(
+            names.contains(&"capture_screenshot"),
+            "missing capture_screenshot"
+        );
+        assert!(names.contains(&"spawn_entity"), "missing spawn_entity");
+        assert!(names.contains(&"set_resource"), "missing set_resource");
+        assert!(names.contains(&"set_asset"), "missing set_asset");
+        assert!(
+            names.contains(&"schedule_actions"),
+            "missing schedule_actions"
+        );
+        assert!(names.contains(&"pause_time"), "missing pause_time");
+
+        // Internal tools must NOT appear
+        assert!(
+            !names.contains(&"list_entities"),
+            "list_entities should be hidden"
+        );
+        assert!(
+            !names.contains(&"get_entity"),
+            "get_entity should be hidden"
+        );
+        assert!(
+            !names.contains(&"list_resources"),
+            "list_resources should be hidden"
+        );
+        assert!(
+            !names.contains(&"capture_with_gizmos"),
+            "capture_with_gizmos should be hidden"
+        );
+        assert!(
+            names.contains(&"query_spatial_neighborhood"),
+            "missing query_spatial_neighborhood"
+        );
+        assert!(
+            names.contains(&"check_all_overlaps"),
+            "missing check_all_overlaps"
+        );
+    }
+
+    #[test]
+    fn list_tools_have_descriptions() {
+        let tools = list_tools();
+        for tool in &tools {
+            let name = tool["name"].as_str().unwrap();
+            let desc = tool["description"].as_str().unwrap();
+            assert!(!desc.is_empty(), "tool {name} has empty description");
+        }
+    }
+
+    #[test]
+    fn list_tools_have_input_schema() {
+        let tools = list_tools();
+        for tool in &tools {
+            let name = tool["name"].as_str().unwrap();
+            let schema = tool.get("inputSchema");
+            assert!(schema.is_some(), "tool {name} missing inputSchema");
+            assert_eq!(
+                schema.unwrap()["type"],
+                "object",
+                "tool {name} inputSchema.type != object"
+            );
+        }
+    }
+
+    #[test]
+    fn list_tools_feature_gates_correct() {
+        let tools = list_tools();
+        let find = |name: &str| -> &Value { tools.iter().find(|t| t["name"] == name).unwrap() };
+
+        assert_eq!(find("capture_screenshot")["feature_gate"], "screenshot");
+        assert_eq!(find("spawn_entity")["feature_gate"], "manipulation");
+        assert_eq!(find("run_code")["feature_gate"], "execute_python");
+        assert!(find("query_entities")["feature_gate"].is_null());
+        assert!(find("pause_time")["feature_gate"].is_null());
+    }
+
+    #[test]
+    fn list_tools_no_tool_discriminator_in_schema() {
+        let tools = list_tools();
+        for tool in &tools {
+            let name = tool["name"].as_str().unwrap();
+            let props = tool["inputSchema"]["properties"].as_object();
+            if let Some(p) = props {
+                assert!(
+                    !p.contains_key("tool"),
+                    "tool {name} has 'tool' discriminator in inputSchema"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn list_tools_refs_resolved() {
+        let tools = list_tools();
+        let json = serde_json::to_string(&tools).unwrap();
+        assert!(
+            !json.contains("$ref"),
+            "unresolved $ref found in tool schemas"
+        );
+    }
+
+    #[test]
+    fn capture_screenshot_has_defaults() {
+        let tools = list_tools();
+        let tool = tools
+            .iter()
+            .find(|t| t["name"] == "capture_screenshot")
+            .unwrap();
+        let props = &tool["inputSchema"]["properties"];
+
+        assert_eq!(props["delay_frames"]["default"], 2);
+        assert_eq!(props["hide_ui"]["default"], true);
+    }
+}

--- a/pybevy/mcp/bridge.py
+++ b/pybevy/mcp/bridge.py
@@ -15,6 +15,8 @@ import threading
 import time
 from typing import Any
 
+import httpx
+
 from . import ApiIndex
 from .definitions import (
     builtin_prompts,
@@ -490,7 +492,6 @@ class McpBridge:
         self, req_id: JsonId, tool_name: str, arguments: JsonDict, timeout: float = 30.0
     ) -> JsonDict:
         """Forward a tool call to the engine's REST API."""
-        import httpx  # noqa: PLC0415
 
         coerced = self._coerce_arguments(tool_name, arguments)
 
@@ -559,13 +560,14 @@ class McpBridge:
         for key, value in coerced.items():
             if key not in props or not isinstance(value, str):
                 continue
-            expected = props[key].get("type", "")
+            raw_type = props[key].get("type", "")
+            types = set(raw_type) if isinstance(raw_type, list) else {raw_type}
             try:
-                if expected == "integer":
+                if "integer" in types:
                     coerced[key] = int(value)
-                elif expected == "number":
+                elif "number" in types:
                     coerced[key] = float(value)
-                elif expected == "boolean":
+                elif "boolean" in types:
                     coerced[key] = value.lower() in ("true", "1", "yes")
             except (ValueError, TypeError):
                 pass
@@ -650,10 +652,9 @@ class McpBridge:
 
     def _call_rest_api(self, tool_name: str, arguments: JsonDict, timeout: float = 30.0) -> JsonDict:
         """Map tool name + arguments to REST API call."""
-        import httpx  # noqa: PLC0415
 
         base = self._base_url
-        entity_ref = str(arguments.get("entity_id", arguments.get("name", "")))
+        entity_ref = str(arguments.get("entity", ""))
 
         if tool_name == "get_component":
             component = arguments.get("component", "")
@@ -686,7 +687,7 @@ class McpBridge:
             url = f"{base}/api/v1/resources/{rt}"
             resp = httpx.delete(url, timeout=timeout)
         elif tool_name == "set_asset":
-            entity = arguments.get("entity_id", arguments.get("name"))
+            entity = arguments.get("entity")
             body = {
                 "entity": entity,
                 "component": arguments.get("component", ""),
@@ -702,20 +703,20 @@ class McpBridge:
         elif tool_name == "query_spatial":
             if "radius" in arguments:
                 # Neighborhood mode
-                entity = arguments.get("entity_id", arguments.get("name"))
+                entity = arguments.get("entity")
                 body = {"entity": entity, "radius": arguments["radius"]}
                 if "max_results" in arguments:
                     body["max_results"] = arguments["max_results"]
                 url = f"{base}/api/v1/spatial/neighborhood"
             else:
                 # Pairwise mode
-                entity_a = arguments.get("entity_id_a", arguments.get("name_a"))
-                entity_b = arguments.get("entity_id_b", arguments.get("name_b"))
+                entity_a = arguments.get("entity_a")
+                entity_b = arguments.get("entity_b")
                 body = {"entity_a": entity_a, "entity_b": entity_b}
                 url = f"{base}/api/v1/spatial/query"
             resp = httpx.post(url, json=body, timeout=timeout)
         elif tool_name == "check_overlaps":
-            entity = arguments.get("entity_id", arguments.get("name"))
+            entity = arguments.get("entity")
             if entity is not None:
                 # Single-entity mode
                 body = {"entity": entity}
@@ -757,7 +758,6 @@ class McpBridge:
 
     def _forward_scene_resource(self, req_id: JsonId, uri: str) -> JsonDict:
         """Forward scene:// resource reads via HTTP."""
-        import httpx  # noqa: PLC0415
 
         resource_map: dict[str, str] = {
             "scene://entities": "/api/v1/entities",
@@ -939,7 +939,6 @@ class McpBridge:
         return self._success(req_id, {"content": [{"type": "text", "text": output}]})
 
     def _try_hub_create_session(self, scene_path: str) -> JsonDict | None:
-        import httpx  # noqa: PLC0415
 
         try:
             resp = httpx.post(
@@ -959,7 +958,6 @@ class McpBridge:
         if self._hub_session_id is None:
             return
 
-        import httpx  # noqa: PLC0415
 
         try:
             httpx.delete(
@@ -973,8 +971,6 @@ class McpBridge:
 
     def _health_check(self) -> bool:
         try:
-            import httpx  # noqa: PLC0415
-
             resp = httpx.get(f"{self._base_url}/health", timeout=2.0)
             return resp.status_code == 200
         except Exception:

--- a/pybevy/mcp/definitions.py
+++ b/pybevy/mcp/definitions.py
@@ -14,7 +14,7 @@ type JsonDict = dict[str, Any]
 def _rust_tools() -> list[JsonDict]:
     """Load engine tool definitions from the Rust pybevy_control crate."""
     try:
-        from pybevy._pybevy import mcp as rust_mcp  # noqa: PLC0415
+        from pybevy._pybevy import mcp as rust_mcp  # type: ignore[import-not-found]  # noqa: PLC0415
 
         return rust_mcp.rust_tool_definitions()  # type: ignore[no-any-return]
     except Exception:

--- a/pybevy/mcp/definitions.py
+++ b/pybevy/mcp/definitions.py
@@ -1,19 +1,28 @@
 """MCP tool, resource, and prompt definitions.
 
-Single source of truth for all MCP protocol definitions.
-Feature gates control which tools are exposed based on engine config.
+Engine tool definitions come from Rust (pybevy_control.tools::list_tools).
+Bridge-local tools and resources/prompts are defined here.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-# TYPE: actually type out the tool schema
 type JsonDict = dict[str, Any]
 
 
-def builtin_tools() -> list[JsonDict]:
-    """All built-in MCP tool definitions with feature gates."""
+def _rust_tools() -> list[JsonDict]:
+    """Load engine tool definitions from the Rust pybevy_control crate."""
+    try:
+        from pybevy._pybevy import mcp as rust_mcp  # noqa: PLC0415
+
+        return rust_mcp.rust_tool_definitions()  # type: ignore[no-any-return]
+    except Exception:
+        return []
+
+
+def bridge_local_tools() -> list[JsonDict]:
+    """Bridge-local tool definitions (not in Rust, handled by Python bridge)."""
     return [
         {
             "name": "get_started",
@@ -64,431 +73,6 @@ def builtin_tools() -> list[JsonDict]:
             },
         },
         {
-            "name": "get_component_schema",
-            "description": "Get component field names, types, defaults, and a JSON spawn example",
-            "feature_gate": None,
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "name": {"type": "string", "description": "Component name (e.g. 'Transform')"},
-                },
-                "required": ["name"],
-            },
-        },
-        {
-            "name": "get_component",
-            "description": "Get live field values for a specific component on an entity. Returns structured field data for debugging.",
-            "feature_gate": None,
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "entity_id": {"type": "integer", "description": "Entity ID (from query_entities)"},
-                    "name": {"type": "string", "description": "Entity name (alternative to entity_id)"},
-                    "component": {"type": "string", "description": "Component name (e.g. 'Transform', 'PointLight')"},
-                },
-                "required": ["component"],
-            },
-        },
-        {
-            "name": "query_entities",
-            "description": "Query entities by With/Without component filters. Also supports Name lookup.",
-            "feature_gate": None,
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "with": {"type": "array", "items": {"type": "string"}, "description": "Component names entities must have"},
-                    "without": {"type": "array", "items": {"type": "string"}, "description": "Component names entities must not have"},
-                },
-            },
-        },
-        {
-            "name": "capture_screenshot",
-            "description": "Capture a screenshot. Default 768px wide. UI elements are hidden by default. Use position/look_at to capture from an arbitrary viewpoint without affecting the scene camera. Use gizmos=true to overlay entity ID/Name labels.",
-            "feature_gate": "screenshot",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "delay_frames": {"type": "integer", "description": "Frames to wait before capture (default 2)", "default": 2},
-                    "max_width": {"type": "integer", "description": "Max image width in pixels (default 768). Use 1280 for detail.", "default": 768},
-                    "position": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Camera position [x, y, z]. If set, spawns a temporary debug camera instead of using the scene camera."},
-                    "look_at": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Point the camera looks at [x, y, z]. Defaults to [0, 0, 0] if position is set."},
-                    "hide_ui": {"type": "boolean", "description": "Hide authored UI Node entities during capture (default true). Internal overlays (hot reload status) are always hidden regardless.", "default": True},
-                    "gizmos": {"type": "boolean", "description": "Overlay entity ID/Name labels on the screenshot (default false)", "default": False},
-                },
-            },
-        },
-        {
-            "name": "capture_timeline",
-            "description": "Capture multiple frames over time into a contact sheet. Shows animation/motion in one image.",
-            "feature_gate": "screenshot",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "total_frames": {"type": "integer", "description": "Frame span to capture over (~1s at 60fps)", "default": 60},
-                    "capture_count": {"type": "integer", "description": "Number of captures (max 20)", "default": 6},
-                    "max_width": {"type": "integer", "description": "Max composite width in pixels", "default": 1200},
-                    "columns": {"type": "integer", "description": "Grid columns", "default": 3},
-                    "position": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Debug camera position [x, y, z]"},
-                    "look_at": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Point the camera looks at [x, y, z]. Defaults to [0, 0, 0] if position is set."},
-                },
-            },
-        },
-        {
-            "name": "reload",
-            "description": "Hot-reload the scene (full or partial). Waits for reload to complete before responding — response includes any errors or escalation info. Use 'pause' and 'time_scale' to control time atomically with the reload.",
-            "feature_gate": None,
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "mode": {"type": "string", "enum": ["full", "partial"], "description": "Reload mode", "default": "full"},
-                    "pause": {"type": "boolean", "description": "Pause time immediately (before reload runs). Scene starts frozen so you can capture at t=0.", "default": False},
-                    "time_scale": {"type": "number", "description": "Set time scale atomically with reload (e.g. 0.1 for slow-motion). Applied before any frames run."},
-                },
-            },
-        },
-        {
-            "name": "get_reload_status",
-            "description": "Get current reload generation, mode, and enabled state",
-            "feature_gate": None,
-            "inputSchema": {"type": "object", "properties": {}},
-        },
-        {
-            "name": "get_last_error",
-            "description": "Get the last Python system error traceback",
-            "feature_gate": None,
-            "inputSchema": {"type": "object", "properties": {}},
-        },
-        {
-            "name": "spawn_entity",
-            "description": "Spawn a new entity with components specified as JSON",
-            "feature_gate": "manipulation",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "components": {"type": "object", "description": 'Component name -> field values (e.g. {"Transform": {"translation": [0, 5, 0]}})'},
-                },
-                "required": ["components"],
-            },
-        },
-        {
-            "name": "despawn_entity",
-            "description": "Remove an entity by ID or Name",
-            "feature_gate": "manipulation",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "entity_id": {"type": "integer", "description": "Entity ID"},
-                    "name": {"type": "string", "description": "Entity Name (alternative to entity_id)"},
-                },
-            },
-        },
-        {
-            "name": "set_component",
-            "description": "Update specific fields on a component without replacing it",
-            "feature_gate": "manipulation",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "entity_id": {"type": "integer", "description": "Entity ID"},
-                    "name": {"type": "string", "description": "Entity Name (alternative to entity_id)"},
-                    "component": {"type": "string", "description": "Component name"},
-                    "fields": {"type": "object", "description": "Fields to update"},
-                },
-                "required": ["component", "fields"],
-            },
-        },
-        {
-            "name": "remove_component",
-            "description": "Remove a component from an entity",
-            "feature_gate": "manipulation",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "entity_id": {"type": "integer", "description": "Entity ID"},
-                    "name": {"type": "string", "description": "Entity Name (alternative to entity_id)"},
-                    "component": {"type": "string", "description": "Component to remove"},
-                },
-                "required": ["component"],
-            },
-        },
-        {
-            "name": "set_resource",
-            "description": "Insert or update a resource on a running scene (in scene code, use commands.insert_resource() instead)",
-            "feature_gate": "manipulation",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "resource_type": {"type": "string", "description": "Resource type name"},
-                    "value": {"type": "object", "description": "Resource value as JSON"},
-                },
-                "required": ["resource_type", "value"],
-            },
-        },
-        {
-            "name": "remove_resource",
-            "description": "Remove a resource from the world",
-            "feature_gate": "manipulation",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "resource_type": {"type": "string", "description": "Resource type name"},
-                },
-                "required": ["resource_type"],
-            },
-        },
-        {
-            "name": "batch",
-            "description": "Execute multiple mutation operations in a single round-trip. Each operation runs independently — failures don't abort the batch. Actions: set_component, spawn, despawn, remove_component.",
-            "feature_gate": "manipulation",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "operations": {
-                        "type": "array",
-                        "description": "Array of operations to execute",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "action": {"type": "string", "enum": ["set_component", "spawn", "despawn", "remove_component"], "description": "Operation type"},
-                                "entity_id": {"type": "integer", "description": "Entity ID (for set_component, despawn, remove_component)"},
-                                "name": {"type": "string", "description": "Entity Name (alternative to entity_id)"},
-                                "component": {"type": "string", "description": "Component name (for set_component, remove_component)"},
-                                "fields": {"type": "object", "description": "Fields to update (for set_component)"},
-                                "components": {"type": "object", "description": "Components to spawn (for spawn)"},
-                            },
-                            "required": ["action"],
-                        },
-                    },
-                },
-                "required": ["operations"],
-            },
-        },
-        {
-            "name": "set_asset",
-            "description": "Update asset properties (material color, mesh settings) live without code reload.",
-            "feature_gate": "manipulation",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "entity_id": {"type": "integer", "description": "Entity ID"},
-                    "name": {"type": "string", "description": "Entity Name (alternative to entity_id)"},
-                    "component": {"type": "string", "description": "Handle component: MeshMaterial3d, Mesh3d, MeshMaterial2d, AudioPlayer"},
-                    "asset_type": {"type": "string", "description": "Asset type: StandardMaterial, Mesh, ColorMaterial, AudioSource"},
-                    "fields": {"type": "object", "description": "Fields to update on the asset"},
-                },
-                "required": ["component", "asset_type", "fields"],
-            },
-        },
-        {
-            "name": "get_bounding_box",
-            "description": "Get the axis-aligned bounding box (AABB) of an entity, both local and world-space. Requires entity to have a mesh.",
-            "feature_gate": None,
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "entity_id": {"type": "integer", "description": "Entity ID"},
-                    "name": {"type": "string", "description": "Entity Name (alternative to entity_id)"},
-                },
-            },
-        },
-        {
-            "name": "get_scene_summary",
-            "description": "Get a grouped entity inventory: counts by type (e.g. '30 Bubble, 6 Fish, 1 Camera3d'). Faster than query_entities for understanding scene composition.",
-            "feature_gate": None,
-            "inputSchema": {"type": "object", "properties": {}},
-        },
-        {
-            "name": "query_spatial",
-            "description": "Spatial queries between entities. Two modes: (1) Pairwise: provide name_a/name_b to get distance, direction, AABB overlap between two entities. (2) Neighborhood: provide name + radius to find all entities within radius.",
-            "feature_gate": None,
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "entity_id_a": {"type": "integer", "description": "Entity A ID (pairwise mode)"},
-                    "name_a": {"type": "string", "description": "Entity A name (pairwise mode)"},
-                    "entity_id_b": {"type": "integer", "description": "Entity B ID (pairwise mode)"},
-                    "name_b": {"type": "string", "description": "Entity B name (pairwise mode)"},
-                    "entity_id": {"type": "integer", "description": "Center entity ID (neighborhood mode)"},
-                    "name": {"type": "string", "description": "Center entity name (neighborhood mode)"},
-                    "radius": {"type": "number", "description": "Search radius (neighborhood mode). If set, uses neighborhood mode."},
-                    "max_results": {"type": "integer", "description": "Max neighbors to return (default 50)"},
-                },
-            },
-        },
-        {
-            "name": "check_overlaps",
-            "description": "Detect AABB overlaps. Two modes: (1) Single entity: provide entity_id/name to check one entity against all others. (2) Scene-wide: omit entity to find all overlapping pairs. Also detects floating entities (no surface below). Note: AABB overlap detection does not detect ground penetration (models sunk below ground). Use ground_y parameter to detect sunken entities.",
-            "feature_gate": None,
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "entity_id": {"type": "integer", "description": "Entity ID (single entity mode)"},
-                    "name": {"type": "string", "description": "Entity name (single entity mode)"},
-                    "include_siblings": {"type": "boolean", "description": "Include siblings under same parent (default false, since parented parts overlap by design)", "default": False},
-                    "min_penetration": {"type": "number", "description": "Minimum overlap depth to report (scene-wide mode, default 0.001)", "default": 0.001},
-                    "max_results": {"type": "integer", "description": "Max overlapping pairs to return (scene-wide mode, default 100)", "default": 100},
-                    "max_float_gap": {"type": "number", "description": "Max gap (units) between entity bottom and surface below to still count as grounded (default 0.1). Increase for scenes with small placement gaps.", "default": 0.1},
-                    "ground_y": {"type": "number", "description": "Ground plane Y coordinate for sunk-detection. When provided, entities whose world AABB min_y is below this value are flagged as sunken. Useful for detecting GLB models placed at origin that are half-buried below the ground plane."},
-                },
-            },
-        },
-        {
-            "name": "reload_and_capture",
-            "description": "Primary iteration tool. Reload and capture in one round-trip. Hot-reloads the scene, waits for completion, checks for errors, then captures a screenshot. Returns combined result with reload status + error info + screenshot image.",
-            "feature_gate": "screenshot",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "mode": {"type": "string", "enum": ["full", "partial"], "description": "Reload mode (default full)", "default": "full"},
-                    "pause": {"type": "boolean", "description": "Pause time before reload", "default": False},
-                    "time_scale": {"type": "number", "description": "Set time scale atomically with reload"},
-                    "delay_frames": {"type": "integer", "description": "Frames to wait after reload before capture (default 30)", "default": 30},
-                    "max_width": {"type": "integer", "description": "Max screenshot width (default 768)", "default": 768},
-                    "position": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Debug camera position [x, y, z]"},
-                    "look_at": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Camera look-at point [x, y, z]"},
-                    "hide_ui": {"type": "boolean", "description": "Hide UI during capture (default true)", "default": True},
-                },
-            },
-        },
-        {
-            "name": "capture_turnaround",
-            "description": "Capture multiple viewpoints orbiting around a target, composited into one contact sheet. Auto-fits distance to scene bounds if not specified.",
-            "feature_gate": "screenshot",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "look_at": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Center point to orbit around. Auto-detected from scene bounds if omitted."},
-                    "distance": {"type": "number", "description": "Camera distance from center. Auto-fitted to scene bounds if omitted."},
-                    "elevation": {"type": "number", "description": "Camera elevation in degrees (default 25)", "default": 25},
-                    "view_count": {"type": "integer", "description": "Number of orbit positions (default 6)", "default": 6},
-                    "include_top": {"type": "boolean", "description": "Include top-down view (default true)", "default": True},
-                    "columns": {"type": "integer", "description": "Grid columns in contact sheet (default 3)", "default": 3},
-                    "max_width": {"type": "integer", "description": "Max composite width (default 1200)", "default": 1200},
-                    "hide_ui": {"type": "boolean", "description": "Hide UI during capture (default true)", "default": True},
-                },
-            },
-        },
-        {
-            "name": "capture_depth",
-            "description": "Capture RGB screenshot + ray-AABB depth samples. Casts rays from camera through sample points (or auto-grid) against entity bounding boxes. Returns structured depth data with hit entity, distance, and world position.",
-            "feature_gate": "screenshot",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "position": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Camera position [x, y, z]"},
-                    "look_at": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Camera look-at [x, y, z]"},
-                    "sample_points": {"type": "array", "items": {"type": "array", "items": {"type": "integer"}, "minItems": 2, "maxItems": 2}, "description": "Screen-space sample points [[x, y], ...]. Auto-generates grid if omitted."},
-                    "grid_density": {"type": "integer", "description": "Auto-generate NxN sample grid (default 8 if no sample_points)", "default": 8},
-                    "include_rgb": {"type": "boolean", "description": "Include RGB screenshot (default true)", "default": True},
-                    "delay_frames": {"type": "integer", "description": "Frames to wait before capture (default 2)", "default": 2},
-                    "hide_ui": {"type": "boolean", "description": "Hide UI during capture (default true)", "default": True},
-                    "max_width": {"type": "integer", "description": "Max screenshot width (default 768)", "default": 768},
-                },
-            },
-        },
-        {
-            "name": "run_code",
-            "description": "Run arbitrary Python code with World context. Returns stdout/stderr capture and change summary.",
-            "feature_gate": "execute_python",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "code": {"type": "string", "description": "Python code to execute"},
-                },
-                "required": ["code"],
-            },
-        },
-        {
-            "name": "get_registry",
-            "description": "Show bridge registry state, entity count, and component detection status",
-            "feature_gate": None,
-            "inputSchema": {"type": "object", "properties": {}},
-        },
-        {
-            "name": "pause_time",
-            "description": "Pause game time. Scene freezes but rendering continues. Useful for inspecting a specific moment. Note: extended pause with a minimized window may cause tool timeouts due to reduced frame processing.",
-            "feature_gate": None,
-            "inputSchema": {"type": "object", "properties": {}},
-        },
-        {
-            "name": "resume_time",
-            "description": "Resume game time after pause.",
-            "feature_gate": None,
-            "inputSchema": {"type": "object", "properties": {}},
-        },
-        {
-            "name": "set_time_scale",
-            "description": "Set game speed multiplier (0.1 = slow-mo, 2.0 = 2x speed). Does not affect pause state.",
-            "feature_gate": None,
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "scale": {"type": "number", "description": "Speed multiplier (default 1.0)", "default": 1.0},
-                },
-            },
-        },
-        {
-            "name": "get_time_status",
-            "description": "Get current time state: paused, speed, elapsed seconds.",
-            "feature_gate": None,
-            "inputSchema": {"type": "object", "properties": {}},
-        },
-        {
-            "name": "seek_time",
-            "description": "Jump virtual time to a specific moment. Seeking backwards resets virtual time (preserves speed). Pauses by default so you can capture at that exact time.",
-            "feature_gate": None,
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "seconds": {"type": "number", "description": "Target elapsed time in seconds"},
-                    "pause": {"type": "boolean", "description": "Pause after seeking (default true)", "default": True},
-                },
-                "required": ["seconds"],
-            },
-        },
-        {
-            "name": "get_performance",
-            "description": "Get full diagnostics: FPS, CPU/GPU/RAM/VRAM usage, entity/asset counts, system profiling times",
-            "feature_gate": None,
-            "inputSchema": {"type": "object", "properties": {}},
-        },
-        {
-            "name": "schedule_actions",
-            "description": (
-                "Submit batched, timed tool calls that execute inside the engine frame loop "
-                "with frame-precise timing. Same-'at' actions fire in the same frame (atomic). "
-                "Supports: time control, mutations, queries, screenshots. "
-                "NOT supported: get_logs, search_api, run_scene (bridge-local tools)."
-            ),
-            "feature_gate": None,
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "actions": {
-                        "type": "array",
-                        "description": "Ordered list of tool calls to execute",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "tool": {"type": "string", "description": "Tool name to call"},
-                                "args": {"type": "object", "description": "Tool arguments (default {})", "default": {}},
-                                "at": {"type": "number", "description": "Game-time offset in seconds from schedule start (default 0). Must be monotonically non-decreasing."},
-                                "at_frame": {"type": "integer", "description": "Frame offset from schedule start (alternative to 'at'). Cannot mix with 'at'."},
-                                "label": {"type": "string", "description": "Label for this action (used by skip_if_error)"},
-                                "skip_if_error": {"type": "string", "description": "Skip this action if the action with the given label errored"},
-                            },
-                            "required": ["tool"],
-                        },
-                        "minItems": 1,
-                        "maxItems": 256,
-                    },
-                    "mode": {"type": "string", "enum": ["sync", "async"], "description": "sync (default): block until all actions complete. async: return schedule_id immediately.", "default": "sync"},
-                    "stop_on_error": {"type": "boolean", "description": "Abort remaining actions on first error (default false)", "default": False},
-                },
-                "required": ["actions"],
-            },
-        },
-        {
             "name": "get_schedule_result",
             "description": "Poll status/results of an async schedule. Returns status (running/completed/error/cancelled) and partial or complete results.",
             "feature_gate": None,
@@ -501,6 +85,11 @@ def builtin_tools() -> list[JsonDict]:
             },
         },
     ]
+
+
+def builtin_tools() -> list[JsonDict]:
+    """All MCP tool definitions: bridge-local tools first (get_started must be first), then Rust engine tools."""
+    return bridge_local_tools() + _rust_tools()
 
 
 def builtin_resources() -> list[JsonDict]:

--- a/pybevy/mcp/definitions.py
+++ b/pybevy/mcp/definitions.py
@@ -14,7 +14,7 @@ type JsonDict = dict[str, Any]
 def _rust_tools() -> list[JsonDict]:
     """Load engine tool definitions from the Rust pybevy_control crate."""
     try:
-        from pybevy._pybevy import mcp as rust_mcp  # type: ignore[import-not-found]  # noqa: PLC0415, I001
+        from .._pybevy import mcp as rust_mcp  # type: ignore[import-not-found]  # noqa: PLC0415, I001
 
         return rust_mcp.rust_tool_definitions()  # type: ignore[no-any-return]
     except Exception:

--- a/pybevy/mcp/definitions.py
+++ b/pybevy/mcp/definitions.py
@@ -14,7 +14,9 @@ type JsonDict = dict[str, Any]
 def _rust_tools() -> list[JsonDict]:
     """Load engine tool definitions from the Rust pybevy_control crate."""
     try:
-        from pybevy._pybevy import mcp as rust_mcp  # type: ignore[import-not-found]  # noqa: PLC0415
+        from pybevy._pybevy import (  # noqa: PLC0415
+            mcp as rust_mcp,  # type: ignore[import-not-found]
+        )
 
         return rust_mcp.rust_tool_definitions()  # type: ignore[no-any-return]
     except Exception:

--- a/pybevy/mcp/definitions.py
+++ b/pybevy/mcp/definitions.py
@@ -14,9 +14,7 @@ type JsonDict = dict[str, Any]
 def _rust_tools() -> list[JsonDict]:
     """Load engine tool definitions from the Rust pybevy_control crate."""
     try:
-        from pybevy._pybevy import (  # noqa: PLC0415
-            mcp as rust_mcp,  # type: ignore[import-not-found]
-        )
+        from pybevy._pybevy import mcp as rust_mcp  # type: ignore[import-not-found]  # noqa: PLC0415, I001
 
         return rust_mcp.rust_tool_definitions()  # type: ignore[no-any-return]
     except Exception:


### PR DESCRIPTION
Fixes #117 

Also:

- migrate string-matching to enums
- simplify code paths, no unnecessary struct unpacking
- split spatial query into two mcp calls