### PR TITLE
Unify Text/Text2d string access with symmetric text/content aliases

### DIFF
--- a/crates/pybevy_text/src/text2d.rs
+++ b/crates/pybevy_text/src/text2d.rs
@@ -27,4 +27,15 @@ impl PyText2d {
         self.as_mut()?.0 = text;
         Ok(())
     }
+
+    /// Alias for `text`, matching UI `Text.content`.
+    #[getter]
+    pub fn content(&self) -> PyResult<String> {
+        self.text()
+    }
+
+    #[setter]
+    pub fn set_content(&mut self, value: String) -> PyResult<()> {
+        self.set_text(value)
+    }
 }

--- a/crates/pybevy_ui/src/text.rs
+++ b/crates/pybevy_ui/src/text.rs
@@ -28,4 +28,15 @@ impl PyText {
         self.as_mut()?.0 = value;
         Ok(())
     }
+
+    /// Alias for `content`, matching `Text2d.text`.
+    #[getter]
+    pub fn text(&self) -> PyResult<String> {
+        self.content()
+    }
+
+    #[setter]
+    pub fn set_text(&mut self, value: String) -> PyResult<()> {
+        self.set_content(value)
+    }
 }

--- a/pybevy/text.pyi
+++ b/pybevy/text.pyi
@@ -781,6 +781,13 @@ class Text2d(Component):
     @text.setter
     def text(self, value: str) -> None: ...
 
+    @property
+    def content(self) -> str:
+        """Alias for `text`, matching UI `Text.content`."""
+
+    @content.setter
+    def content(self, value: str) -> None: ...
+
 class Text2dShadow(Component):
     """Adds a shadow behind Text2d text.
 

--- a/pybevy/ui.pyi
+++ b/pybevy/ui.pyi
@@ -981,6 +981,13 @@ class Text(Component):
     @content.setter
     def content(self, value: str) -> None: ...
 
+    @property
+    def text(self) -> str:
+        """Alias for `content`, matching `Text2d.text`."""
+
+    @text.setter
+    def text(self, value: str) -> None: ...
+
 
 class Node(Component):
     """UI layout node component.


### PR DESCRIPTION
UI `Text` exposes `.content` while `Text2d` exposes `.text` for the same concept — a guaranteed first-session stumble when writing HUD code against both (it was mine: `AttributeError: 'builtins.Text' object has no attribute 'text'`). Rust Bevy sidesteps this via tuple-struct field access, so the naming split is purely a Python-layer artifact.

This PR adds symmetric aliases so either spelling works on either type:

- `Text.text` / `Text.set_text` → delegates to `content` (`crates/pybevy_ui/src/text.rs`)
- `Text2d.content` / `Text2d.set_content` → delegates to `text` (`crates/pybevy_text/src/text2d.rs`)
- Both declared in the corresponding `.pyi` stubs, marked as aliases.

No behaviour change for existing code; both accessors hit the same underlying field. `cargo check -p pybevy_ui -p pybevy_text` passes.

Alternative if you'd rather converge on a single name with a deprecation path instead of dual aliases — happy to rework in whichever direction you prefer.
