### PR TITLE
Migrate *mut World to world cell params

### DIFF
--- a/crates/pybevy_core/src/registry/resource_bridge.rs
+++ b/crates/pybevy_core/src/registry/resource_bridge.rs
@@ -9,7 +9,10 @@
 
 use std::any::TypeId;
 
-use bevy::ecs::{component::ComponentId, world::World};
+use bevy::ecs::{
+    component::ComponentId,
+    world::{World, unsafe_world_cell::UnsafeWorldCell},
+};
 use pyo3::{ffi::PyTypeObject, prelude::*, types::PyType};
 
 use crate::ValidityFlagWithMode;
@@ -71,6 +74,37 @@ pub trait ResourceBridge: Send + Sync + 'static {
     fn get_mut(
         &self,
         world: &mut World,
+        validity: ValidityFlagWithMode,
+        py: Python,
+    ) -> PyResult<Py<PyAny>>;
+
+    /// Get resource through an [`UnsafeWorldCell`] (read-only), touching only this
+    /// bridge's `Resource` type instead of borrowing the whole `World`.
+    ///
+    /// Used by `DynamicSystem::run_unsafe`, which holds a non-exclusive
+    /// `UnsafeWorldCell` and must not conjure `&World`/`&mut World`.
+    ///
+    /// # Safety
+    /// The caller must guarantee that `DynamicSystem::initialize` declared read
+    /// access to this resource and that Bevy's executor prevents any concurrent
+    /// writer, so the cell's unchecked resource read is unique.
+    unsafe fn get_from_cell(
+        &self,
+        cell: UnsafeWorldCell,
+        validity: ValidityFlagWithMode,
+        py: Python,
+    ) -> PyResult<Py<PyAny>>;
+
+    /// Get resource through an [`UnsafeWorldCell`] (mutable), touching only this
+    /// bridge's `Resource` type. Read-only bridges (`no_mut`) return read access.
+    ///
+    /// # Safety
+    /// The caller must guarantee that `DynamicSystem::initialize` declared write
+    /// access to this resource and that Bevy's executor prevents any concurrent
+    /// access, so the cell's unchecked resource borrow is unique.
+    unsafe fn get_mut_from_cell(
+        &self,
+        cell: UnsafeWorldCell,
         validity: ValidityFlagWithMode,
         py: Python,
     ) -> PyResult<Py<PyAny>>;

--- a/crates/pybevy_ecs/src/shared/system_flags.rs
+++ b/crates/pybevy_ecs/src/shared/system_flags.rs
@@ -4,9 +4,18 @@ use bevy::ecs::system::SystemStateFlags;
 ///
 /// - `needs_exclusive`: system has a World parameter (requires exclusive access)
 /// - `needs_commands`: system has a Commands parameter (requires deferred sync points)
