### PR TITLE
docs: remove stale disjoint-filter limitation note from 2d/rotation.py

### DIFF
--- a/examples/bevy/2d/rotation.py
+++ b/examples/bevy/2d/rotation.py
@@ -7,10 +7,11 @@ Based on Bevy's examples/2d/rotation.rs, this example shows:
 - Combining Single with Query for disjoint entity sets
 - 2D rotation and movement using quaternions
 
-NOTE: The snap_to_player_system currently fails due to a PyBevy limitation.
-PyBevy doesn't yet recognize disjoint filters (With/Without) as making
-queries safe for simultaneous mutable and immutable access. This works
-in Rust Bevy but not in PyBevy yet.
+Note on query access: mixing Single[Transform, With[Player]] with
+Query[Mut[Transform], ..., Without[Player]] is accepted because the
+With/Without filters prove the two entity sets are disjoint — the same
+rule as Rust Bevy. (An earlier PyBevy version rejected this; verified
+working on 0.2.1.)
 """
 
 import math


### PR DESCRIPTION
`examples/bevy/2d/rotation.py`'s module docstring warns:

> *"NOTE: The snap_to_player_system currently fails due to a PyBevy limitation. PyBevy doesn't yet recognize disjoint filters (With/Without) as making queries safe for simultaneous mutable and immutable access."*

Verified on **0.2.1**: this is no longer true. The example runs cleanly, and minimal probes confirm the access checker accepts `Single[Transform, With[Player]]` + `Query[Mut[Transform], (..., Without[Player])]` — and even two mutable Transform queries — when the filters prove disjointness (matching Rust Bevy semantics; `With`-only pairs are still correctly rejected).

The stale note actively misleads: I read it while building several games on PyBevy and architected around a limitation that doesn't exist (see #289 for a related error-message suggestion). This PR replaces the warning with a short explanation of *why* the mixed access pattern is legal.

No code changes — docstring only. Example still runs identically (tested on 0.2.1, Python 3.13, macOS arm64).
