### PR TITLE
docs: fix stub docstring examples that fail as written (MouseInput, Val.px)

### DIFF
--- a/pybevy/input.pyi
+++ b/pybevy/input.pyi
@@ -301,14 +301,14 @@ class MouseInput(Resource):
 
     Example:
         ```python
-        def handle_mouse_system(mouse: MouseInput) -> None:
-            if mouse.just_pressed(MouseButton.Left):
+        def handle_mouse_system(mouse: Res[MouseInput]) -> None:
+            if mouse.just_pressed(MouseButton.Left()):
                 print("Left mouse button was just pressed!")
 
-            if mouse.pressed(MouseButton.Right):
+            if mouse.pressed(MouseButton.Right()):
                 print("Right mouse button is being held")
 
-            if mouse.just_released(MouseButton.Middle):
+            if mouse.just_released(MouseButton.Middle()):
                 print("Middle mouse button was just released")
         ```
     """

--- a/pybevy/ui.pyi
+++ b/pybevy/ui.pyi
@@ -801,7 +801,7 @@ class Val2:
         offset = Val2.percent(50.0, 50.0)
 
         # Mixed values
-        pos = Val2(Val.Px(10.0), Val.Percent(50.0))
+        pos = Val2(Val.px(10.0), Val.Percent(50.0))
         ```
     """
 
@@ -958,8 +958,8 @@ class Text(Component):
         # Spawn UI text with styling
         node = Node()
         node.position_type = PositionType.Absolute
-        node.top = Val.Px(10.0)
-        node.left = Val.Px(10.0)
+        node.top = Val.px(10.0)
+        node.left = Val.px(10.0)
         commands.spawn((
             Text("Hello, UI!"),
             node,
@@ -998,23 +998,23 @@ class Node(Component):
         # Absolutely positioned node
         node = Node()
         node.position_type = PositionType.Absolute
-        node.top = Val.Px(10.0)
-        node.left = Val.Px(10.0)
+        node.top = Val.px(10.0)
+        node.left = Val.px(10.0)
         commands.spawn((node, Text("Top Left")))
 
         # Flexbox layout
         node = Node()
         node.flex_direction = FlexDirection.Column  # Stack vertically
         node.display = Display.Flex
-        node.width = Val.Px(300.0)
-        node.height = Val.Px(200.0)
+        node.width = Val.px(300.0)
+        node.height = Val.px(200.0)
         commands.spawn(node)
 
         # Custom positioning
         node = Node()
         node.position_type = PositionType.Absolute
-        node.top = Val.Px(50.0)
-        node.left = Val.Px(100.0)
+        node.top = Val.px(50.0)
+        node.left = Val.px(100.0)
         commands.spawn((node, Text("Custom Position")))
         ```
 


### PR DESCRIPTION
Two stub docstrings currently fail when copied verbatim; this fixes them.

**`pybevy/input.pyi` — the `MouseInput` example fails two ways as written:**

1. `def handle_mouse_system(mouse: MouseInput)` is rejected at registration (`TypeError: ... must use Res[MouseInput] for read-only or ResMut[MouseInput] for mutable access`) → now `mouse: Res[MouseInput]`.
2. `mouse.just_pressed(MouseButton.Left)` raises (`argument 'button': 'type' object cannot be cast as 'MouseButton'`) because the variants are constructors → now `MouseButton.Left()` (same for `Right`/`Middle` in the docstring).

The deeper comparison footgun with uncalled variants is #288 — this PR only fixes the examples that demonstrate it.

**`pybevy/ui.pyi` — `Val.Px(...)` doesn't exist** (`AttributeError`; the accessor is `Val.px(...)`). Fixed 9 occurrences across the docstrings.

All verified against 0.2.1 on Python 3.13 / macOS arm64.