+///
+/// Exclusive systems are NON_SEND | EXCLUSIVE, exactly like Bevy's
+/// ExclusiveFunctionSystem. A Send exclusive system is a state vanilla Bevy
+/// cannot construct, and MultiThreadedExecutor's local-thread accounting
+/// assumes the pairing: exclusive spawn sets `local_thread_running`
+/// unconditionally but only non-Send completion clears it, so a bare
+/// EXCLUSIVE system leaks the flag and permanently blocks every non-Send
+/// system still in the queue (`ready_systems.is_clear()` assertion at scope
+/// end).
 pub fn compute_system_flags(needs_exclusive: bool, needs_commands: bool) -> SystemStateFlags {
     if needs_exclusive {
-        SystemStateFlags::EXCLUSIVE
+        SystemStateFlags::NON_SEND | SystemStateFlags::EXCLUSIVE
     } else if needs_commands {
         SystemStateFlags::DEFERRED
     } else {
@@ -22,12 +31,14 @@ mod tests {
     fn exclusive_takes_priority_over_commands() {
         let flags = compute_system_flags(true, true);
         assert!(flags.contains(SystemStateFlags::EXCLUSIVE));
+        assert!(flags.contains(SystemStateFlags::NON_SEND));
     }
 
     #[test]
     fn exclusive_without_commands() {
         let flags = compute_system_flags(true, false);
         assert!(flags.contains(SystemStateFlags::EXCLUSIVE));
+        assert!(flags.contains(SystemStateFlags::NON_SEND));
     }
 
     #[test]

--- a/crates/pybevy_macros/src/resource.rs
+++ b/crates/pybevy_macros/src/resource.rs
@@ -407,6 +407,89 @@ pub(crate) fn generate_resource_bridge_tokens(
         }
     };
 
+    // Cell-based read accessor: narrow access to just this resource through an
+    // UnsafeWorldCell, so run_unsafe never conjures `&World`.
+    let get_from_cell_impl = quote! {
+        unsafe fn get_from_cell(
+            &self,
+            cell: bevy::ecs::world::unsafe_world_cell::UnsafeWorldCell,
+            validity: pybevy_core::ValidityFlagWithMode,
+            py: pyo3::Python,
+        ) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>> {
+            // SAFETY: initialize declared read access to this resource and the
+            // executor prevents a concurrent writer, so this unchecked resource
+            // read is unique.
+            let resource = unsafe { cell.get_resource::<#bevy_type>() }.ok_or_else(|| {
+                pyo3::exceptions::PyRuntimeError::new_err(concat!(#resource_name, " resource not found"))
+            })?;
+
+            // TODO(pybevy/pybevy#90): use a read-only ResourceStorage variant to avoid *const -> *mut cast
+            let ptr = resource as *const #bevy_type as *mut #bevy_type;
+            // SAFETY: ptr is from a valid Bevy resource borrow; validity flag invalidates storage when borrow expires.
+            let storage = unsafe {
+                pybevy_core::ResourceStorage::borrowed(ptr, validity)
+            };
+
+            let obj = pyo3::Py::new(py, #py_type::from_borrowed(storage))?;
+            Ok(obj.into_any())
+        }
+    };
+
+    // Cell-based mutable accessor (or read-only override for no_mut resources).
+    let get_mut_from_cell_impl = if no_mut {
+        quote! {
+            unsafe fn get_mut_from_cell(
+                &self,
+                cell: bevy::ecs::world::unsafe_world_cell::UnsafeWorldCell,
+                validity: pybevy_core::ValidityFlagWithMode,
+                py: pyo3::Python,
+            ) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>> {
+                // SAFETY: initialize declared read access; the executor prevents a
+                // concurrent writer, so this unchecked resource read is unique.
+                let resource = unsafe { cell.get_resource::<#bevy_type>() }.ok_or_else(|| {
+                    pyo3::exceptions::PyRuntimeError::new_err(concat!(#resource_name, " resource not found"))
+                })?;
+
+                // TODO(pybevy/pybevy#90): use a read-only ResourceStorage variant to avoid *const -> *mut cast
+                let ptr = resource as *const #bevy_type as *mut #bevy_type;
+                // Override to read mode even though caller requested write
+                let read_validity = validity.flag.with_access_mode(pybevy_core::AccessMode::Read);
+                // SAFETY: ptr is from a valid Bevy resource borrow; validity flag invalidates storage when borrow expires.
+                let storage = unsafe {
+                    pybevy_core::ResourceStorage::borrowed(ptr, read_validity)
+                };
+
+                let obj = pyo3::Py::new(py, #py_type::from_borrowed(storage))?;
+                Ok(obj.into_any())
+            }
+        }
+    } else {
+        quote! {
+            unsafe fn get_mut_from_cell(
+                &self,
+                cell: bevy::ecs::world::unsafe_world_cell::UnsafeWorldCell,
+                validity: pybevy_core::ValidityFlagWithMode,
+                py: pyo3::Python,
+            ) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>> {
+                // SAFETY: initialize declared write access to this resource and the
+                // executor prevents any concurrent access, so this unchecked
+                // resource borrow is unique.
+                let resource = unsafe { cell.get_resource_mut::<#bevy_type>() }.ok_or_else(|| {
+                    pyo3::exceptions::PyRuntimeError::new_err(concat!(#resource_name, " resource not found"))
+                })?;
+
+                let ptr = resource.into_inner() as *mut #bevy_type;
+                // SAFETY: ptr is from a valid Bevy resource mutable borrow; validity flag invalidates storage when borrow expires.
+                let storage = unsafe {
+                    pybevy_core::ResourceStorage::borrowed(ptr, validity)
+                };
+
+                let obj = pyo3::Py::new(py, #py_type::from_borrowed(storage))?;
+                Ok(obj.into_any())
+            }
+        }
+    };
+
     // Generate remove method based on no_remove flag
     let remove_impl = if no_remove {
         quote! {
@@ -483,6 +566,10 @@ pub(crate) fn generate_resource_bridge_tokens(
             }
 
             #get_mut_impl
+
+            #get_from_cell_impl
+
+            #get_mut_from_cell_impl
 
             #insert_impl
 

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -40,14 +40,19 @@ stored_query[0]  # Would be use-after-free without protection!
 PyBevy uses **runtime validity flags** with RAII guards to automatically invalidate all system parameters when execution completes:
 
 ```rust
-// In DynamicSystem::run_unsafe() - src/dynamic_system.rs
+// In DynamicSystem::run_unsafe() - src/ecs/dynamic_system.rs
 let validity = ValidityFlag::new();
 let _guard = ValidityGuard::new(validity.clone());
 
 // All parameters share the same validity flag
 let py_world = unsafe { PyWorld::new(world_mut, validity.clone()) };
-let py_commands = unsafe { PyCommands::new(&mut commands, validity.clone()) };
-let py_query = PyQuery::new(query_state, validity.clone());
+let py_commands = unsafe { PyCommands::new(commands, validity.clone()) };
+// Query parameters borrow a QueryState cached in `initialize` and fetch through
+// this run's UnsafeWorldCell (no &mut World). See "Query Parameters and the
+// World Cell" below.
+let py_query = unsafe {
+    PyQueryIter::new(cached, world, validity.clone(), last_run, this_run)
+};
 
 // Execute Python system...
 python_function.call()?;
@@ -88,6 +93,50 @@ stored_query[0]  # RuntimeError: Component access is no longer valid
 - **Impact**: ~4-8% of Query iteration cost (negligible compared to Python overhead)
 - **Benefit**: Complete prevention of use-after-free bugs
 
+### Query Parameters and the World Cell
+
+Query and View data are not rebuilt on every run from a fresh `&mut World`.
+Instead:
+
+- `DynamicSystem::initialize` builds one `QueryState` per Query parameter and
+  stores it in a `CachedQuery` on the `DynamicSystem` (which the schedule owns and
+  which outlives every run). See `CachedQuery::build` in
+  `src/ecs/query/query_runtime.rs` and the `query_caches` field in
+  `src/ecs/dynamic_system.rs`.
+- At run time the Query arm hands `PyQueryIter` the run's `UnsafeWorldCell` plus a
+  raw pointer to the cached state. Iteration fetches through
+  the unchecked `QueryState::query_unchecked_with_ticks` API. The uniqueness
+  obligation of that unchecked call is discharged by the access this parameter
+  declared in `initialize` (see Section 4, "How the Scheduler Learns Each System's
+  Access"): the executor never schedules a system with conflicting declared access
+  alongside it, so the query has unique access to the components it touches.
+- Both the cached-state pointer and the world cell are fenced by the same
+  `ValidityFlag`, so a leaked `PyQueryIter` (or an iterator derived from it) fails
+  the validity check rather than dereferencing a stale cell.
+
+All parameter arms build from the world cell; no shared `&mut World` is
+materialized across the parameter loop. The arms differ in shape:
+
+- **Resource** arms use narrow cell accessors (`UnsafeWorldCell::get_resource` /
+  `get_resource_mut`, or the `ResourceRegistry`/`PyResourceStorage` reads for
+  custom Python resources), touching only the declared resource.
+- **World** arms derive a genuine `&mut World`, which is sound because a `World`
+  parameter makes `flags()` mark the system EXCLUSIVE, and the multithreaded
+  executor never runs an exclusive system while anything else is in flight.
+  `initialize` returns an EMPTY access set for such systems, exactly like Bevy's
+  `ExclusiveFunctionSystem`: exclusivity is enforced by the flag, not by
+  declared access, and declaring whole-world read+write instead creates an
+  asymmetric conflict graph next to Bevy's empty-access exclusive systems that
+  wedges the executor's ready-queue accounting (its `ready_systems.is_clear()`
+  assertion fires with three or more exclusives of mixed shape in one schedule).
+- **View, message, and asset** wrappers hold the cell and derive a momentary
+  world pointer per operation, because their internals (`QueryBuilder`, the
+  message macros, the `AssetBridge`) take `&mut World`. The declared access from
+  `initialize` bounds the data those operations actually touch. This is the same
+  residual-pointer class as the custom-component write-back path inside
+  `PyQueryIter` (`world_ptr`), which still stamps change ticks through a
+  `*mut World`; narrowing these internals is planned follow-up work.
+
 ---
 
 ## 2. Parameter Validation (Borrowing Rules)
@@ -117,32 +166,20 @@ PyBevy validates **all** system parameters when the system is **added** to the a
 3. **Asset Access** (Assets[T] parameters)
 4. **World Exclusivity** (World parameter)
 
-**Implementation**: `src/ecs/dynamic_system.rs:1142-1209` (`validate_parameters()`)
+**Implementation**: `src/ecs/dynamic_system.rs` (`validate_access` in the shared
+validation module, invoked from `DynamicSystem::initialize`)
 
-The validation tracks three separate access maps:
-- `component_access` - Query/View component conflicts
-- `resource_access` - Res/ResMut resource conflicts
-- `asset_access` - Assets[T] asset type conflicts
+The validation checks three kinds of access for conflicts:
+- Query/View component conflicts
+- Res/ResMut resource conflicts
+- Assets[T] asset type conflicts
 
 Plus special handling for World's exclusive access requirement.
 
-**Called from**: `DynamicSystem::initialize()` when system is added to the app
-
-### Validation Coverage
-
-| Parameter Type | Validates | Test Coverage |
-|----------------|-----------|---------------|
-| **Query** | Component access conflicts | 10+ tests |
-| **View** | Component access conflicts | 8 tests |
-| **Resource** | Resource borrow conflicts | 9 tests |
-| **Assets** | Asset type borrow conflicts | 8 tests |
-| **Time** | Treated as resource conflict | 5 tests |
-| **World** | Exclusive access enforcement | 14 tests |
-| Commands | No validation (buffers only) | - |
-| Local | No validation (isolated state) | - |
-| AssetServer | No validation (read-only) | - |
-
-**Total**: 58 safety tests (100% passing)
+**When it runs**: `DynamicSystem::initialize` computes the conflict once (it holds
+`&mut World` there for the ComponentId lookups) and stores the result in
+`precomputed_validation`; `validate_params` (called on every run) just returns the
+stored error, so the app's error handler surfaces the conflict.
 
 ### Examples: Query Conflicts
 
@@ -533,10 +570,13 @@ Most of PyBevy's safety comes from **Bevy's ECS scheduler** and **parameter vali
        pass  # RuntimeError - conflicting access
    ```
 
-3. **Bevy's scheduler** - Ensures systems with conflicting access never run in parallel
-   - `Query[Mut[T]]` + `Query[Mut[T]]` → Never concurrent
-   - `ResMut[R]` + `ResMut[R]` → Rejected by validation
-   - Each entity accessed by at most one system at a time
+3. **Bevy's scheduler** - Keeps systems with conflicting access off the same
+   thread, but only because PyBevy tells it what each system touches. A Python
+   system is opaque to Bevy, so `DynamicSystem::initialize` returns a
+   `FilteredAccessSet` describing every component and resource the system reads or
+   writes. The parallel executor then treats a pybevy system exactly like a native
+   one: two systems whose declared access is incompatible never run concurrently.
+   The next subsection describes how that access is declared.
 
 4. **Wrapper storage components** - Mutations go through Rust memory
    ```python
@@ -555,6 +595,52 @@ Most of PyBevy's safety comes from **Bevy's ECS scheduler** and **parameter vali
        for t in query:
            t.translation.x = 100.0  # Safe - Bevy prevents conflicts
    ```
+
+### How the Scheduler Learns Each System's Access
+
+The scheduler can only keep conflicting systems apart if it knows what each system
+accesses, and a Python function tells it nothing. `DynamicSystem::initialize`
+(`src/ecs/dynamic_system.rs`) therefore translates the system's parameters into a
+`FilteredAccessSet` of resolved `ComponentId`s. The building blocks live in
+`crates/pybevy_ecs/src/shared/access_sets.rs`:
+
+- **One `FilteredAccess` per Query/View parameter** (`QueryParamAccess::build`),
+  plus one shared `FilteredAccess` for all resource-like access
+  (`build_resource_access`). Filters are per-parameter on purpose: a `With` on one
+  query must not narrow another query's access, or the scheduler would think two
+  genuinely conflicting systems are disjoint.
+- **Required components** declare read or write access and, because their presence
+  gates the access, also contribute a `With` filter. **Optional components** declare
+  access with no `With` filter, since the query still matches archetypes that lack
+  them.
+- **`Without[T]`** declares an `and_without` filter. Declaring it as `With`
+  (an earlier defect) would fabricate disjointness and let conflicting systems run
+  in parallel.
+- **`Changed[T]` / `Added[T]`** read the filtered component's change ticks, so they
+  declare *read* access on that component (a native writer of T also writes T's
+  ticks, so it must conflict).
+- **`Has[T]` and `AnyOf[...]`** deliberately declare no filter narrowing. `Has`
+  matches regardless of the component's presence, and `AnyOf`'s OR semantics cannot
+  be expressed by a conjunctive `With`. Omitting the filter is conservative: it can
+  only cost parallelism, never soundness. Their ids are still registered so the
+  runtime query builder can see them.
+- **Resource, message, and asset `ComponentId`s are registered (not merely looked
+  up) at `initialize`.** A resource inserted after schedule build would otherwise
+  have no id yet, leaving the access undeclared and letting the scheduler run a
+  conflicting system in parallel (UB). Registering up front means late-inserted
+  resources are never invisible to the scheduler. (The one residual lookup-only
+  case is custom message types; see `MessageType::register_resource_id`.)
+
+Two test suites guard this translation:
+
+- `tests/bevy_invariants.rs` pins the upstream Bevy semantics PyBevy depends on
+  (for example that `Without` disjointness is real, that `Changed`/`Added` declare
+  read access, that `Has` and OR filters narrow nothing, that `Option` does not
+  narrow access, and that resources are components in the access set). If a Bevy
+  upgrade changes any of these, these tests fail first.
+- The differential tests in `access_sets.rs` build each pybevy access and compare
+  it against the access a native `QueryState` reports for the equivalent
+  `Query<..., ...>`, asserting the two agree on compatibility.
 
 ### What Requires Caution
 
@@ -613,7 +699,25 @@ def system(state: ResMut[GameState]) -> None:
 
 **CAUTION: Spawning threads inside systems**:
 
-Passing component references to threads spawned within a system bypasses PyBevy's safety guarantees. Without the GIL, two threads calling `as_mut()` on the same component simultaneously would create a data race on the underlying Rust memory. In practice the effect is limited to corrupted field values (torn writes on non-atomic types). A thread-id check in the validity flag could detect this, but would add a branch to every component access on the hot path.
+Passing a component reference (or a Query/View parameter, or anything derived from
+one) to a thread spawned inside a system bypasses PyBevy's safety guarantees.
+
+Under the GIL this is contained: the spawned thread cannot run Python concurrently
+with the system, so by the time it touches the parameter the ValidityFlag has
+already been invalidated and the access raises. Without the GIL, that containment
+is gone, and the ValidityFlag check is **check-then-act**. Two threads writing the
+same component concurrently can tear a non-atomic field, but the more serious
+problem is timing: a leaked thread can pass the validity check while the system is
+still running, then dereference the pointer *after* the system ends and its
+commands apply. Those commands move entities between archetypes and free component
+storage, so the pointer the thread holds can dangle. That is a genuine
+use-after-free, not merely a torn write.
+
+This is a known limitation of the check-then-act design. The considered future
+mitigation is a thread-affinity check in the validity flag (record the system's
+thread id and reject access from any other thread), which would turn the leak into
+a clean error at the cost of a branch on every component access on the hot path.
+Until then, the rule stands: do not hand system parameters to other threads.
 
 ### Safe Patterns
 
@@ -701,6 +805,33 @@ def system(commands: Commands, loader: ResMut[AssetLoader]) -> None:
     loader.queue_load("texture.png", on_complete=lambda tex: ...)
 ```
 
+### Explicitly Prevented: Mutating Run Conditions
+
+**Run conditions must be read-only.** A run condition (a function passed to
+`run_if`) is evaluated under Bevy's read-only system contract:
+`DynamicCondition` is declared `unsafe impl ReadOnlySystem`, the executor runs it
+with only read permission to the world, and any deferred operations it queues are
+**never applied**. A condition that mutated the world (or queued commands expecting
+them to take effect) would either violate that contract or silently do nothing.
+
+PyBevy therefore rejects any parameter kind that could mutate the world when a
+condition is registered, before the condition ever reaches Bevy
+(`condition_param_rejection` / `validate_condition_params` in
+`src/ecs/dynamic_condition.rs`):
+
+- `World` (exclusive world access)
+- `Commands` (its queued mutations are never applied to conditions)
+- `ResMut` (mutable resource access)
+- mutable `Assets` (mutable asset access)
+- `Query` / `View` with a `Mut` component (mutable component access)
+- `MessageWriter` (writing messages mutates the world)
+- `MessageReader` (advancing the read cursor mutates the world; read messages in a
+  regular system instead)
+
+Read-only parameters (`Res`, read-only `Query`/`View`, `Local`, read-only `Assets`)
+are allowed. The error names the offending parameter index and explains the
+read-only requirement. Coverage lives in `tests/safety/test_condition_readonly.py`.
+
 ### Unsafe Patterns (Free-Threaded Mode)
 
 **UNSAFE:Global mutable state**:
@@ -769,7 +900,7 @@ Used for diagnostics/logging. The extension module declares `gil_used = false` v
 
 | Component | GIL Mode | Free-Threaded | Notes |
 |-----------|----------|---------------|-------|
-| ValidityFlag | Safe | Safe | Uses atomics |
+| ValidityFlag | Safe | Check-then-act gap* | Atomic flag. *Safe under the GIL; without the GIL a parameter leaked to another thread can pass the check then dereference after teardown (use-after-free) |
 | Parameter validation | Safe | Safe | Registration-time |
 | Wrapper components | Safe | Safe | Rust storage |
 | PyObject components | Safe | Safe | Bevy prevents conflicts |
@@ -796,8 +927,10 @@ Used for diagnostics/logging. The extension module declares `gil_used = false` v
 PyBevy's safety architecture was designed around **Bevy's guarantees**, not Python's:
 
 1. **Bevy's scheduler** prevents concurrent mutable access to components/resources
+   (using the per-system `FilteredAccessSet` that `initialize` declares)
 2. **Parameter validation** enforces borrowing rules at registration time
-3. **ValidityFlag** uses atomics (works without GIL)
+3. **ValidityFlag** uses atomics (works without GIL, with the check-then-act caveat
+   above for parameters leaked to other threads)
 4. **Borrowed fields** point to Bevy-managed memory (not Python objects)
 
 The GIL was **defensive redundancy** - an extra layer of protection against user code doing unsafe things (global state). The core safety mechanisms work regardless of GIL status.
@@ -826,7 +959,7 @@ The issue: `transform.translation` returns a copy of the Vec3. Modifying `copy.x
 PyBevy implements an enum-based storage pattern where property getters return **borrowed** references pointing directly to component fields:
 
 ```rust
-// Vec3 can be either owned or borrowed - src/math/vec3.rs
+// Vec3 can be either owned or borrowed - crates/pybevy_math/src/vec3.rs
 enum Vec3Storage {
     Owned(Vec3),  // Created via Vec3(1.0, 2.0, 3.0)
     Borrowed {
@@ -872,7 +1005,7 @@ impl PyVec3 {
 
 **Transform property returns borrowed Vec3**:
 ```rust
-// In Transform::translation() - src/transform/transform.rs
+// In Transform::translation() - crates/pybevy_transform/src/transform.rs
 #[getter]
 pub fn translation(&self) -> PyResult<PyVec3> {
     self.check_valid()?;
@@ -912,11 +1045,11 @@ for transform in Query[Mut[Transform]]:
 
 Types with borrowed field access:
 
-- **Vec2** (`src/math/vec2.rs`) - 2D vectors with `.x`, `.y` setters
-- **Vec3** (`src/math/vec3.rs`) - 3D vectors with `.x`, `.y`, `.z` setters
-- **Quat** (`src/math/quat.rs`) - Quaternions with `.x`, `.y`, `.z`, `.w` setters
-- **Transform** (`src/transform/transform.rs`) - Uses borrowed Vec3/Quat for properties
-- **PointLight** (`src/light/point_light.rs`) - Direct field mutations
+- **Vec2** (`crates/pybevy_math/src/vec2.rs`) - 2D vectors with `.x`, `.y` setters
+- **Vec3** (`crates/pybevy_math/src/vec3.rs`) - 3D vectors with `.x`, `.y`, `.z` setters
+- **Quat** (`crates/pybevy_math/src/quat.rs`) - Quaternions with `.x`, `.y`, `.z`, `.w` setters
+- **Transform** (`crates/pybevy_transform/src/transform.rs`) - Uses borrowed Vec3/Quat for properties
+- **PointLight** (`crates/pybevy_light/src/point_light.rs`) - Direct field mutations
 
 ### Safety Guarantees
 
@@ -1026,6 +1159,56 @@ RuntimeError: Cannot write to component - query does not have mutable access
 
 ---
 
+## Error Reporting and Message Resources
+
+### System Errors Are Buffered Off-World
+
+When a Python system raises, `run_unsafe` is on the parallel execution path and
+must not perform a structural world mutation (inserting or mutating a resource
+there would be unsound while other systems may be running). So the error path
+touches no world state: it writes the message and traceback into a shared
+off-world buffer (`SystemErrorBuffer`, an `Arc<Mutex<Option<BufferedSystemError>>>`
+in `src/ecs/dynamic_system.rs`).
+
+An exclusive system registered in the `Last` schedule, `drain_last_system_error`
+(`src/app/app.rs`), then moves the most recent buffered error into the
+`LastSystemError` resource that MCP reads. Two consequences follow from draining in
+`Last` rather than at the moment of failure:
+
+- The `LastSystemError` timestamp is read at **drain time** (from `Time`), not when
+  the error occurred, so it can lag up to one frame. This is acceptable for MCP
+  display and keeps the error path free of world access.
+- `LastSystemError` (and the `LastErrorBuffer` that wraps the shared buffer) are
+  **pre-inserted** when the app is built, so the drain always has a resource to
+  write into and never has to insert one.
+
+### Message Resources
+
+Message access is designed so that a system in the parallel path never has to
+insert a `Messages<T>` resource (again, a structural world mutation would be
+unsound there):
+
+- **Readers of a missing `Messages` resource see an empty read.** A
+  `MessageReader` whose buffer does not exist yields no messages rather than
+  creating the resource (`iter_messages` returns an empty vector; the
+  clear/len/`is_empty` helpers fall back to an `EmptyMessages` stand-in). See
+  `src/ecs/messages.rs`.
+- **Writers raise instead of creating the resource.** A `MessageWriter` to a
+  missing buffer returns an error telling you to register the message type with
+  `app.add_message(T)` first (`src/ecs/message.rs`), rather than silently inserting
+  the buffer from a possibly-parallel system.
+- **Built-in message resources are pre-inserted at `PreStartup`.** Buffers whose
+  owning plugin may be absent (keyboard input, window events, world-instance-ready,
+  and image/mesh asset events) are filled in by `ensure_builtin_message_resources`
+  (`src/ecs/messages.rs`), registered in `PreStartup` so any plugin that owns a
+  buffer has already inserted it first; only genuinely missing ones are filled.
+
+This is also why message resource, asset, and `Res`/`ResMut` `ComponentId`s are
+**registered** (not just looked up) in `initialize`: see Section 4, "How the
+Scheduler Learns Each System's Access."
+
+---
+
 ## Performance Impact
 
 | Safety Mechanism | Overhead | Impact |
@@ -1042,18 +1225,26 @@ RuntimeError: Cannot write to component - query does not have mutable access
 
 ### Key Files
 
-- **Core Storage Layer** (`crates/pybevy_core/src/`):
-  - `validity_guard.rs` - ValidityFlag, ValidityGuard (RAII), AccessMode
+- **Core Storage Layer** (`crates/pybevy_storage/src/`, re-exported by
+  `pybevy_core` and, for the main crate, by `src/ecs/helpers/validity_guard.rs`):
+  - `validity_guard.rs` - ValidityFlag, ValidityFlagWithMode, ValidityGuard (RAII), AccessMode
   - `pycomponent.rs` - Owned/Borrowed component storage
   - `value_storage.rs` - Copy-type field storage (Vec3, Quat, f32, etc.)
   - `field_storage.rs` - Non-Copy field storage (TextureAtlas, WindowResolution, etc.)
   - `list_storage.rs` - Vec<T> field storage with Python list interface
-  - `storage/pyasset.rs` - Asset storage (read-only vs mutable variants)
-- **Parameter Validation**: `src/ecs/dynamic_system.rs` (`validate_parameters()`, `validate_component_access_internal()`)
-- **Borrowed Fields**: `src/math/vec2.rs`, `src/math/vec3.rs`, `src/math/quat.rs`
-- **Component Pattern**: `src/transform/transform.rs`, `src/light/point_light.rs`
-- **Python Safety Tests**: `tests/safety/` (15 test files)
-- **Rust Unit Tests**: `cargo test -p pybevy_core` (63 tests covering all storage types)
+  - `pyasset.rs` - Asset storage (read-only vs mutable variants)
+  - `pyresource.rs` - Resource storage
+- **Access Declaration**: `crates/pybevy_ecs/src/shared/access_sets.rs`
+  (`QueryParamAccess`, `build_resource_access`)
+- **Parameter Validation and Access Declaration**: `src/ecs/dynamic_system.rs`
+  (`initialize` builds the `FilteredAccessSet` and precomputes conflict validation)
+- **Run-Condition Validation**: `src/ecs/dynamic_condition.rs`
+- **Borrowed Fields**: `crates/pybevy_math/src/vec2.rs`, `crates/pybevy_math/src/vec3.rs`, `crates/pybevy_math/src/quat.rs`
+- **Component Pattern**: `crates/pybevy_transform/src/transform.rs`, `crates/pybevy_light/src/point_light.rs`
+- **Python Safety Tests**: `tests/safety/` (Python safety test suite)
+- **Rust Unit Tests**: storage-layer tests live in `pybevy_storage`
+  (`cargo test -p pybevy_storage`); registry and handle tests live in `pybevy_core`
+  (`cargo test -p pybevy_core`)
 
 ### Related Documentation
 
@@ -1067,25 +1258,29 @@ RuntimeError: Cannot write to component - query does not have mutable access
 
 ### Overview
 
-The `pybevy_core` crate contains all the unsafe pointer logic (owned/borrowed storage, validity flags, field borrowing). These are tested with pure Rust unit tests that can run without the Python interpreter.
+The `pybevy_storage` crate contains the unsafe pointer logic (owned/borrowed
+storage, validity flags, field borrowing), re-exported by `pybevy_core`. These are
+tested with pure Rust unit tests that can run without the Python interpreter. The
+registry and handle logic is tested in `pybevy_core`.
 
 ```bash
-cargo test -p pybevy_core    # 63 tests, ~0s runtime
+cargo test -p pybevy_storage   # storage-layer unit tests
+cargo test -p pybevy_core      # registry + handle unit tests
 ```
 
 ### Coverage
 
-| Module | Tests | What's Tested |
+| Module | Crate | What's Tested |
 |--------|-------|---------------|
-| `validity_guard` | 10 | Flag lifecycle, read/write/invalid modes, RAII guard drop, clone propagation, ValidityFlagWithMode |
-| `pycomponent` | 9 | Owned/borrowed modes, mutation persistence, validity enforcement, write permissions, into_owned |
-| `value_storage` | 8 | Same as pycomponent for Copy types (Vec3, f32, etc.) |
-| `field_storage` | 12 | Owned/borrowed, borrow_field chains (owned→field, borrowed→field), mutation persistence through nested borrows, Drop invalidation, clone independence |
-| `list_storage` | 11 | Vec storage, mutation persistence, validity/write enforcement, normalize_index edge cases |
-| `pyasset` | 8 | Read-only vs mutable variants, take/consume, validity enforcement |
-| `handle` | 2 | UUID handling |
-| `global_registry` | 2 | Registry basics |
-| **Total** | **63** | |
+| `validity_guard` | pybevy_storage | Flag lifecycle, read/write/invalid modes, RAII guard drop, clone propagation, ValidityFlagWithMode |
+| `pycomponent` | pybevy_storage | Owned/borrowed modes, mutation persistence, validity enforcement, write permissions, into_owned |
+| `value_storage` | pybevy_storage | Same as pycomponent for Copy types (Vec3, f32, etc.) |
+| `field_storage` | pybevy_storage | Owned/borrowed, borrow_field chains (owned→field, borrowed→field), mutation persistence through nested borrows, Drop invalidation, clone independence |
+| `list_storage` | pybevy_storage | Vec storage, mutation persistence, validity/write enforcement, normalize_index edge cases |
+| `pyasset` | pybevy_storage | Read-only vs mutable variants, take/consume, validity enforcement |
+| `pyresource` | pybevy_storage | Resource storage variants (owned/borrowed, validity enforcement) |
+| `handle` | pybevy_core | UUID handling |
+| `global_registry` | pybevy_core | Registry basics |
 
 ### Key Safety Properties Tested
 
@@ -1120,8 +1315,8 @@ sudo apt install libasan8    # only needed for --full (Phase 2)
 
 ### What It Does
 
-1. **Phase 1** (default): Runs `cargo +nightly test -p pybevy_core` with `-Z sanitizer=address` — validates the Rust storage layer under ASan. Always works because `pybevy_core` has minimal dependencies.
-2. **Phase 2** (`--full`): Builds the full PyO3 `.so` with ASan instrumentation via `maturin develop`, then runs `pytest` with `LD_PRELOAD=libasan.so` — catches memory errors during actual Python-to-Rust interaction.
+1. **Phase 1** (default): Runs `cargo +nightly test -p pybevy_core` with `-Z sanitizer=address`, exercising the core Rust unit tests under ASan. Always works because `pybevy_core` has minimal dependencies. The storage primitives themselves now live in `pybevy_storage`; run `cargo +nightly test -p pybevy_storage` under ASan to cover them directly.
+2. **Phase 2** (`--full`): Builds the full PyO3 `.so` with ASan instrumentation via `maturin develop`, then runs `pytest` with `LD_PRELOAD=libasan.so`, catching memory errors during actual Python-to-Rust interaction.
 3. **Cleanup** (Phase 2 only): Rebuilds without ASan to restore the normal dev environment.
 
 ### What ASan Detects
@@ -1129,7 +1324,7 @@ sudo apt install libasan8    # only needed for --full (Phase 2)
 - Use-after-free (dangling pointer dereference)
 - Heap/stack buffer overflow
 - Stack use after return
-- Memory leaks (disabled by default — Python's GC makes this noisy)
+- Memory leaks (disabled by default: Python's GC makes this noisy)
 
 ### Limitations
 
@@ -1151,18 +1346,19 @@ PyBevy achieves production-ready safety through:
    - Assets[T] asset access
    - World exclusive access
 3. **Standard Python reference semantics** - Within parameters, follows normal Python behavior
-4. **Free-threading compatible** - Works with Python 3.13+ without GIL
+4. **Free-threading compatible** - Works with Python 3.13+ without GIL (with a
+   check-then-act gap for parameters leaked to other threads; see Section 4)
 5. **Async system detection** - Blocks async functions at registration (would break ValidityFlag)
 6. **Borrowed field access** - Direct mutations persist safely (zero overhead)
-7. **Rust unit tests** - 63 tests covering all storage types in `pybevy_core`
+7. **Rust unit tests** - Pure-Rust unit tests covering all storage types in `pybevy_storage`
 8. **AddressSanitizer support** - `scripts/check_asan.sh` for runtime memory error detection
 
 ### Test Coverage
 
-| Layer | What's Tested | Count |
+| Layer | What's Tested | Scope |
 |-------|---------------|-------|
-| Rust storage (pybevy_core) | Validity flags, owned/borrowed storage, field borrows, Drop safety | 63 tests |
-| Python safety (tests/safety/) | Parameter conflicts, aliasing, async detection, field mutations | 15 test files |
+| Rust storage (pybevy_storage) | Validity flags, owned/borrowed storage, field borrows, Drop safety | pure-Rust unit tests |
+| Python safety (tests/safety/) | Parameter conflicts, aliasing, async detection, run-condition read-only, field mutations | Python safety suite |
 | ASan (scripts/check_asan.sh) | Runtime memory errors across Rust + Python boundary | On-demand |
 
 These mechanisms ensure that PyBevy maintains Rust's safety guarantees at runtime, making it safe for production use while keeping performance impact minimal.

--- a/src/assets/asset_server.rs
+++ b/src/assets/asset_server.rs
@@ -1,7 +1,7 @@
 use bevy::{
     asset::{AssetPath, AssetServer, UntypedAssetId},
+    ecs::world::unsafe_world_cell::UnsafeWorldCell,
     image::Image,
-    prelude::World,
 };
 use pybevy_core::{handle::PyHandle, registry::global_registry};
 use pybevy_image::loader_settings::PyImageLoaderSettings;
@@ -36,7 +36,9 @@ fn extract_asset_path(path: &Bound<'_, PyAny>) -> PyResult<AssetPath<'static>> {
 #[pyclass(name = "AssetServer", extends = PyResource)]
 #[derive(Debug)]
 pub struct PyAssetServer {
-    world: *const World,
+    /// World cell (lifetime-erased), valid only while `validity` is active. Only
+    /// ever used to read the declared `AssetServer` resource, never `&World`.
+    cell: UnsafeWorldCell<'static>,
     validity: ValidityFlag,
 }
 
@@ -44,13 +46,25 @@ unsafe impl Send for PyAssetServer {}
 unsafe impl Sync for PyAssetServer {}
 
 impl PyAssetServer {
-    pub(crate) unsafe fn new(world: *const World, validity: ValidityFlag) -> Self {
-        Self { world, validity }
+    /// # Safety
+    /// `cell` must reference the World this AssetServer belongs to and must stay
+    /// valid for as long as `validity` is active.
+    pub(crate) unsafe fn new(cell: UnsafeWorldCell, validity: ValidityFlag) -> Self {
+        // SAFETY: layout-preserving lifetime erasure of a Copy pointer type; the
+        // cell is only touched while `validity` is active.
+        let cell: UnsafeWorldCell<'static> = unsafe { std::mem::transmute(cell) };
+        Self { cell, validity }
     }
 
-    fn world_ref(&self) -> PyResult<&World> {
+    /// Borrow the `AssetServer` resource through the cell.
+    fn asset_server(&self) -> PyResult<&AssetServer> {
         self.validity.check()?;
-        Ok(unsafe { &*self.world })
+        // SAFETY: `Res`/`ResMut[AssetServer]` registers AssetServer's ComponentId in
+        // DynamicSystem::initialize, so read access is declared; the executor prevents a
+        // concurrent writer, so this unchecked resource read is unique. AssetServer's own
+        // methods use interior mutability, so shared access suffices for load/query.
+        unsafe { self.cell.get_resource::<AssetServer>() }
+            .ok_or_else(|| PyRuntimeError::new_err("AssetServer resource not found"))
     }
 }
 
@@ -77,8 +91,7 @@ impl PyAssetServer {
             )));
         }
 
-        let world = self.world_ref()?;
-        let asset_server = world.resource::<AssetServer>();
+        let asset_server = self.asset_server()?;
         let asset_path = extract_asset_path(&path)?;
         let untyped_handle = bridge.load(asset_server, asset_path);
         let py_handle = PyHandle::from_untyped(untyped_handle, type_ptr);
@@ -113,8 +126,7 @@ impl PyAssetServer {
             ))
         })?;
 
-        let world = self.world_ref()?;
-        let asset_server = world.resource::<AssetServer>();
+        let asset_server = self.asset_server()?;
         let asset_path = extract_asset_path(&path)?;
 
         let untyped_handle = match bridge.name() {
@@ -151,8 +163,7 @@ impl PyAssetServer {
         let bridge = global_registry::get_asset_bridge_by_name("Image")
             .ok_or_else(|| PyRuntimeError::new_err("Asset bridge for 'Image' not found"))?;
 
-        let world = self.world_ref()?;
-        let asset_server = world.resource::<AssetServer>();
+        let asset_server = self.asset_server()?;
         let asset_path = extract_asset_path(&path)?;
         let bevy_settings: bevy::image::ImageLoaderSettings = settings.into();
         let untyped_handle = asset_server
@@ -179,22 +190,19 @@ impl PyAssetServer {
     }
 
     pub fn load_state(&self, id: &PyHandle) -> PyResult<PyLoadState> {
-        let world = self.world_ref()?;
-        let asset_server = world.resource::<AssetServer>();
+        let asset_server = self.asset_server()?;
         let untyped_id: UntypedAssetId = id.clone().into();
         Ok(PyLoadState::from(asset_server.load_state(untyped_id)))
     }
 
     pub fn is_loaded(&self, id: &PyHandle) -> PyResult<bool> {
-        let world = self.world_ref()?;
-        let asset_server = world.resource::<AssetServer>();
+        let asset_server = self.asset_server()?;
         let untyped_id: UntypedAssetId = id.clone().into();
         Ok(asset_server.is_loaded(untyped_id))
     }
 
     pub fn is_loaded_with_dependencies(&self, id: &PyHandle) -> PyResult<bool> {
-        let world = self.world_ref()?;
-        let asset_server = world.resource::<AssetServer>();
+        let asset_server = self.asset_server()?;
         let untyped_id: UntypedAssetId = id.clone().into();
         Ok(asset_server.is_loaded_with_dependencies(untyped_id))
     }
@@ -213,8 +221,7 @@ impl PyAssetServer {
             ))
         })?;
 
-        let world = self.world_ref()?;
-        let asset_server = world.resource::<AssetServer>();
+        let asset_server = self.asset_server()?;
         let asset_path = extract_asset_path(&path)?;
 
         match bridge.get_handle(asset_server, asset_path) {
@@ -239,8 +246,7 @@ impl PyAssetServer {
             PyRuntimeError::new_err(format!("Asset bridge for '{}' not found", name))
         })?;
 
-        let world = self.world_ref()?;
-        let asset_server = world.resource::<AssetServer>();
+        let asset_server = self.asset_server()?;
         let asset_path = extract_asset_path(&path)?;
         let untyped_handle = bridge.load(asset_server, asset_path);
         let py_handle = PyHandle::from_untyped(untyped_handle, bridge.py_type_ptr());

--- a/src/assets/assets.rs
+++ b/src/assets/assets.rs
@@ -22,7 +22,7 @@
 //!   - Both `get()` and `get_mut()` allowed
 use std::{collections::VecDeque, sync::Arc};
 
-use bevy::prelude::World;
+use bevy::{ecs::world::unsafe_world_cell::UnsafeWorldCell, prelude::World};
 use pybevy_core::{
     handle::PyHandle,
     registry::{AssetBridge, global_registry},
@@ -48,8 +48,9 @@ pub struct PyAssets {
     type_ptr: *const PyTypeObject,
     /// If set, the `@material`-decorated class for auto-wrapping `get_mut()` results.
     wrapper_class: Option<*const PyTypeObject>,
-    // Raw pointer to World - SAFETY: Only valid when validity flag is true
-    world: *mut World,
+    /// World cell (lifetime-erased), valid only while the validity flag is active.
+    /// Used only to reach the declared `Assets<T>` resource through the AssetBridge.
+    cell: UnsafeWorldCell<'static>,
     // Runtime validity check with read/write mode - prevents use after system execution
     // and enforces Res[Assets[T]] (read-only) vs ResMut[Assets[T]] (mutable) semantics
     validity: ValidityFlagWithMode,
@@ -72,11 +73,12 @@ impl PyAssets {
     /// Create a new PyAssets wrapper
     ///
     /// # Safety
-    /// The provided world pointer must be valid for the lifetime of the ValidityFlag.
+    /// The provided world cell must reference the world holding the `Assets<T>`
+    /// resource and stay valid for as long as the ValidityFlag is active.
     pub(crate) unsafe fn new(
         type_ptr: *const PyTypeObject,
         wrapper_class: Option<*const PyTypeObject>,
-        world: *mut World,
+        cell: UnsafeWorldCell,
         validity: ValidityFlag,
         is_mutable: bool,
     ) -> Self {
@@ -86,10 +88,14 @@ impl PyAssets {
             AccessMode::Read
         };
 
+        // SAFETY: layout-preserving lifetime erasure of a Copy pointer type; the
+        // cell is only touched while `validity` is active.
+        let cell: UnsafeWorldCell<'static> = unsafe { std::mem::transmute(cell) };
+
         Self {
             type_ptr,
             wrapper_class,
-            world,
+            cell,
             validity: validity.with_access_mode(access_mode),
         }
     }
@@ -116,7 +122,11 @@ impl PyAssets {
     /// Get a reference to the world (read-only access)
     fn world_ref(&self) -> PyResult<&World> {
         self.validity.check_read()?;
-        Ok(unsafe { &*self.world })
+        // SAFETY: momentary derivation of a shared world reference, used only to reach
+        // the declared `Assets<T>` resource through the AssetBridge. `initialize`
+        // declares `Assets<T>` read access; the executor prevents a concurrent writer.
+        // This is the same residual-pointer class as query_runtime::world_ptr.
+        Ok(unsafe { self.cell.world() })
     }
 
     /// Get a mutable reference to the world
@@ -131,7 +141,11 @@ impl PyAssets {
             ));
         }
 
-        Ok(unsafe { &mut *self.world })
+        // SAFETY: momentary derivation of a mutable world reference, used only to reach
+        // the declared `Assets<T>` resource through the AssetBridge. `initialize`
+        // declares `Assets<T>` write access; the executor prevents a concurrent access.
+        // This is the same residual-pointer class as query_runtime::world_ptr.
+        Ok(unsafe { self.cell.world_mut() })
     }
 }
 

--- a/src/ecs/dynamic_system.rs
+++ b/src/ecs/dynamic_system.rs
@@ -40,14 +40,16 @@ use crate::{
             validity_guard::{ValidityFlag, ValidityGuard},
         },
         message::{PyMessageReader, PyMessageWriter},
-        messages::PyMessages,
+        messages::{MessageRegistry, MessageType, MessageWorld, PyMessages},
         mutable::PyMut,
         observer::PyOn,
         query::{
-            query_param::QueryData, query_runtime::PyQueryIter, single_runtime::PySingleQuery,
+            query_param::QueryData,
+            query_runtime::{CachedQuery, PyQueryIter},
+            single_runtime::PySingleQuery,
         },
         resource::PyResource,
-        resource_type::PyResourceType,
+        resource_type::{PyResourceStorage, PyResourceType, ResourceRegistry},
         system::{SystemFunction, SystemParamType},
         view::{view::PyView, view_param::ViewParamType},
         world::PyWorld,
@@ -169,6 +171,13 @@ pub struct DynamicSystem {
     suppressed_error_count: u32,
     /// Parameter-conflict error precomputed in `initialize` (`None` = no conflict)
     precomputed_validation: Option<SystemParamValidationError>,
+    /// One cached QueryState per Query parameter, built once in `initialize` and
+    /// reused across every run. Stored here (not inside the Arc<Mutex<inner>>) so it
+    /// lives as long as the DynamicSystem the schedule owns; `PyQueryIter` borrows
+    /// entries via raw pointer fenced by the per-run ValidityFlag. Indexed in the
+    /// order Query parameters appear in the system signature. Never touched by
+    /// `gut()`, which only releases Python refs held in the inner state.
+    query_caches: Vec<CachedQuery>,
 }
 
 // SAFETY: PyTypeObject pointers are stable for the lifetime of the Python interpreter
@@ -330,6 +339,7 @@ impl DynamicSystem {
             last_error_print_time: None,
             suppressed_error_count: 0,
             precomputed_validation: None,
+            query_caches: Vec::new(),
         };
 
         // Validate parameters immediately to catch conflicts early
@@ -507,6 +517,16 @@ impl System for DynamicSystem {
 
         self.validate_params()?;
 
+        // Advance the world change tick once per run, matching FunctionSystem so change
+        // detection windows advance even in an all-DynamicSystem schedule. We read
+        // change_tick() AFTER incrementing (not the value increment_change_tick returns)
+        // so `this_run` equals the tick pybevy's mutation write-backs stamp (both observe
+        // world.change_tick()); using the pre-increment value would make a system
+        // re-detect its own writes on the next frame. See stage-1 report.
+        world.increment_change_tick();
+        let this_run = world.change_tick();
+        let last_run = self.get_last_run();
+
         // Start timing for profiler (captures entire system execution)
         Python::attach(|py| {
             let start_time = Instant::now();
@@ -546,8 +566,12 @@ impl System for DynamicSystem {
                 None
             };
 
-            // Get world_mut for other parameters (unsafe: we know Commands won't conflict)
-            let world_mut = unsafe { world.world_mut() };
+            // No shared `&mut World` is materialized here: each parameter arm below
+            // reaches the world through the `UnsafeWorldCell` (narrow resource
+            // accessors, or per-operation pointer derivation inside the wrappers),
+            // so a non-exclusive system never conjures whole-world access. The one
+            // exception is the World arm, which derives its own `world.world_mut()`
+            // under the EXCLUSIVE-scheduling guarantee.
 
             // Lock the inner state to access system_func and message_cursor_storage
             let mut inner_guard = lock_or_recover(&self.inner);
@@ -563,6 +587,7 @@ impl System for DynamicSystem {
             };
 
             let mut message_reader_idx = 0usize;
+            let mut query_cache_idx = 0usize;
             for param in &system_func.params {
                 match &param.ty {
                     SystemParamType::Local(local) => {
@@ -579,12 +604,18 @@ impl System for DynamicSystem {
                             }
                         };
 
-                        // Use appropriate extraction method based on mutability
+                        // Use appropriate extraction method based on mutability.
+                        // Both paths go through narrow cell accessors so no `&World`
+                        // or `&mut World` is ever materialized for a resource read.
                         let resource = if *mutable {
-                            // Mutable access - get borrowed mutable reference
-                            let world_mut = unsafe { world.world_mut() };
-                            match resource_type.get_from_world_mut(world_mut, py, validity.clone())
-                            {
+                            // SAFETY: `initialize` declared write access to this
+                            // resource (AssetServer/Dynamic bridge id, or the
+                            // ResourceRegistry/PyResourceStorage reads for Custom);
+                            // the executor prevents a conflicting system from running
+                            // concurrently, so the cell's unchecked borrow is unique.
+                            match unsafe {
+                                resource_type.get_from_cell_mut(world, py, validity.clone())
+                            } {
                                 Ok(r) => r,
                                 Err(_e) => {
                                     let type_name = type_bound
@@ -600,9 +631,12 @@ impl System for DynamicSystem {
                                 }
                             }
                         } else {
-                            // Read-only access - get borrowed const reference
-                            let world_ref = unsafe { world.world() };
-                            match resource_type.get_from_world(world_ref, py, validity.clone()) {
+                            // SAFETY: `initialize` declared read access to this
+                            // resource; the executor prevents a concurrent writer, so
+                            // the cell's unchecked read is unique.
+                            match unsafe {
+                                resource_type.get_from_cell(world, py, validity.clone())
+                            } {
                                 Ok(r) => r,
                                 Err(_e) => {
                                     let type_name = type_bound
@@ -621,16 +655,25 @@ impl System for DynamicSystem {
 
                         Self::wrap_resource_in_res(py, resource, *mutable, &mut self.args_buffer);
                     }
-                    SystemParamType::Query { param: query_param } => {
-                        if query_param.single_entity_enforced {
-                            // Use PySingleQuery for Single<T> queries
+                    SystemParamType::Query { .. } => {
+                        // Static per-parameter state was built once in `initialize`;
+                        // borrow the cached QueryState by raw pointer (fenced by the
+                        // ValidityFlag) instead of rebuilding and conjuring `&mut World`.
+                        let cached = &self.query_caches[query_cache_idx];
+                        query_cache_idx += 1;
+                        if cached.single_entity_enforced {
+                            // SAFETY: `world` is this run's UnsafeWorldCell; the declared
+                            // access from `initialize` covers this cached state and the
+                            // executor prevents conflicting systems from running
+                            // concurrently, so the query's access is unique. `cached`
+                            // lives on the DynamicSystem, which outlives the run.
                             let single_query = unsafe {
                                 PySingleQuery::new(
-                                    query_param.clone(),
-                                    world_mut,
-                                    Arc::new(self.custom_component_ids.clone()),
+                                    cached,
+                                    world,
                                     validity.clone(),
-                                    self.get_last_run(),
+                                    last_run,
+                                    this_run,
                                 )
                             };
 
@@ -638,14 +681,15 @@ impl System for DynamicSystem {
                                 Py::new(py, single_query).expect("Failed to create PySingleQuery");
                             self.args_buffer.push(obj.into_any());
                         } else {
-                            // Use PyQueryIter for normal Query<T> queries
+                            // SAFETY: as above — unique access to the cached state's
+                            // components is guaranteed by the declared-access scheduling.
                             let query_runtime = unsafe {
                                 PyQueryIter::new(
-                                    query_param.clone(),
-                                    world_mut,
-                                    Arc::new(self.custom_component_ids.clone()),
+                                    cached,
+                                    world,
                                     validity.clone(),
-                                    self.get_last_run(),
+                                    last_run,
+                                    this_run,
                                 )
                             };
 
@@ -673,6 +717,10 @@ impl System for DynamicSystem {
                         let added_filter_types = param.added_filters.to_vec();
                         let last_run = self.get_last_run();
 
+                        // SAFETY: `world` is this run's UnsafeWorldCell; PyView reads
+                        // this_run via cell.change_tick() and derives per-operation
+                        // world pointers internally, bounded by the view's declared
+                        // component read/write access from `initialize`.
                         let py_view = unsafe {
                             PyView::new_with_filters(
                                 component_types,
@@ -682,7 +730,7 @@ impl System for DynamicSystem {
                                 changed_filter_types,
                                 added_filter_types,
                                 last_run,
-                                world_mut,
+                                world,
                                 validity.clone(),
                             )
                         };
@@ -690,7 +738,13 @@ impl System for DynamicSystem {
                         self.args_buffer.push(obj.into_any());
                     }
                     SystemParamType::World => {
-                        // Create PyWorld wrapper for exclusive world access
+                        // A World param requests exclusive access: `flags()` marks this
+                        // system EXCLUSIVE, so the executor runs it with no other
+                        // system in flight (initialize declares an empty access set,
+                        // matching Bevy's ExclusiveFunctionSystem).
+                        // SAFETY: exclusive scheduling guarantees this `&mut World` is
+                        // the only borrow of the world for the duration of the run.
+                        let world_mut = unsafe { world.world_mut() };
                         let py_world = unsafe { PyWorld::new(world_mut, validity.clone()) };
                         let obj = Py::new(py, py_world).expect("Failed to create PyWorld");
                         self.args_buffer.push(obj.into_any());
@@ -705,21 +759,24 @@ impl System for DynamicSystem {
                         self.args_buffer.push(obj.into_any());
                     }
                     SystemParamType::MessageWriter { message_type } => {
-                        // Create PyMessageWriter wrapper with world access
-
-                        let py_world = unsafe { PyWorld::new(world_mut, validity.clone()) };
+                        // Create PyMessageWriter with narrow cell-based world access.
+                        // SAFETY: `initialize` declares write access for this
+                        // writer's Messages<T> id; the writer only reaches that buffer.
+                        let mw = unsafe { MessageWorld::new(world, validity.clone()) };
                         let py_writer = PyMessageWriter {
                             message_type: message_type.clone(),
-                            world: py_world,
+                            world: mw,
                         };
                         let obj = Py::new(py, py_writer).expect("Failed to create PyMessageWriter");
                         self.args_buffer.push(obj.into_any());
                     }
                     SystemParamType::MessageReader { message_type } => {
-                        // Create PyMessageReader wrapper with world access and persistent cursor
-
-                        let py_world_1 = unsafe { PyWorld::new(world_mut, validity.clone()) };
-                        let py_world_2 = unsafe { PyWorld::new(world_mut, validity.clone()) };
+                        // Create PyMessageReader with narrow cell-based world access.
+                        // SAFETY: `initialize` declares reads for this reader's
+                        // resource ids (Messages<T>, plus ButtonInput<KeyCode> for
+                        // KeyboardInput); the reader only reaches those.
+                        let mw_1 = unsafe { MessageWorld::new(world, validity.clone()) };
+                        let mw_2 = unsafe { MessageWorld::new(world, validity.clone()) };
                         let cursor = inner_guard
                             .message_cursor_storage
                             .get(message_reader_idx)
@@ -727,11 +784,11 @@ impl System for DynamicSystem {
                         message_reader_idx += 1;
                         let py_messages = PyMessages {
                             message_type: message_type.clone(),
-                            world: py_world_1,
+                            world: mw_1,
                             cursor_storage: cursor,
                         };
                         let py_reader = PyMessageReader {
-                            world: py_world_2,
+                            world: mw_2,
                             messages: py_messages,
                         };
                         let obj = Py::new(py, py_reader).expect("Failed to create PyMessageReader");
@@ -749,12 +806,15 @@ impl System for DynamicSystem {
                         wrapper_class,
                         mutable,
                     } => {
-                        // Create PyAssets wrapper with world access
+                        // Create PyAssets wrapper with cell-based world access.
+                        // SAFETY: `world` is this run's UnsafeWorldCell; `initialize`
+                        // declares this Assets<T> resource's access, which
+                        // bounds the data PyAssets reaches via the AssetBridge.
                         let py_assets = unsafe {
                             PyAssets::new(
                                 type_ptr.0,
                                 wrapper_class.map(|w| w.0),
-                                world_mut,
+                                world,
                                 validity.clone(),
                                 *mutable,
                             )
@@ -959,7 +1019,14 @@ impl System for DynamicSystem {
             }
         });
 
-        // Update last_run tick for change detection (same as FunctionSystem::run_unsafe)
+        // Record last_run as the world change tick read AFTER the run's writes, not the
+        // `this_run` captured at the top. Unlike a Bevy FunctionSystem (whose writes flow
+        // through params stamped with `this_run`), pybevy's writes stamp `world.change_tick()`
+        // live at write time (View batch writes, custom-component write-back). If the tick
+        // advances between `this_run`'s capture and those writes, storing `this_run` would
+        // leave last_run < the write tick and the same system would re-detect its own writes
+        // as changes on the next frame. Reading the tick here guarantees last_run covers
+        // every write this run made, matching the pre-existing (pre-increment) behavior.
         self.last_run = Some(world.change_tick());
 
         Ok(())
@@ -1075,6 +1142,21 @@ impl System for DynamicSystem {
                                 self.resources_to_read.push(id);
                             }
                         }
+                        // Custom Python resources live inside `PyResourceStorage`,
+                        // keyed through `ResourceRegistry`; `run_unsafe`'s cell read
+                        // path touches both (see PyResourceType::get_custom_from_cell),
+                        // so declare those reads to keep declared >= actual access.
+                        // Both read and write params only READ these two resources
+                        // (the write path returns the same stored Python object).
+                        if matches!(rt, PyResourceType::Custom(_)) {
+                            let registry_id = world.register_component::<ResourceRegistry>();
+                            let storage_id = world.register_component::<PyResourceStorage>();
+                            for id in [registry_id, storage_id] {
+                                if !self.resources_to_read.contains(&id) {
+                                    self.resources_to_read.push(id);
+                                }
+                            }
+                        }
                     }
                 }
                 SystemParamType::Assets {
@@ -1133,7 +1215,10 @@ impl System for DynamicSystem {
                     // Local state doesn't affect world access
                 }
                 SystemParamType::World => {
-                    // World access requires exclusive access - no filtering needed
+                    // A World param means the system wants exclusive access. `flags()`
+                    // marks it EXCLUSIVE and initialize returns an EMPTY access set for
+                    // it (see the exclusive early-return below), exactly like Bevy's
+                    // ExclusiveFunctionSystem.
                 }
                 SystemParamType::Commands => {
                     // Commands don't require specific component access
@@ -1146,6 +1231,15 @@ impl System for DynamicSystem {
                     if let Some(id) = message_type.register_resource_id(world) {
                         self.resources_to_write.push(id);
                     }
+                    // Custom message paths resolve their message number through the
+                    // MessageRegistry resource at run time; declare that read so
+                    // declared access covers the actual access.
+                    if matches!(message_type, MessageType::Custom(_)) {
+                        let registry_id = world.register_component::<MessageRegistry>();
+                        if !self.resources_to_read.contains(&registry_id) {
+                            self.resources_to_read.push(registry_id);
+                        }
+                    }
                 }
                 SystemParamType::MessageReader { message_type } => {
                     // reader_resource_ids returns the primary Messages<T> id plus any
@@ -1155,6 +1249,15 @@ impl System for DynamicSystem {
                             self.resources_to_read.push(id);
                         }
                     }
+                    // Custom message paths resolve their message number through the
+                    // MessageRegistry resource at run time; declare that read so
+                    // declared access covers the actual access.
+                    if matches!(message_type, MessageType::Custom(_)) {
+                        let registry_id = world.register_component::<MessageRegistry>();
+                        if !self.resources_to_read.contains(&registry_id) {
+                            self.resources_to_read.push(registry_id);
+                        }
+                    }
                 }
                 SystemParamType::On { .. } => {
                     // Observers don't require component access registration
@@ -1162,6 +1265,26 @@ impl System for DynamicSystem {
                 }
             }
         }
+
+        // Build (or rebuild) the per-Query-parameter cached QueryState now that all
+        // component ids are resolved. `initialize` legitimately holds `&mut World`, so
+        // this heavy work (id registration, QueryState construction, extraction/access
+        // arrays) happens once per parameter instead of on every run. The snapshot of
+        // custom_component_ids is complete because the loop above already registered
+        // every custom component this system's queries reference. Iterating `params`
+        // in signature order keeps `query_caches` aligned with `run_unsafe`'s counter.
+        let cc_snapshot = Arc::new(self.custom_component_ids.clone());
+        let mut query_caches = Vec::new();
+        for param in &params {
+            if let SystemParamType::Query { param: query_param } = &param.ty {
+                query_caches.push(CachedQuery::build(
+                    world,
+                    query_param.clone(),
+                    cc_snapshot.clone(),
+                ));
+            }
+        }
+        self.query_caches = query_caches;
 
         // run_unsafe's generation guard reads HotReloadGeneration
         let generation_id = world.register_component::<HotReloadGeneration>();
@@ -1221,6 +1344,23 @@ impl System for DynamicSystem {
                     )
                 });
 
+        // Exclusive systems declare NO access, exactly like Bevy's
+        // ExclusiveFunctionSystem (its initialize returns FilteredAccessSet::new()).
+        // The EXCLUSIVE flag alone makes the executor run them with nothing else in
+        // flight, which is what soundly covers run_unsafe's `world.world_mut()`.
+        // Declaring read_all+write_all here instead gives the schedule an asymmetric
+        // conflict graph next to Bevy's empty-access exclusive systems and wedges
+        // MultiThreadedExecutor's ready-queue accounting: three or more exclusive
+        // systems mixing both shapes in one schedule die on its
+        // `ready_systems.is_clear()` assertion. Registrations above still ran, so
+        // ids and query caches are ready for run time.
+        if params
+            .iter()
+            .any(|p| matches!(p.ty, SystemParamType::World))
+        {
+            return FilteredAccessSet::default();
+        }
+
         // One FilteredAccess per Query/View parameter, plus one shared access for
         // all resource-like reads/writes. `FilteredAccessSet::is_compatible` does
         // the pairwise filter checks that keep genuinely conflicting systems from
@@ -1236,7 +1376,16 @@ impl System for DynamicSystem {
         set
     }
 
-    fn check_change_tick(&mut self, _check: CheckChangeTicks) {}
+    fn check_change_tick(&mut self, check: CheckChangeTicks) {
+        // Clamp our stored last_run so it never ages past the change-detection
+        // window, mirroring FunctionSystem's check_system_change_tick. Bevy's
+        // QueryState exposes no tick-check method (it caches archetype/access data,
+        // not change ticks), so clamping last_run is the whole job; every cached
+        // query reads this last_run at the start of each run.
+        if let Some(last_run) = self.last_run.as_mut() {
+            last_run.check_tick(check);
+        }
+    }
 
     fn get_last_run(&self) -> Tick {
         self.last_run.unwrap_or(Tick::new(0))
@@ -1369,6 +1518,14 @@ pub(crate) fn execute_system_func(
     world: &mut World,
     on_param: Py<PyOn>,
 ) -> PyResult<()> {
+    // Transient per-Query cached states for this observer dispatch. Observers have no
+    // DynamicSystem cache (they run outside the schedule), but they hold an exclusive
+    // `&mut World`, so building a CachedQuery here is sound. Boxed so each state has a
+    // stable heap address while a PyQueryIter holds a raw pointer to it. Declared before
+    // the validity guard so it drops LAST: the guard invalidates the shared flag before
+    // these caches are freed, so any leaked PyQueryIter sees "invalid" before use.
+    let mut transient_caches: Vec<Box<CachedQuery>> = Vec::new();
+
     let validity = ValidityFlag::new();
     let _validity_guard = ValidityGuard::new(validity.clone());
 
@@ -1397,27 +1554,38 @@ pub(crate) fn execute_system_func(
                 args_buffer.push(obj.into_any());
             }
             SystemParamType::Query { param: query_param } => {
+                // Build a transient cached state; the exclusive &mut World makes this
+                // sound in the observer context (no parallel systems here).
+                transient_caches.push(Box::new(CachedQuery::build(
+                    world,
+                    query_param.clone(),
+                    custom_component_ids.clone(),
+                )));
+                let this_run = world.change_tick();
+                let cell = world.as_unsafe_world_cell();
+                // The box's heap address is stable across later pushes, so this
+                // reference (used only to hand a pointer to the query) stays valid.
+                let cached_ref: &CachedQuery = transient_caches.last().unwrap();
                 if query_param.single_entity_enforced {
+                    // SAFETY: exclusive &mut World during observer dispatch; the cached
+                    // state and cell reference this same World. `transient_caches` keeps
+                    // the box alive until after the Python call. No prior run for
+                    // observers, so last_run = Tick(0).
                     let single_query = unsafe {
                         PySingleQuery::new(
-                            query_param.clone(),
-                            world,
-                            custom_component_ids.clone(),
+                            cached_ref,
+                            cell,
                             validity.clone(),
-                            Tick::new(0), // No prior run for observers
+                            Tick::new(0),
+                            this_run,
                         )
                     };
                     let obj = Py::new(py, single_query).expect("Failed to create PySingleQuery");
                     args_buffer.push(obj.into_any());
                 } else {
+                    // SAFETY: see above.
                     let query_runtime = unsafe {
-                        PyQueryIter::new(
-                            query_param.clone(),
-                            world,
-                            custom_component_ids.clone(),
-                            validity.clone(),
-                            Tick::new(0), // No prior run for observers
-                        )
+                        PyQueryIter::new(cached_ref, cell, validity.clone(), Tick::new(0), this_run)
                     };
                     let obj = Py::new(py, query_runtime).expect("Failed to create PyQueryIter");
                     args_buffer.push(obj.into_any());
@@ -1455,11 +1623,13 @@ pub(crate) fn execute_system_func(
                 wrapper_class,
                 mutable,
             } => {
+                // SAFETY: observer dispatch holds an exclusive `&mut World`; the cell
+                // derived from it is fenced by `validity`.
                 let py_assets = unsafe {
                     PyAssets::new(
                         type_ptr.0,
                         wrapper_class.map(|w| w.0),
-                        world,
+                        world.as_unsafe_world_cell(),
                         validity.clone(),
                         *mutable,
                     )
@@ -1491,6 +1661,8 @@ pub(crate) fn execute_system_func(
                 let without_filter_types = param.without_filters.to_vec();
                 let changed_filter_types = param.changed_filters.to_vec();
                 let added_filter_types = param.added_filters.to_vec();
+                // SAFETY: observer dispatch holds an exclusive `&mut World`; the cell
+                // derived from it is fenced by `validity`.
                 let py_view = unsafe {
                     PyView::new_with_filters(
                         component_types,
@@ -1500,7 +1672,7 @@ pub(crate) fn execute_system_func(
                         changed_filter_types,
                         added_filter_types,
                         Tick::new(0), // No prior run for observers
-                        world,
+                        world.as_unsafe_world_cell(),
                         validity.clone(),
                     )
                 };
@@ -1508,24 +1680,31 @@ pub(crate) fn execute_system_func(
                 args_buffer.push(obj.into_any());
             }
             SystemParamType::MessageWriter { message_type } => {
-                let py_world = unsafe { PyWorld::new(world, validity.clone()) };
+                // SAFETY: observer dispatch holds an exclusive `&mut World`; the cell
+                // derived from it is fenced by `validity`.
+                let mw =
+                    unsafe { MessageWorld::new(world.as_unsafe_world_cell(), validity.clone()) };
                 let py_writer = PyMessageWriter {
                     message_type: message_type.clone(),
-                    world: py_world,
+                    world: mw,
                 };
                 let obj = Py::new(py, py_writer).expect("Failed to create PyMessageWriter");
                 args_buffer.push(obj.into_any());
             }
             SystemParamType::MessageReader { message_type } => {
-                let py_world_1 = unsafe { PyWorld::new(world, validity.clone()) };
-                let py_world_2 = unsafe { PyWorld::new(world, validity.clone()) };
+                // SAFETY: observer dispatch holds an exclusive `&mut World`; the cells
+                // derived from it are fenced by `validity`.
+                let mw_1 =
+                    unsafe { MessageWorld::new(world.as_unsafe_world_cell(), validity.clone()) };
+                let mw_2 =
+                    unsafe { MessageWorld::new(world.as_unsafe_world_cell(), validity.clone()) };
                 let py_messages = PyMessages {
                     message_type: message_type.clone(),
-                    world: py_world_1,
+                    world: mw_1,
                     cursor_storage: None,
                 };
                 let py_reader = PyMessageReader {
-                    world: py_world_2,
+                    world: mw_2,
                     messages: py_messages,
                 };
                 let obj = Py::new(py, py_reader).expect("Failed to create PyMessageReader");

--- a/src/ecs/message.rs
+++ b/src/ecs/message.rs
@@ -17,7 +17,7 @@ use super::{
         CustomMessage6, CustomMessage7, CustomMessage8, CustomMessage9, CustomMessage10,
         CustomMessage11, CustomMessage12, CustomMessage13, CustomMessage14, CustomMessage15,
         CustomMessage16, CustomMessage17, CustomMessage18, CustomMessage19, CustomMessage20,
-        MessageRegistry, MessageType, PyMessages,
+        MessageRegistry, MessageType, MessageWorld, PyMessages,
     },
     world::PyWorld,
 };
@@ -71,7 +71,7 @@ pub struct MessageTypeParam {
 #[pyclass(name = "MessageWriter", frozen)]
 pub struct PyMessageWriter {
     pub(crate) message_type: MessageType,
-    pub(crate) world: PyWorld,
+    pub(crate) world: MessageWorld,
 }
 
 impl PyMessageWriter {
@@ -239,7 +239,7 @@ impl PyMessageWriter {
 #[pyclass(name = "MessageReader", frozen)]
 pub struct PyMessageReader {
     #[allow(dead_code)] // retained for potential future direct-world access
-    pub(crate) world: PyWorld,
+    pub(crate) world: MessageWorld,
     pub(crate) messages: PyMessages,
 }
 

--- a/src/ecs/messages.rs
+++ b/src/ecs/messages.rs
@@ -10,7 +10,7 @@ use bevy::{
         component::ComponentId,
         message::{Message, MessageCursor, Messages},
         resource::Resource,
-        world::World,
+        world::{World, unsafe_world_cell::UnsafeWorldCell},
     },
     image::Image,
     input::{
@@ -31,7 +31,52 @@ use pyo3::{
 pub(crate) type CursorStorage = Arc<Mutex<Option<Box<dyn Any + Send + Sync>>>>;
 
 use super::message::{PyMessage, PyMessageId};
-use crate::ecs::{resource::PyResource, world::PyWorld};
+use crate::ecs::{helpers::validity_guard::ValidityFlag, resource::PyResource};
+
+/// Narrow world access for message wrappers.
+///
+/// Holds the lifetime-erased [`UnsafeWorldCell`] (fenced by the same `ValidityFlag`
+/// as `PyQueryIter`) and derives a momentary `&mut World` per operation. The
+/// message macros/bridges only reach their `Messages<T>` resource (plus
+/// `MessageRegistry` and, for KeyboardInput readers, `ButtonInput<KeyCode>`), all
+/// of which `DynamicSystem::initialize` declares. This is the same
+/// residual-pointer class as `query_runtime::world_ptr`.
+#[derive(Clone)]
+pub(crate) struct MessageWorld {
+    cell: UnsafeWorldCell<'static>,
+    validity: ValidityFlag,
+}
+
+// SAFETY: mirrors PyQueryIter's discipline. The cell is only touched while the
+// owning system runs on a single thread, fenced by `validity`.
+unsafe impl Send for MessageWorld {}
+unsafe impl Sync for MessageWorld {}
+
+impl MessageWorld {
+    /// # Safety
+    /// `cell` must reference the world holding the message buffers and stay valid
+    /// for as long as `validity` is active.
+    pub(crate) unsafe fn new(cell: UnsafeWorldCell, validity: ValidityFlag) -> Self {
+        // SAFETY: layout-preserving lifetime erasure of a Copy pointer type; the
+        // cell is only touched while `validity` is active.
+        let cell: UnsafeWorldCell<'static> = unsafe { std::mem::transmute(cell) };
+        Self { cell, validity }
+    }
+
+    /// Momentary `&mut World` for the message macros/bridges (they take `&mut World`
+    /// but only touch the declared `Messages<T>` resource).
+    ///
+    /// SAFETY of the returned reference: `initialize` declares reads for
+    /// reader resource ids and writes for writer ids; the executor prevents a
+    /// conflicting system running concurrently, so the actual message access is
+    /// unique. Same residual-pointer class as `query_runtime::world_ptr`.
+    #[allow(clippy::mut_from_ref)]
+    pub(crate) fn world_mut(&self) -> PyResult<&mut World> {
+        self.validity.check()?;
+        // SAFETY: momentary derivation; see method docs.
+        Ok(unsafe { self.cell.world_mut() })
+    }
+}
 
 // Macro to generate CustomMessage types
 macro_rules! define_custom_messages {
@@ -119,7 +164,7 @@ macro_rules! with_messages_arms {
 #[pyclass(name = "Messages", extends = PyResource, frozen)]
 pub struct PyMessages {
     pub(crate) message_type: MessageType,
-    pub(crate) world: PyWorld,
+    pub(crate) world: MessageWorld,
     /// Persistent cursor for MessageReader iteration.
     /// When Some, iter_to_python uses the stored cursor to avoid re-reading messages.
     /// When None, creates a fresh cursor each time (legacy behavior).

--- a/src/ecs/query/query_runtime.rs
+++ b/src/ecs/query/query_runtime.rs
@@ -5,7 +5,7 @@ use bevy::{
         change_detection::{ComponentTicks, Tick},
         component::ComponentId,
         query::{QueryIter, QueryState},
-        world::{FilteredEntityMut, FilteredEntityRef},
+        world::{FilteredEntityMut, FilteredEntityRef, unsafe_world_cell::UnsafeWorldCell},
     },
     prelude::*,
 };
@@ -65,42 +65,43 @@ impl ErasedQueryState {
     }
 
     /// Count matching entities (O(n) - iterates all).
-    fn count(&self, world: &World) -> usize {
+    ///
+    /// SAFETY: declared access from `initialize` covers this state's access and the
+    /// executor prevents conflicting systems from running concurrently, so the
+    /// unchecked query has unique access to the components it reads.
+    fn count(&self, cell: UnsafeWorldCell, last_run: Tick, this_run: Tick) -> usize {
         let (read_only, p) = self.parts();
         unsafe {
             if read_only {
-                (&*(p as *const QueryState<FilteredEntityRef>))
-                    .iter_manual(world)
+                let qs = &mut *(p as *mut QueryState<FilteredEntityRef>);
+                qs.query_unchecked_with_ticks(cell, last_run, this_run)
+                    .iter_inner()
                     .count()
             } else {
-                (&*(p as *const QueryState<FilteredEntityMut>))
-                    .iter_manual(world)
+                let qs = &mut *(p as *mut QueryState<FilteredEntityMut>);
+                qs.query_unchecked_with_ticks(cell, last_run, this_run)
+                    .iter_inner()
                     .count()
             }
         }
     }
 
     /// Check if no entities match.
-    fn is_empty_check(
-        &self,
-        world: &World,
-        last_tick: bevy::ecs::change_detection::Tick,
-        current_tick: bevy::ecs::change_detection::Tick,
-    ) -> bool {
+    ///
+    /// SAFETY: declared access from `initialize` covers this state's access and the
+    /// executor prevents conflicting systems from running concurrently, so the
+    /// unchecked query has unique access to the components it reads.
+    fn is_empty_check(&self, cell: UnsafeWorldCell, last_run: Tick, this_run: Tick) -> bool {
         let (read_only, p) = self.parts();
         unsafe {
             if read_only {
-                (&*(p as *const QueryState<FilteredEntityRef>)).is_empty(
-                    world,
-                    last_tick,
-                    current_tick,
-                )
+                let qs = &mut *(p as *mut QueryState<FilteredEntityRef>);
+                qs.query_unchecked_with_ticks(cell, last_run, this_run)
+                    .is_empty()
             } else {
-                (&*(p as *const QueryState<FilteredEntityMut>)).is_empty(
-                    world,
-                    last_tick,
-                    current_tick,
-                )
+                let qs = &mut *(p as *mut QueryState<FilteredEntityMut>);
+                qs.query_unchecked_with_ticks(cell, last_run, this_run)
+                    .is_empty()
             }
         }
     }
@@ -108,42 +109,58 @@ impl ErasedQueryState {
 
 /// Create a new lazy iterator. Freestanding to avoid borrowing ErasedQueryState.
 ///
-/// SAFETY: `qs_ptr` must point to a valid QueryState of the type indicated by `read_only`.
-/// `world_ptr` must point to a valid World for the duration of iteration.
+/// Uses `query_unchecked_with_ticks`, which calls `update_archetypes_unsafe_world_cell`
+/// internally, so the cached state picks up archetypes created since `initialize`.
+/// Ticks flow explicitly so per-entity Changed/Added checks stay consistent.
+///
+/// SAFETY: `qs_ptr` must point to a valid QueryState of the type indicated by
+/// `read_only`. `cell` must point to the World this state was initialized from.
+/// The declared access from `initialize` covers this state and the executor
+/// prevents conflicting systems from running concurrently, so the unchecked
+/// query has unique access to the components it touches.
 unsafe fn erased_create_iter(
     read_only: bool,
     qs_ptr: *mut (),
-    mut world_ptr: NonNull<World>,
+    cell: UnsafeWorldCell,
+    last_run: Tick,
+    this_run: Tick,
 ) -> ErasedQueryIter {
     if read_only {
         let qs = unsafe { &mut *(qs_ptr as *mut QueryState<FilteredEntityRef>) };
-        let iter = qs.iter(unsafe { world_ptr.as_ref() });
+        let iter = unsafe { qs.query_unchecked_with_ticks(cell, last_run, this_run) }.iter_inner();
         ErasedQueryIter::ReadOnly(Box::into_raw(Box::new(iter)) as *mut ())
     } else {
         let qs = unsafe { &mut *(qs_ptr as *mut QueryState<FilteredEntityMut>) };
-        let iter = qs.iter_mut(unsafe { world_ptr.as_mut() });
+        let iter = unsafe { qs.query_unchecked_with_ticks(cell, last_run, this_run) }.iter_inner();
         ErasedQueryIter::Mutable(Box::into_raw(Box::new(iter)) as *mut ())
     }
 }
 
 /// Look up a single entity by ID. Freestanding to avoid borrowing ErasedQueryState.
 ///
-/// SAFETY: `qs_ptr` must point to a valid QueryState of the type indicated by `read_only`.
-/// `world_ptr` must point to a valid World.
+/// SAFETY: `qs_ptr` must point to a valid QueryState of the type indicated by
+/// `read_only`. `cell` must point to the World this state was initialized from.
+/// The declared access from `initialize` covers this state and the executor
+/// prevents conflicting systems from running concurrently, so the unchecked
+/// query has unique access to the components it touches.
 unsafe fn erased_get_entity<'a>(
     read_only: bool,
     qs_ptr: *mut (),
-    mut world_ptr: NonNull<World>,
+    cell: UnsafeWorldCell<'a>,
+    last_run: Tick,
+    this_run: Tick,
     entity: Entity,
 ) -> Option<FilteredEntityAccess<'a, 'a>> {
     if read_only {
         let qs = unsafe { &mut *(qs_ptr as *mut QueryState<FilteredEntityRef>) };
-        qs.get(unsafe { world_ptr.as_ref() }, entity)
+        unsafe { qs.query_unchecked_with_ticks(cell, last_run, this_run) }
+            .get_inner(entity)
             .ok()
             .map(FilteredEntityAccess::Ref)
     } else {
         let qs = unsafe { &mut *(qs_ptr as *mut QueryState<FilteredEntityMut>) };
-        qs.get_mut(unsafe { world_ptr.as_mut() }, entity)
+        unsafe { qs.query_unchecked_with_ticks(cell, last_run, this_run) }
+            .get_inner(entity)
             .ok()
             .map(FilteredEntityAccess::Mut)
     }
@@ -217,105 +234,62 @@ impl Drop for ErasedQueryIter {
     }
 }
 
-/// Runtime query iterator that can be passed to Python systems.
-/// Uses Bevy's QueryState for efficient cached iteration.
+/// Static, per-Query-parameter state built once in `DynamicSystem::initialize` and
+/// reused across every run. Owns the heavy `ErasedQueryState` plus the resolved
+/// component-id caches, extraction function pointers, access modes and tick-filter
+/// ids that would otherwise be recomputed on every `PyQueryIter::new`.
 ///
-/// SAFETY: This struct uses unsafe transmute to erase the lifetime from QueryState.
-/// It must only be used within the scope of a system execution and must not escape
-/// the Python GIL callback. Python code must not store references to this object
-/// or any iterators derived from it beyond the system function scope.
-///
-/// # Performance Notes
-/// For benchmarking, the main bottlenecks are typically:
-/// 1. Bevy's `iter.next()` - iterating entities and fetching components
-/// 2. `Py::new()` - creating Python wrapper objects (PyTransformMut, etc.)
-/// 3. `clone_ref(py)` - Python reference counting overhead
-/// 4. `PyTuple::new()` - allocating tuples for multi-component returns
-/// 5. GIL acquisition/release (handled by PyO3 automatically)
-#[pyclass(name = "QueryIter")]
-pub struct PyQueryIter {
-    /// The query parameter information (shared via Arc to avoid clones)
-    param: Arc<PyQueryParam>,
+/// Stored on `DynamicSystem` (which the schedule owns and which outlives every run),
+/// so `PyQueryIter` can borrow it via a raw pointer fenced by the same `ValidityFlag`
+/// that fences the world cell.
+pub struct CachedQuery {
+    /// The query parameter information (shared via Arc to avoid clones).
+    pub param: Arc<PyQueryParam>,
 
     /// The Bevy QueryState (type-erased, owns the heap allocation).
     query_state: ErasedQueryState,
 
-    /// Current lazy iterator state (created on first `__next__` call).
-    query_iter: Option<ErasedQueryIter>,
-
-    /// Raw pointer to the World (only valid during system execution)
-    /// SAFETY: This pointer is only valid within the scope of the system execution
-    world_ptr: Option<NonNull<World>>,
-
-    /// Maps PyComponentType to their registered ComponentIds (cached for fast access)
-    /// Stores component IDs for all queried components for efficient lookup
+    /// Maps PyComponentType to their registered ComponentIds (cached for fast access).
     component_id_cache: HashMap<PyComponentType, ComponentId>,
 
-    /// Maps custom component type pointers to their registered ComponentIds (shared via Arc)
+    /// Maps custom component type pointers to their registered ComponentIds (shared via Arc).
     custom_component_ids: Arc<HashMap<*const PyTypeObject, ComponentId>>,
 
-    /// Reusable buffer for return values - avoids allocation on every __next__ call
-    /// SmallVec[8] keeps up to 8 items on stack (most queries have 1-4 params)
-    values_buffer: SmallVec<[Py<PyAny>; 8]>,
-
-    /// Master validity flag - invalidated when system exits (RAII via ValidityGuard)
-    /// All component proxies check this to ensure they're only used during system execution
-    validity: ValidityFlag,
-
-    /// Per-parameter access modes (Read or Write)
-    /// Indexed by parameter position, determines if a component can be read-only or mutated
+    /// Per-parameter access modes (Read or Write), indexed by parameter position.
     param_access_modes: SmallVec<[AccessMode; 8]>,
 
     /// Extraction function pointers for Dynamic components, indexed by parameter position.
-    /// None for non-Dynamic parameters, Some(fn) for Dynamic components.
-    /// This eliminates HashMap lookup overhead during per-entity iteration.
     extract_fns: SmallVec<[Option<ExtractFn>; 8]>,
-
-    /// True while iteration is in progress (__next__ has been called but not yet exhausted).
-    /// Used to detect and reject nested iteration (which would silently corrupt state),
-    /// matching Bevy's borrow-checker prevention of nested query.iter() calls.
-    iterating: bool,
-
-    /// Cached ComponentLayouts and storage types for custom wrapper components, keyed by type pointer.
-    /// Avoids re-parsing Python __annotations__ and __pybevy_storage__ on every entity iteration.
-    layout_cache: RefCell<
-        HashMap<
-            *const PyTypeObject,
-            (
-                crate::ecs::component_layout::ComponentStorageType,
-                Option<Arc<crate::ecs::component_layout::ComponentLayout>>,
-            ),
-        >,
-    >,
 
     /// ComponentIds for Changed[T] tick filters - entities must pass per-entity tick check.
     changed_filter_ids: Vec<ComponentId>,
     /// ComponentIds for Added[T] tick filters - entities must pass per-entity tick check.
     added_filter_ids: Vec<ComponentId>,
-    /// System's last_run tick (from DynamicSystem::get_last_run()).
-    last_run: Tick,
-    /// Current world change tick (captured during new()).
-    this_run: Tick,
+
+    /// Whether this query was declared as `Single<T>` (enforces exactly one match).
+    pub single_entity_enforced: bool,
 }
 
-// SAFETY: PyQueryIter is only used during system execution on a single thread.
-// The world pointer and query state are only accessed during system execution and never across threads.
-// Arc<PyQueryParam> and Arc<HashMap> are already Send/Sync.
-unsafe impl Send for PyQueryIter {}
-unsafe impl Sync for PyQueryIter {}
+// SAFETY: CachedQuery mirrors the Send/Sync discipline of the old PyQueryIter: the
+// raw QueryState pointer and the Arc<HashMap> of type pointers are only ever touched
+// while the owning DynamicSystem runs on a single thread. DynamicSystem is already
+// declared Send + Sync; this makes the intent explicit for the standalone type.
+unsafe impl Send for CachedQuery {}
+unsafe impl Sync for CachedQuery {}
 
-impl PyQueryIter {
-    /// Creates a new runtime query from a Bevy world
+impl CachedQuery {
+    /// Build the cached query state for a single Query parameter.
     ///
-    /// SAFETY: The world pointer must remain valid for the lifetime of this object
-    pub unsafe fn new(
-        param: Arc<PyQueryParam>,
+    /// This performs all the static, per-system work (component-id registration,
+    /// filter-id collection, QueryState construction, extraction fn/access-mode
+    /// arrays) that would otherwise run on every `PyQueryIter::new`. `initialize` legitimately
+    /// holds `&mut World`, so building here is sound and happens once per parameter.
+    pub fn build(
         world: &mut World,
+        param: Arc<PyQueryParam>,
         custom_component_ids: Arc<HashMap<*const PyTypeObject, ComponentId>>,
-        validity: ValidityFlag,
-        last_run: Tick,
     ) -> Self {
-        // First, collect and register all component IDs (tracking optional and mutable status)
+        // Collect and register all component IDs (tracking optional and mutable status)
         let mut component_ids = Vec::new();
         for param_type in &param.data {
             if let QueryData::Component {
@@ -387,7 +361,6 @@ impl PyQueryIter {
         // Retain filter IDs for per-entity tick checking (they get moved into QueryBuildSpec)
         let tick_changed_ids = changed_filter_ids.clone();
         let tick_added_ids = added_filter_ids.clone();
-        let this_run = world.change_tick();
 
         // Build the QueryState once
         let spec = QueryBuildSpec {
@@ -399,8 +372,6 @@ impl PyQueryIter {
             anyof_filters: anyof_filter_ids,
         };
         // Build the correct QueryState variant.
-        // SAFETY: Lifetime is erased — the caller guarantees this is only used
-        // within the system execution scope where the World reference is valid.
         // Use FilteredEntityRef for all-read-only queries to enable parallel scheduling.
         let query_state = if spec.is_read_only() {
             ErasedQueryState::from_ref(build_query_state_ref(world, &spec))
@@ -413,14 +384,12 @@ impl PyQueryIter {
         let mut component_idx = 0; // Track index in component_ids vec
         for param_type in param.data.iter() {
             if let QueryData::Component { ty, .. } = param_type {
-                // Get the corresponding ComponentId from the component_ids vec
                 if let Some(&QueryComponent { id: comp_id, .. }) = component_ids.get(component_idx)
                 {
                     // For built-in components, verify by TypeId
                     let type_id = ty.type_id();
 
                     if let Some(type_id) = type_id {
-                        // Verify this is the right component by checking TypeId
                         if world
                             .components()
                             .get_info(comp_id)
@@ -438,11 +407,7 @@ impl PyQueryIter {
             }
         }
 
-        // Use the provided validity flag - shared with other system parameters
-        // This will be automatically invalidated when the system completes
-
         // Build parallel array of extraction function pointers for Dynamic components
-        // This eliminates HashMap lookup overhead during per-entity iteration
         let extract_fns: SmallVec<[Option<ExtractFn>; 8]> = param
             .data
             .iter()
@@ -464,38 +429,161 @@ impl PyQueryIter {
         let param_access_modes: SmallVec<[AccessMode; 8]> = param
             .data
             .iter()
-            .map(|param_type| {
-                match param_type {
-                    QueryData::Component { mutable, .. } => {
-                        if *mutable {
-                            AccessMode::Write
-                        } else {
-                            AccessMode::Read
-                        }
+            .map(|param_type| match param_type {
+                QueryData::Component { mutable, .. } => {
+                    if *mutable {
+                        AccessMode::Write
+                    } else {
+                        AccessMode::Read
                     }
-                    _ => AccessMode::Read, // Default to read for non-component params
                 }
+                _ => AccessMode::Read,
             })
             .collect();
+
+        let single_entity_enforced = param.single_entity_enforced;
 
         Self {
             param,
             query_state,
-            query_iter: None,
-            world_ptr: Some(NonNull::from(world)),
             component_id_cache,
             custom_component_ids,
-            values_buffer: SmallVec::new(),
-            validity,
             param_access_modes,
             extract_fns,
-            iterating: false,
-            layout_cache: RefCell::new(HashMap::new()),
             changed_filter_ids: tick_changed_ids,
             added_filter_ids: tick_added_ids,
+            single_entity_enforced,
+        }
+    }
+}
+
+/// Runtime query iterator that can be passed to Python systems.
+/// Uses Bevy's cached [`CachedQuery`] state for efficient iteration.
+///
+/// SAFETY: This struct erases the lifetimes of both the `UnsafeWorldCell` and the
+/// borrowed `CachedQuery`. It must only be used within the scope of a system
+/// execution and must not escape the Python GIL callback. Python code must not
+/// store references to this object or any iterators derived from it beyond the
+/// system function scope; the shared `ValidityFlag` fences any that leak.
+///
+/// # Performance Notes
+/// For benchmarking, the main bottlenecks are typically:
+/// 1. Bevy's `iter.next()` - iterating entities and fetching components
+/// 2. `Py::new()` - creating Python wrapper objects (PyTransformMut, etc.)
+/// 3. `clone_ref(py)` - Python reference counting overhead
+/// 4. `PyTuple::new()` - allocating tuples for multi-component returns
+/// 5. GIL acquisition/release (handled by PyO3 automatically)
+#[pyclass(name = "QueryIter")]
+pub struct PyQueryIter {
+    /// The query parameter information (Arc-shared clone of the cache's copy).
+    /// Kept as its own field so per-entity extraction can iterate `param.data`
+    /// while mutating `values_buffer` (disjoint-field borrows).
+    param: Arc<PyQueryParam>,
+
+    /// Raw pointer to the static per-parameter state owned by the DynamicSystem.
+    /// SAFETY: valid while the ValidityFlag is active; the DynamicSystem outlives the run.
+    cached: NonNull<CachedQuery>,
+
+    /// Current lazy iterator state (created on first `__next__` call).
+    query_iter: Option<ErasedQueryIter>,
+
+    /// The world cell (lifetime-erased). Copy, valid only during system execution.
+    /// SAFETY: fenced by the ValidityFlag.
+    world_cell: Option<UnsafeWorldCell<'static>>,
+
+    /// Reusable buffer for return values - avoids allocation on every __next__ call
+    /// SmallVec[8] keeps up to 8 items on stack (most queries have 1-4 params)
+    values_buffer: SmallVec<[Py<PyAny>; 8]>,
+
+    /// Master validity flag - invalidated when system exits (RAII via ValidityGuard)
+    /// All component proxies check this to ensure they're only used during system execution
+    validity: ValidityFlag,
+
+    /// True while iteration is in progress (__next__ has been called but not yet exhausted).
+    /// Used to detect and reject nested iteration (which would silently corrupt state),
+    /// matching Bevy's borrow-checker prevention of nested query.iter() calls.
+    iterating: bool,
+
+    /// Cached ComponentLayouts and storage types for custom wrapper components, keyed by type pointer.
+    /// Avoids re-parsing Python __annotations__ and __pybevy_storage__ on every entity iteration.
+    layout_cache: RefCell<
+        HashMap<
+            *const PyTypeObject,
+            (
+                crate::ecs::component_layout::ComponentStorageType,
+                Option<Arc<crate::ecs::component_layout::ComponentLayout>>,
+            ),
+        >,
+    >,
+
+    /// System's last_run tick (from DynamicSystem::get_last_run()).
+    last_run: Tick,
+    /// Current world change tick for this run (the incremented tick from run_unsafe).
+    this_run: Tick,
+}
+
+// SAFETY: PyQueryIter is only used during system execution on a single thread.
+// The world cell and cached state are only accessed during system execution and never across threads.
+// Arc<PyQueryParam> and NonNull<CachedQuery> are fenced by the ValidityFlag.
+unsafe impl Send for PyQueryIter {}
+unsafe impl Sync for PyQueryIter {}
+
+impl PyQueryIter {
+    /// Creates a new runtime query bound to a cached query state and world cell.
+    ///
+    /// The heavy per-system work (component-id registration, QueryState
+    /// construction) lives in `cached`, built once in `DynamicSystem::initialize`.
+    ///
+    /// SAFETY: `cached` must remain valid for the lifetime of this object (it is
+    /// owned by the DynamicSystem, which outlives every run), and `world_cell` must
+    /// reference the World that `cached` was built from. Both are fenced by
+    /// `validity`, which is invalidated when the system finishes.
+    pub unsafe fn new(
+        cached: &CachedQuery,
+        world_cell: UnsafeWorldCell,
+        validity: ValidityFlag,
+        last_run: Tick,
+        this_run: Tick,
+    ) -> Self {
+        // Erase the cell lifetime for storage; it is only ever used while the
+        // system runs, fenced by `validity`.
+        // SAFETY: size- and layout-preserving lifetime erasure of a Copy pointer type.
+        let world_cell: UnsafeWorldCell<'static> = unsafe { std::mem::transmute(world_cell) };
+
+        Self {
+            param: cached.param.clone(),
+            cached: NonNull::from(cached),
+            query_iter: None,
+            world_cell: Some(world_cell),
+            values_buffer: SmallVec::new(),
+            validity,
+            iterating: false,
+            layout_cache: RefCell::new(HashMap::new()),
             last_run,
             this_run,
         }
+    }
+
+    /// Borrow the static cached query state.
+    ///
+    /// SAFETY: `cached` points into a CachedQuery owned by the DynamicSystem, which
+    /// outlives every run; access is fenced by the same ValidityFlag as `world_cell`.
+    #[inline]
+    fn cached(&self) -> &CachedQuery {
+        unsafe { self.cached.as_ref() }
+    }
+
+    /// Raw `*mut World` for the legacy custom-component write-back path.
+    ///
+    /// SAFETY: the custom-component mutation write-back still needs a `&mut World`
+    /// to stamp change ticks (not yet migrated off the raw pointer, slated for a
+    /// later stage). The cell is valid while the ValidityFlag is active.
+    #[inline]
+    fn world_ptr(&self) -> *mut World {
+        let cell = self
+            .world_cell
+            .expect("Query used outside system execution");
+        unsafe { cell.world_mut() as *mut World }
     }
 
     /// Get extraction function pointer for a parameter by index.
@@ -504,7 +592,7 @@ impl PyQueryIter {
     /// Uses direct array indexing - O(1) with no HashMap overhead.
     #[inline(always)]
     pub(crate) fn get_extract_fn(&self, param_idx: usize) -> Option<ExtractFn> {
-        self.extract_fns.get(param_idx).copied().flatten()
+        self.cached().extract_fns.get(param_idx).copied().flatten()
     }
 
     /// Extract a custom component from an entity and return as PyObject
@@ -570,13 +658,10 @@ impl PyQueryIter {
 
                 // Create lazy wrapper proxy
                 let entity_id = entity.id();
-                let access_mode = self.param_access_modes[param_idx];
+                let access_mode = self.cached().param_access_modes[param_idx];
                 let validity = self.validity.with_access_mode(access_mode);
                 let mutable = access_mode == AccessMode::Write;
-                let world_ptr = self
-                    .world_ptr
-                    .expect("Query used outside system execution")
-                    .as_ptr();
+                let world_ptr = self.world_ptr();
                 let proxy = unsafe {
                     PyLazyWrapperProxy::new(
                         data_ptr,
@@ -614,12 +699,9 @@ impl PyQueryIter {
                 };
 
                 // Create borrowed reference with validity tracking and entity context
-                let access_mode = self.param_access_modes[param_idx];
+                let access_mode = self.cached().param_access_modes[param_idx];
                 let validity = self.validity.with_access_mode(access_mode);
-                let world_ptr = self
-                    .world_ptr
-                    .expect("Query used outside system execution")
-                    .as_ptr();
+                let world_ptr = self.world_ptr();
 
                 let custom_comp = PyCustomComponent::from_borrowed(
                     py_obj_ptr,
@@ -662,10 +744,12 @@ impl PyQueryIter {
                     // Get component ID from cache (handles both built-in and custom components)
                     let component_id = match ty {
                         PyComponentType::Custom(type_ptr) => *self
+                            .cached()
                             .custom_component_ids
                             .get(type_ptr)
                             .expect("Custom component ID should be registered"),
                         _ => *self
+                            .cached()
                             .component_id_cache
                             .get(ty)
                             .expect("Component ID should be cached"),
@@ -678,7 +762,7 @@ impl PyQueryIter {
                     }
 
                     // Create validity flag with correct access mode
-                    let access_mode = self.param_access_modes[param_idx];
+                    let access_mode = self.cached().param_access_modes[param_idx];
                     let validity = self.validity.with_access_mode(access_mode);
 
                     // Use macro-generated dispatch method (handles all component types)
@@ -702,10 +786,11 @@ impl PyQueryIter {
     /// Fast path: returns true immediately when no tick filters exist.
     #[inline]
     fn entity_passes_tick_filters(&self, entity: &FilteredEntityAccess) -> bool {
+        let cached = self.cached();
         passes_tick_filters(
             |id| entity.get_change_ticks_by_id(id),
-            &self.changed_filter_ids,
-            &self.added_filter_ids,
+            &cached.changed_filter_ids,
+            &cached.added_filter_ids,
             self.last_run,
             self.this_run,
         )
@@ -714,7 +799,8 @@ impl PyQueryIter {
     /// Returns true if there are any tick filters (Added/Changed) on this query.
     #[inline]
     fn has_tick_filters(&self) -> bool {
-        !self.changed_filter_ids.is_empty() || !self.added_filter_ids.is_empty()
+        let cached = self.cached();
+        !cached.changed_filter_ids.is_empty() || !cached.added_filter_ids.is_empty()
     }
 }
 
@@ -785,10 +871,16 @@ impl PyQueryIter {
 
         // Create iterator on first call
         if self.query_iter.is_none() {
-            let world_ptr = self.world_ptr.expect("Query used outside system execution");
-            let (read_only, qs_ptr) = self.query_state.parts();
-            // SAFETY: world_ptr and qs_ptr are valid during system execution
-            self.query_iter = Some(unsafe { erased_create_iter(read_only, qs_ptr, world_ptr) });
+            let cell = self
+                .world_cell
+                .expect("Query used outside system execution");
+            let (read_only, qs_ptr) = self.cached().query_state.parts();
+            // SAFETY: declared access from initialize covers this state; the executor
+            // prevents conflicting systems from running concurrently, so the unchecked
+            // access is unique. Ticks flow explicitly for per-entity change detection.
+            self.query_iter = Some(unsafe {
+                erased_create_iter(read_only, qs_ptr, cell, self.last_run, self.this_run)
+            });
         }
 
         // Advance iterator — get raw pointer to avoid borrow conflict with self.
@@ -833,65 +925,53 @@ impl PyQueryIter {
     /// Python users calling `len(query)` may expect O(1) but Bevy's
     /// `QueryState` does not cache entity counts.
     fn __len__(&self) -> usize {
-        let world = match self.world_ptr {
-            Some(ptr) => unsafe { ptr.as_ref() },
-            None => return 0,
+        let Some(cell) = self.world_cell else {
+            return 0;
         };
 
+        let cached = self.cached();
         if !self.has_tick_filters() {
-            return self.query_state.count(world);
+            return cached.query_state.count(cell, self.last_run, self.this_run);
         }
 
-        // Count with tick filtering using iter_manual (&World - safe with &self)
-        let (read_only, qs_ptr) = self.query_state.parts();
-        let changed = &self.changed_filter_ids;
-        let added = &self.added_filter_ids;
-        let (lr, tr) = (self.last_run, self.this_run);
-        unsafe {
-            if read_only {
-                let qs = &*(qs_ptr as *const QueryState<FilteredEntityRef>);
-                qs.iter_manual(world)
-                    .filter(|e| {
-                        passes_tick_filters(
-                            |id| e.get_change_ticks_by_id(id),
-                            changed,
-                            added,
-                            lr,
-                            tr,
-                        )
-                    })
-                    .count()
-            } else {
-                let qs = &*(qs_ptr as *const QueryState<FilteredEntityMut>);
-                qs.iter_manual(world)
-                    .filter(|e| {
-                        passes_tick_filters(
-                            |id| e.get_change_ticks_by_id(id),
-                            changed,
-                            added,
-                            lr,
-                            tr,
-                        )
-                    })
-                    .count()
+        // Count with tick filtering: iterate the cell-based unchecked iterator and
+        // apply the per-entity Changed/Added checks.
+        let (read_only, qs_ptr) = cached.query_state.parts();
+        // SAFETY: declared access from initialize covers this state; the executor
+        // prevents conflicting systems from running concurrently, so the unchecked
+        // access is unique.
+        let mut iter =
+            unsafe { erased_create_iter(read_only, qs_ptr, cell, self.last_run, self.this_run) };
+        let mut n = 0usize;
+        while let Some(access) = iter.next() {
+            if self.entity_passes_tick_filters(&access) {
+                n += 1;
             }
         }
+        n
     }
 
     /// Get exactly one entity from the query.
     /// Returns an error if there are 0 or 2+ entities matching the query.
     fn single(&mut self, py: Python) -> PyResult<Py<PyAny>> {
-        let mut world_ptr = self.world_ptr.expect("Query used outside system execution");
-        let (read_only, qs_ptr) = self.query_state.parts();
+        let cell = self
+            .world_cell
+            .expect("Query used outside system execution");
+        let last_run = self.last_run;
+        let this_run = self.this_run;
+        let (read_only, qs_ptr) = self.cached().query_state.parts();
 
         // Validate exactly one entity exists and get it for extraction.
         // Loop through entities to find those passing tick filters.
-        // SAFETY: world_ptr and qs_ptr are valid during system execution.
-        // We use raw pointer casts to avoid holding borrows across extraction.
+        // SAFETY: declared access from initialize covers this state; the executor
+        // prevents conflicting systems from running concurrently, so the unchecked
+        // access is unique. Raw pointer casts avoid holding borrows across extraction.
         let mut entity_access: FilteredEntityAccess = unsafe {
             if read_only {
                 let qs = &mut *(qs_ptr as *mut QueryState<FilteredEntityRef>);
-                let mut iter = qs.iter(world_ptr.as_ref());
+                let mut iter = qs
+                    .query_unchecked_with_ticks(cell, last_run, this_run)
+                    .iter_inner();
                 // Find first entity passing tick filters
                 let first = loop {
                     match iter.next() {
@@ -930,7 +1010,9 @@ impl PyQueryIter {
                 }
             } else {
                 let qs = &mut *(qs_ptr as *mut QueryState<FilteredEntityMut>);
-                let mut iter = qs.iter_mut(world_ptr.as_mut());
+                let mut iter = qs
+                    .query_unchecked_with_ticks(cell, last_run, this_run)
+                    .iter_inner();
                 // Find first entity passing tick filters
                 let first = loop {
                     match iter.next() {
@@ -983,50 +1065,54 @@ impl PyQueryIter {
     /// Check if the query has no matching entities.
     /// Returns true if there are no entities matching the query filters.
     fn is_empty(&self) -> PyResult<bool> {
-        // SAFETY: world_ptr is guaranteed to be valid during system execution.
-        // Only shared access needed - last_change_tick/read_change_tick/is_empty all take &World.
-        let world = unsafe {
-            self.world_ptr
-                .expect("Query used outside system execution")
-                .as_ref()
-        };
+        let cell = self
+            .world_cell
+            .expect("Query used outside system execution");
+        let cached = self.cached();
 
         if !self.has_tick_filters() {
-            let last_tick = world.last_change_tick();
-            let current_tick = world.read_change_tick();
-            return Ok(self
+            return Ok(cached
                 .query_state
-                .is_empty_check(world, last_tick, current_tick));
+                .is_empty_check(cell, self.last_run, self.this_run));
         }
 
-        // Check with tick filtering using iter_manual (&World - safe with &self)
-        let (read_only, qs_ptr) = self.query_state.parts();
-        let changed = &self.changed_filter_ids;
-        let added = &self.added_filter_ids;
-        let (lr, tr) = (self.last_run, self.this_run);
-        unsafe {
-            Ok(if read_only {
-                let qs = &*(qs_ptr as *const QueryState<FilteredEntityRef>);
-                !qs.iter_manual(world).any(|e| {
-                    passes_tick_filters(|id| e.get_change_ticks_by_id(id), changed, added, lr, tr)
-                })
-            } else {
-                let qs = &*(qs_ptr as *const QueryState<FilteredEntityMut>);
-                !qs.iter_manual(world).any(|e| {
-                    passes_tick_filters(|id| e.get_change_ticks_by_id(id), changed, added, lr, tr)
-                })
-            })
+        // Check with tick filtering: iterate the cell-based unchecked iterator and
+        // stop at the first entity that passes the per-entity Changed/Added checks.
+        let (read_only, qs_ptr) = cached.query_state.parts();
+        // SAFETY: declared access from initialize covers this state; the executor
+        // prevents conflicting systems from running concurrently, so the unchecked
+        // access is unique.
+        let mut iter =
+            unsafe { erased_create_iter(read_only, qs_ptr, cell, self.last_run, self.this_run) };
+        while let Some(access) = iter.next() {
+            if self.entity_passes_tick_filters(&access) {
+                return Ok(false);
+            }
         }
+        Ok(true)
     }
 
     /// Get components for a specific entity by ID.
     /// Returns None if the entity doesn't match the query filters.
     /// Returns an error if the entity doesn't have the queried components.
     fn get(&mut self, entity: PyEntity, py: Python) -> PyResult<Option<Py<PyAny>>> {
-        let world_ptr = self.world_ptr.expect("Query used outside system execution");
-        let (read_only, qs_ptr) = self.query_state.parts();
-        // SAFETY: world_ptr and qs_ptr are valid during system execution
-        let result = unsafe { erased_get_entity(read_only, qs_ptr, world_ptr, entity.0) };
+        let cell = self
+            .world_cell
+            .expect("Query used outside system execution");
+        let (read_only, qs_ptr) = self.cached().query_state.parts();
+        // SAFETY: declared access from initialize covers this state; the executor
+        // prevents conflicting systems from running concurrently, so the unchecked
+        // access is unique.
+        let result = unsafe {
+            erased_get_entity(
+                read_only,
+                qs_ptr,
+                cell,
+                self.last_run,
+                self.this_run,
+                entity.0,
+            )
+        };
 
         match result {
             Some(mut entity_access) => {
@@ -1067,16 +1153,21 @@ impl PyQueryIter {
     /// ```
     fn iter_many(&mut self, entities: &Bound<'_, PyAny>, py: Python) -> PyResult<Vec<Py<PyAny>>> {
         let mut results = Vec::new();
-        let world_ptr = self.world_ptr.expect("Query used outside system execution");
-        let (read_only, qs_ptr) = self.query_state.parts();
+        let cell = self
+            .world_cell
+            .expect("Query used outside system execution");
+        let (read_only, qs_ptr) = self.cached().query_state.parts();
+        let (last_run, this_run) = (self.last_run, self.this_run);
 
         for entity_obj in entities.try_iter()? {
             let entity_id: PyEntity = entity_obj?.extract()?;
 
-            // SAFETY: world_ptr and qs_ptr are valid during system execution
-            if let Some(mut access) =
-                unsafe { erased_get_entity(read_only, qs_ptr, world_ptr, entity_id.0) }
-            {
+            // SAFETY: declared access from initialize covers this state; the executor
+            // prevents conflicting systems from running concurrently, so the unchecked
+            // access is unique.
+            if let Some(mut access) = unsafe {
+                erased_get_entity(read_only, qs_ptr, cell, last_run, this_run, entity_id.0)
+            } {
                 // Check tick filters before extracting
                 if !self.entity_passes_tick_filters(&access) {
                     continue;

--- a/src/ecs/query/single_runtime.rs
+++ b/src/ecs/query/single_runtime.rs
@@ -1,11 +1,9 @@
-use std::{collections::HashMap, sync::Arc};
-
-use bevy::ecs::{change_detection::Tick, component::ComponentId};
-use pyo3::{exceptions::PyRuntimeError, ffi::PyTypeObject, prelude::*};
+use bevy::ecs::{change_detection::Tick, world::unsafe_world_cell::UnsafeWorldCell};
+use pyo3::{exceptions::PyRuntimeError, prelude::*};
 
 use crate::ecs::{
     helpers::validity_guard::ValidityFlag,
-    query::{query_param::PyQueryParam, query_runtime::PyQueryIter},
+    query::query_runtime::{CachedQuery, PyQueryIter},
 };
 
 /// Runtime wrapper for Single<T> queries that enforces exactly one entity matches.
@@ -26,17 +24,19 @@ impl PySingleQuery {
     /// Creates a new Single query wrapper
     ///
     /// # Safety
-    /// The world pointer must remain valid for the lifetime of this object
+    /// `cached` must remain valid and `world_cell` must reference the World it was
+    /// built from, for the lifetime of this object (fenced by `validity`).
     pub unsafe fn new(
-        param: Arc<PyQueryParam>,
-        world: &mut bevy::prelude::World,
-        custom_component_ids: Arc<HashMap<*const PyTypeObject, ComponentId>>,
+        cached: &CachedQuery,
+        world_cell: UnsafeWorldCell,
         validity: ValidityFlag,
         last_run: Tick,
+        this_run: Tick,
     ) -> Self {
-        // SAFETY: Caller guarantees world pointer is valid during system execution
+        // SAFETY: Caller guarantees the cached state and world cell are valid during
+        // system execution (see PyQueryIter::new safety contract).
         let query_iter =
-            unsafe { PyQueryIter::new(param, world, custom_component_ids, validity, last_run) };
+            unsafe { PyQueryIter::new(cached, world_cell, validity, last_run, this_run) };
 
         Python::attach(|py| {
             let query_iter_py = Py::new(py, query_iter).expect("Failed to create PyQueryIter");

--- a/src/ecs/resource_type.rs
+++ b/src/ecs/resource_type.rs
@@ -1,7 +1,10 @@
 use core::fmt;
 use std::collections::HashMap;
 
-use bevy::{ecs::component::ComponentId, prelude::*};
+use bevy::{
+    ecs::{component::ComponentId, world::unsafe_world_cell::UnsafeWorldCell},
+    prelude::*,
+};
 use pybevy_core::registry::global_registry;
 use pyo3::{PyTypeInfo, exceptions::PyTypeError, ffi::PyTypeObject, prelude::*, types::PyType};
 
@@ -53,10 +56,7 @@ unsafe impl Sync for PyResourceType {}
 impl PyResourceType {
     /// Get AssetServer resource from world (read-only)
     fn get_asset_server(world: &World, py: Python, validity: ValidityFlag) -> PyResult<Py<PyAny>> {
-        let world_ptr = world as *const World as *mut World;
-        let py_asset_server = unsafe { PyAssetServer::new(world_ptr, validity) };
-        let asset_server_obj = Py::new(py, (py_asset_server, PyResource))?;
-        Ok(asset_server_obj.into_any())
+        Self::get_asset_server_cell(world.as_unsafe_world_cell_readonly(), py, validity)
     }
 
     /// Get AssetServer resource from world (mutable)
@@ -65,10 +65,141 @@ impl PyResourceType {
         py: Python,
         validity: ValidityFlag,
     ) -> PyResult<Py<PyAny>> {
-        let world_ptr = world as *mut World;
-        let py_asset_server = unsafe { PyAssetServer::new(world_ptr, validity) };
+        Self::get_asset_server_cell(world.as_unsafe_world_cell(), py, validity)
+    }
+
+    /// Wrap the AssetServer resource from a world cell.
+    fn get_asset_server_cell(
+        cell: UnsafeWorldCell,
+        py: Python,
+        validity: ValidityFlag,
+    ) -> PyResult<Py<PyAny>> {
+        // SAFETY: `cell` references the world the AssetServer belongs to and stays
+        // valid while `validity` is active; PyAssetServer reads only the declared
+        // AssetServer resource through it.
+        let py_asset_server = unsafe { PyAssetServer::new(cell, validity) };
         let asset_server_obj = Py::new(py, (py_asset_server, PyResource))?;
         Ok(asset_server_obj.into_any())
+    }
+
+    /// Read a custom Python resource through a world cell, touching only the
+    /// `ResourceRegistry` and `PyResourceStorage` resources (both declared by
+    /// `DynamicSystem::initialize` for Custom resource params).
+    ///
+    /// # Safety
+    /// The caller must guarantee those two reads are declared and that the executor
+    /// prevents a concurrent structural writer, so the unchecked reads are unique.
+    unsafe fn get_custom_from_cell(
+        cell: UnsafeWorldCell,
+        type_ptr: *const PyTypeObject,
+        py: Python,
+    ) -> PyResult<Py<PyAny>> {
+        // SAFETY: read access to ResourceRegistry is declared for Custom params.
+        let registry = unsafe { cell.get_resource::<ResourceRegistry>() }.ok_or_else(|| {
+            let type_name = get_python_type_name(py, type_ptr);
+            PyTypeError::new_err(format!(
+                "Resource type `{}` is not found. Did you call `init_resource` or `insert_resource`?",
+                type_name
+            ))
+        })?;
+
+        let component_id = registry.registry.get(&type_ptr).ok_or_else(|| {
+            let type_name = get_python_type_name(py, type_ptr);
+            PyTypeError::new_err(format!(
+                "Resource type `{}` is not found. Did you call `init_resource` or `insert_resource`?",
+                type_name
+            ))
+        })?;
+
+        // SAFETY: read access to PyResourceStorage is declared for Custom params.
+        let storage = unsafe { cell.get_resource::<PyResourceStorage>() }.ok_or_else(|| {
+            let type_name = get_python_type_name(py, type_ptr);
+            PyTypeError::new_err(format!(
+                "Resource type `{}` not present in the world",
+                type_name
+            ))
+        })?;
+
+        let resource = storage.resources.get(component_id).ok_or_else(|| {
+            let type_name = get_python_type_name(py, type_ptr);
+            PyTypeError::new_err(format!(
+                "Resource type `{}` not present in the world",
+                type_name
+            ))
+        })?;
+
+        Ok(resource.clone_ref(py))
+    }
+
+    /// Read a resource through an `UnsafeWorldCell`, touching only this resource's
+    /// declared data instead of borrowing the whole world (as `get_from_world` does).
+    ///
+    /// # Safety
+    /// The caller must guarantee `DynamicSystem::initialize` declared read access to
+    /// this resource (and, for Custom resources, to `ResourceRegistry` /
+    /// `PyResourceStorage`) and that the executor prevents a concurrent writer, so
+    /// the cell's unchecked reads are unique.
+    pub unsafe fn get_from_cell(
+        &self,
+        cell: UnsafeWorldCell,
+        py: Python,
+        validity: ValidityFlag,
+    ) -> PyResult<Py<PyAny>> {
+        match self {
+            PyResourceType::AssetServer => Self::get_asset_server_cell(cell, py, validity),
+            PyResourceType::Dynamic(type_ptr) => {
+                let bridge = global_registry::get_resource_bridge_by_py_type(*type_ptr)
+                    .ok_or_else(|| {
+                        PyTypeError::new_err("Resource bridge not found for dynamic type")
+                    })?;
+                // SAFETY: read access to this resource is declared; the executor
+                // prevents a concurrent writer, so the cell read is unique.
+                unsafe {
+                    bridge.get_from_cell(cell, validity.with_access_mode(AccessMode::Read), py)
+                }
+            }
+            PyResourceType::Custom(type_ptr) => {
+                // SAFETY: forwarded obligation, see get_custom_from_cell.
+                unsafe { Self::get_custom_from_cell(cell, *type_ptr, py) }
+            }
+        }
+    }
+
+    /// Mutable counterpart of `get_from_cell`. Custom resources return the same
+    /// stored Python object (Python objects are inherently mutable), matching
+    /// `get_from_world_mut`.
+    ///
+    /// # Safety
+    /// The caller must guarantee `DynamicSystem::initialize` declared write access
+    /// to this resource (Custom resources only require the declared storage reads)
+    /// and that the executor prevents a concurrent access, so the cell's unchecked
+    /// borrow is unique.
+    pub unsafe fn get_from_cell_mut(
+        &self,
+        cell: UnsafeWorldCell,
+        py: Python,
+        validity: ValidityFlag,
+    ) -> PyResult<Py<PyAny>> {
+        match self {
+            PyResourceType::AssetServer => Self::get_asset_server_cell(cell, py, validity),
+            PyResourceType::Dynamic(type_ptr) => {
+                let bridge = global_registry::get_resource_bridge_by_py_type(*type_ptr)
+                    .ok_or_else(|| {
+                        PyTypeError::new_err("Resource bridge not found for dynamic type")
+                    })?;
+                // SAFETY: write access to this resource is declared; the executor
+                // prevents any concurrent access, so the cell borrow is unique.
+                unsafe {
+                    bridge.get_mut_from_cell(cell, validity.with_access_mode(AccessMode::Write), py)
+                }
+            }
+            PyResourceType::Custom(type_ptr) => {
+                // Custom mutable access returns the same Python object as the read
+                // path (Python objects are inherently mutable).
+                // SAFETY: forwarded obligation, see get_custom_from_cell.
+                unsafe { Self::get_custom_from_cell(cell, *type_ptr, py) }
+            }
+        }
     }
 
     /// Get the resource from the world and convert it to a Python object (read-only access)

--- a/src/ecs/view/view.rs
+++ b/src/ecs/view/view.rs
@@ -20,7 +20,6 @@
 use std::{
     cell::RefCell,
     collections::{HashMap, HashSet},
-    ptr::NonNull,
     sync::{
         Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
@@ -33,7 +32,7 @@ use bevy::{
         component::ComponentId,
         query::QueryBuilder,
         storage::TableId,
-        world::{FilteredEntityMut, World},
+        world::{FilteredEntityMut, World, unsafe_world_cell::UnsafeWorldCell},
     },
     prelude::*,
 };
@@ -93,8 +92,10 @@ pub struct PyView {
     /// This prevents getting multiple mutable column proxies for the same component
     borrowed_mut: RefCell<HashSet<PyComponentType>>,
 
-    /// Raw pointer to the World (only valid during system execution)
-    world_ptr: Option<NonNull<World>>,
+    /// World cell (lifetime-erased), valid only during system execution. The View's
+    /// batch ops (QueryBuilder / par_iter_mut) fundamentally need `&mut World`, so a
+    /// `*mut World` is derived per-operation from this cell (see `world_ptr`).
+    world_cell: Option<UnsafeWorldCell<'static>>,
 
     /// Master validity flag - invalidated when system exits
     validity: ValidityFlag,
@@ -164,7 +165,9 @@ impl Drop for PyView {
 impl PyView {
     /// Create a new View with filter components
     ///
-    /// SAFETY: The world pointer must remain valid for the lifetime of this object
+    /// # Safety
+    /// `world` must reference the World the view operates on and must remain valid
+    /// for as long as `validity` is active.
     #[allow(clippy::too_many_arguments)]
     pub unsafe fn new_with_filters(
         component_types: Vec<PyComponentType>,
@@ -174,10 +177,15 @@ impl PyView {
         changed_filter_types: Vec<PyComponentType>,
         added_filter_types: Vec<PyComponentType>,
         last_run: Tick,
-        world: &mut World,
+        world: UnsafeWorldCell,
         validity: ValidityFlag,
     ) -> Self {
+        // Stamp this_run from the cell (safe read) so batch write-backs and the
+        // system's last_run end-read observe the same tick (5a semantics).
         let this_run = world.change_tick();
+        // SAFETY: layout-preserving lifetime erasure of a Copy pointer type; the cell
+        // is only used while `validity` is active.
+        let world_cell: UnsafeWorldCell<'static> = unsafe { std::mem::transmute(world) };
         Self {
             component_types,
             filter_types,
@@ -188,12 +196,30 @@ impl PyView {
             this_run,
             mutable_components,
             borrowed_mut: RefCell::new(HashSet::new()),
-            world_ptr: Some(NonNull::from(world)),
+            world_cell: Some(world_cell),
             validity,
             bytecode_cache: RefCell::new(view_engine::BytecodeCache::new()),
             component_ids: RefCell::new(HashMap::new()),
             batch_validity_tokens: RefCell::new(Vec::new()),
         }
+    }
+
+    /// Derive a raw `*mut World` from the stored cell for a single batch operation.
+    ///
+    /// The View's batch machinery (`QueryBuilder`, `par_iter_mut`) fundamentally
+    /// requires `&mut World`, so a pointer is derived per-operation rather than a
+    /// long-lived borrow. This is the same residual-pointer pattern as
+    /// `query_runtime::world_ptr`.
+    ///
+    /// SAFETY of dereferencing the returned pointer: `initialize` declares this
+    /// view's component read/write access; the executor prevents a conflicting
+    /// system from running concurrently, so the data the batch ops touch is unique.
+    fn world_ptr(&self) -> PyResult<*mut World> {
+        let cell = self
+            .world_cell
+            .ok_or_else(|| PyRuntimeError::new_err("View used outside system execution"))?;
+        // SAFETY: momentary derivation of a Copy pointer; see method docs.
+        Ok(unsafe { cell.world_mut() as *mut World })
     }
 
     /// Build a `ViewFilter` from this view's filter types for use with `view_engine` functions.
@@ -231,11 +257,8 @@ impl PyView {
         }
 
         // Register component
-        let world = unsafe {
-            self.world_ptr
-                .ok_or_else(|| PyRuntimeError::new_err("View used outside system execution"))?
-                .as_mut()
-        };
+        // SAFETY: momentary &mut World for a batch op; see PyView::world_ptr.
+        let world = unsafe { &mut *self.world_ptr()? };
 
         let id = register_component_id_simple(world, comp_type);
 
@@ -344,11 +367,8 @@ impl PyView {
         let bytecode = Arc::new(compiler.finalize());
 
         // Get world pointer
-        let world = unsafe {
-            self.world_ptr
-                .ok_or_else(|| PyRuntimeError::new_err("View used outside system execution"))?
-                .as_mut()
-        };
+        // SAFETY: momentary &mut World for a batch op; see PyView::world_ptr.
+        let world = unsafe { &mut *self.world_ptr()? };
 
         // Determine which component type to query based on the compiled expression.
         // The bytecode's field_map contains the ComponentId for each field reference,
@@ -703,11 +723,8 @@ impl PyView {
             .push(validity_token.clone());
 
         // Discover matching archetype tables (same pattern as expression path)
-        let world = unsafe {
-            self.world_ptr
-                .ok_or_else(|| PyRuntimeError::new_err("View used outside system execution"))?
-                .as_ref()
-        };
+        // SAFETY: momentary &World for archetype discovery; see PyView::world_ptr.
+        let world = unsafe { &*self.world_ptr()? };
 
         // Register all component IDs
         let component_ids: Vec<ComponentId> = self
@@ -783,7 +800,7 @@ impl PyView {
         let iterator = PyBatchIterator {
             component_types: self.component_types.clone(),
             mutable_components: self.mutable_components.clone(),
-            world_ptr: self.world_ptr,
+            world_cell: self.world_cell,
             validity_token,
             validity: self.validity.clone(),
             table_ids,
@@ -816,11 +833,8 @@ impl PyView {
             Ok(sum as usize)
         } else {
             // Count all entities - simpler path without expression evaluation
-            let world = unsafe {
-                self.world_ptr
-                    .ok_or_else(|| PyRuntimeError::new_err("View used outside system execution"))?
-                    .as_mut()
-            };
+            // SAFETY: momentary &mut World for a batch op; see PyView::world_ptr.
+            let world = unsafe { &mut *self.world_ptr()? };
 
             // Build a query using the first component type's ID
             let component_type = self
@@ -1238,11 +1252,8 @@ impl PyViewColMut {
 
         // Get world reference
         let view = unsafe { &*self.view_ptr };
-        let world = unsafe {
-            view.world_ptr
-                .ok_or_else(|| PyRuntimeError::new_err("View used outside system execution"))?
-                .as_mut()
-        };
+        // SAFETY: momentary &mut World for a batch op; see PyView::world_ptr.
+        let world = unsafe { &mut *view.world_ptr()? };
 
         // If all fields are from the same component, use the optimized single-component path
         if component_ids.len() == 1 && component_ids.contains(&self.component_id) {
@@ -1389,15 +1400,16 @@ pub struct PyBatch {
     /// Mutable component types (same as parent View)
     mutable_components: HashSet<PyComponentType>,
 
-    /// Raw pointer to the World
-    world_ptr: Option<NonNull<World>>,
+    /// World cell (lifetime-erased), valid only during system execution. A
+    /// `*mut World` is derived per-operation (see `world_ptr`).
+    world_cell: Option<UnsafeWorldCell<'static>>,
 
     /// Validity token shared with ViewColumn instances
     /// When this is poisoned, all ViewColumns become invalid
     validity_token: Arc<std::sync::atomic::AtomicBool>,
 
     /// Master validity flag from parent View
-    /// Must be checked before dereferencing world_ptr to prevent use-after-free
+    /// Must be checked before dereferencing the world cell to prevent use-after-free
     validity: ValidityFlag,
 
     /// Specific archetype table for this batch
@@ -1412,7 +1424,7 @@ impl PyBatch {
     pub(crate) fn new(
         component_types: Vec<PyComponentType>,
         mutable_components: HashSet<PyComponentType>,
-        world_ptr: Option<NonNull<World>>,
+        world_cell: Option<UnsafeWorldCell<'static>>,
         validity_token: Arc<std::sync::atomic::AtomicBool>,
         validity: ValidityFlag,
         table_id: TableId,
@@ -1420,21 +1432,31 @@ impl PyBatch {
         Self {
             component_types,
             mutable_components,
-            world_ptr,
+            world_cell,
             validity_token,
             validity,
             table_id,
         }
     }
 
+    /// Derive a raw `*mut World` from the stored cell for a single batch operation.
+    ///
+    /// Same residual-pointer pattern as `PyView::world_ptr`: the batch column and
+    /// change-tick machinery need `&mut World`; the parent view's declared
+    /// component access bounds the data actually touched.
+    fn world_ptr(&self) -> PyResult<*mut World> {
+        let cell = self
+            .world_cell
+            .ok_or_else(|| PyRuntimeError::new_err("Batch not properly initialized"))?;
+        // SAFETY: momentary derivation of a Copy pointer; see method docs.
+        Ok(unsafe { cell.world_mut() as *mut World })
+    }
+
     /// Get component ID for a component type
     fn get_component_id(&self, comp_type: &PyComponentType) -> PyResult<ComponentId> {
         self.validity.check()?;
-        let world = unsafe {
-            self.world_ptr
-                .ok_or_else(|| PyRuntimeError::new_err("Batch not properly initialized"))?
-                .as_mut()
-        };
+        // SAFETY: momentary &mut World for component registration; see world_ptr.
+        let world = unsafe { &mut *self.world_ptr()? };
 
         Ok(register_component_id_simple(world, comp_type))
     }
@@ -1465,11 +1487,8 @@ impl PyBatch {
         let component_id = self.get_component_id(&comp_type)?;
 
         // Access the table directly via stored table_id (archetype filtering already done in iter_batches)
-        let world = unsafe {
-            self.world_ptr
-                .ok_or_else(|| PyRuntimeError::new_err("Batch used outside system execution"))?
-                .as_ref()
-        };
+        // SAFETY: momentary &World for table access; see PyBatch::world_ptr.
+        let world = unsafe { &*self.world_ptr()? };
 
         let storages = world.storages();
         let tables = &storages.tables;
@@ -1592,11 +1611,8 @@ impl PyBatch {
 
         // Access the table directly via stored table_id (archetype filtering already done in iter_batches)
         // Mutable access needed for change tick marking
-        let world = unsafe {
-            self.world_ptr
-                .ok_or_else(|| PyRuntimeError::new_err("Batch used outside system execution"))?
-                .as_mut()
-        };
+        // SAFETY: momentary &mut World for change-tick marking; see PyBatch::world_ptr.
+        let world = unsafe { &mut *self.world_ptr()? };
 
         // Get change tick before immutable borrows
         let change_tick = world.change_tick();
@@ -1701,11 +1717,8 @@ impl PyBatch {
     /// ```
     fn entities(&self, py: Python) -> PyResult<Vec<Py<PyEntity>>> {
         self.validity.check()?;
-        let world = unsafe {
-            self.world_ptr
-                .ok_or_else(|| PyRuntimeError::new_err("Batch used outside system execution"))?
-                .as_ref()
-        };
+        // SAFETY: momentary &World for table access; see PyBatch::world_ptr.
+        let world = unsafe { &*self.world_ptr()? };
 
         let table = world
             .storages()
@@ -1722,11 +1735,8 @@ impl PyBatch {
 
     fn __len__(&self) -> PyResult<usize> {
         self.validity.check()?;
-        let world = unsafe {
-            self.world_ptr
-                .ok_or_else(|| PyRuntimeError::new_err("Batch used outside system execution"))?
-                .as_ref()
-        };
+        // SAFETY: momentary &World for table access; see PyBatch::world_ptr.
+        let world = unsafe { &*self.world_ptr()? };
 
         let table = world
             .storages()
@@ -1756,8 +1766,8 @@ pub struct PyBatchIterator {
     /// Mutable components
     mutable_components: HashSet<PyComponentType>,
 
-    /// World pointer
-    world_ptr: Option<NonNull<World>>,
+    /// World cell (lifetime-erased), passed to each PyBatch it yields
+    world_cell: Option<UnsafeWorldCell<'static>>,
 
     /// Validity token for all batches
     validity_token: Arc<std::sync::atomic::AtomicBool>,
@@ -1797,7 +1807,7 @@ impl PyBatchIterator {
         let batch = PyBatch::new(
             self.component_types.clone(),
             self.mutable_components.clone(),
-            self.world_ptr,
+            self.world_cell,
             self.validity_token.clone(),
             self.validity.clone(),
             table_id,

--- a/src/ecs/world.rs
+++ b/src/ecs/world.rs
@@ -206,11 +206,14 @@ impl PyWorld {
 
         // Create PyAssets wrapper for the specified asset type
         // When called from World.resource(), assume mutable access (for backwards compatibility)
+        // SAFETY: `world_ptr` is valid while this PyWorld is valid; the derived cell is
+        // fenced by the same `validity` flag. PyAssets only reaches the `Assets<T>` resource.
+        let cell = unsafe { (*world_ptr).as_unsafe_world_cell() };
         let py_assets = unsafe {
             Py::new(
                 py,
                 (
-                    PyAssets::new(type_ptr, None, world_ptr, validity, true),
+                    PyAssets::new(type_ptr, None, cell, validity, true),
                     super::resource::PyResource,
                 ),
             )?

--- a/tests/bevy_invariants.rs
+++ b/tests/bevy_invariants.rs
@@ -846,3 +846,46 @@ fn test_resources_are_components() {
         "register_component and resource lookup must share one ComponentId space"
     );
 }
+
+#[test]
+fn test_exclusive_function_systems_declare_empty_access_and_non_send() {
+    //! INVARIANT: Bevy's ExclusiveFunctionSystem (a `fn(&mut World)` system)
+    //! returns an EMPTY FilteredAccessSet from initialize and its flags are
+    //! NON_SEND | EXCLUSIVE. Exclusivity is enforced through the flags, not
+    //! through declared access, and the NON_SEND half is load-bearing:
+    //! MultiThreadedExecutor sets `local_thread_running` unconditionally when
+    //! it spawns an exclusive system but clears it on completion only for
+    //! non-Send systems. A Send exclusive system (unreachable in vanilla Bevy,
+    //! constructible via a custom System impl) leaks the flag and permanently
+    //! blocks every non-Send system still queued, ending the schedule scope on
+    //! the debug assertion `state.ready_systems.is_clear()`.
+    //!
+    //! Relied on by: DynamicSystem's World-parameter systems return an empty
+    //! access set from initialize and NON_SEND | EXCLUSIVE from flags() to
+    //! match this shape; pybevy's built-in exclusive systems (e.g. the
+    //! Last-schedule error drain) are plain fn(&mut World) systems.
+    //!
+    //! Reevaluate if it fails: Bevy changed the exclusive-system contract;
+    //! DynamicSystem's World arm and compute_system_flags must mirror whatever
+    //! ExclusiveFunctionSystem now declares.
+
+    let mut world = World::new();
+    let mut system = IntoSystem::into_system(|_world: &mut World| {});
+    let access_set = system.initialize(&mut world);
+
+    let combined = access_set.combined_access();
+    assert!(
+        !combined.has_any_read(),
+        "exclusive fn systems must declare no reads"
+    );
+    assert!(
+        !combined.has_any_write(),
+        "exclusive fn systems must declare no writes"
+    );
+    assert!(system.is_exclusive(), "fn(&mut World) must be exclusive");
+    assert!(
+        !system.is_send(),
+        "exclusive fn systems must be non-Send; the executor's local-thread \
+         accounting assumes the pairing"
+    );
+}


### PR DESCRIPTION
PyBevy was carrying *mut World or &mut World around for accesses (assetserver, assets, queries, views) accross the DynamicSystem. Migrated to UnsafeWorldCell for better auditing.