### PR TITLE
Fix #33: capture init_resource on reload temp app so resources survive Full reload

### DIFF
--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -1096,8 +1096,18 @@ impl PyApp {
     ) -> PyResult<Py<PyApp>> {
         pyself.ensure_active()?;
 
-        // Skip during hot reload — resources are preserved or re-inserted via insert_resource
+        // If this is a temp reload app, capture a default instance for
+        // re-insertion after the reload (mirrors insert_resource above).
+        // Custom Python resources are wiped on a Full reload and only
+        // pending_resources are re-registered, so skipping here leaves any
+        // init_resource'd type permanently missing — every system that
+        // parameterizes on it dies with a buffered param error (#33).
         if pyself.is_reload_temp.get() {
+            let instance = resource.call0()?;
+            pyself
+                .pending_resources
+                .borrow_mut()
+                .push(instance.unbind());
             return Ok(pyself.into());
         }
 


### PR DESCRIPTION
Fixes #33 — and the answer to the issue's question ("orbit camera bug, or input bug?") is: neither. It's a hot-reload resource bug that kills the whole control system, mouse and keyboard alike.

## Root cause

`OrbitCameraPlugin.build()` calls `app.init_resource(OrbitCameraState)`. On the reload temp app, `PyApp::init_resource` was a **silent no-op**:

```rust
// Skip during hot reload — resources are preserved or re-inserted via insert_resource
if pyself.is_reload_temp.get() {
    return Ok(pyself.into());
}
```

The comment's claim doesn't hold for a Full reload: `clear_custom_resources` wipes all Python resources, and `register_resources` re-inserts only what was captured into `pending_resources` — which `insert_resource`'s temp branch does, and `init_resource`'s didn't. So after any Full reload, `OrbitCameraState` no longer exists, `orbit_camera_control_system`'s `ResMut[OrbitCameraState]` param fails to build every frame, and the system never runs again. The failure is invisible at default verbosity because param errors are buffered into `error_state` rather than printed — the camera just goes dead.

Same latent bug in everything else that uses `init_resource` in a plugin: `contrib/fly_camera.py` (`FlyCameraState`) and `examples/complex/meteor_strike.py`.

## Fix

Mirror `insert_resource`'s temp branch: default-construct the instance (same `call0()` the live path uses in `PyWorld::init_resource`) and push it into `pending_resources` for re-registration after the reload.

Behavioral parity note: the live `init_resource` path always inserts a fresh default (it does not skip if present), so unconditionally pushing the default keeps hot-reload end-state identical to a cold start for every `insert_resource`/`init_resource` ordering. A side benefit: `init_resource`'d types now participate in the pending-definitions accounting like inserted ones do.

## Repro / verification (macOS, `pybevy dev --full`)

Scene: `Camera3d` + `OrbitCamera` + `OrbitCameraPlugin()` + a heartbeat system taking `ResMut[OrbitCameraState]` that prints every 60 ticks.

- **Before the fix**: heartbeat prints once per second; after touching the file (Full reload), heartbeat freezes permanently — 14 beats at reload, still 14 fifteen seconds later. No error visible at default verbosity.
- **After the fix**: heartbeat continues across the reload, and the orbit camera keeps responding to drag input.
